### PR TITLE
Fix runtime bridge credential recovery

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -24,14 +24,17 @@ Dirs & patterns
   ```python
   from starlette.requests import Request
 
+
   def _build_request(path: str) -> Request:
-      return Request({
-          "type": "http",
-          "method": "GET",
-          "path": path,
-          "headers": [(b"host", b"ragtime.dev")],
-          "scheme": "https",
-      })
+      return Request(
+          {
+              "type": "http",
+              "method": "GET",
+              "path": path,
+              "headers": [(b"host", b"ragtime.dev")],
+              "scheme": "https",
+          }
+      )
   ```
 
 ## Boundaries and Isolation
@@ -44,6 +47,7 @@ Dirs & patterns
 import unittest
 from types import SimpleNamespace
 from unittest import mock
+
 
 class MyFeatureTests(unittest.IsolatedAsyncioTestCase):
     async def test_does_behavior(self) -> None:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,18 +74,18 @@ from pydantic import BaseModel, Field
 
 
 class MyToolInput(BaseModel):
-  query: str = Field(description="What to search or process")
+    query: str = Field(description="What to search or process")
 
 
 async def execute_my_tool(query: str) -> str:
-  return f"Processed: {query}"
+    return f"Processed: {query}"
 
 
 my_tool_tool = StructuredTool.from_function(
-  coroutine=execute_my_tool,
-  name="my_tool",
-  description="Describe when this tool should be used.",
-  args_schema=MyToolInput,
+    coroutine=execute_my_tool,
+    name="my_tool",
+    description="Describe when this tool should be used.",
+    args_schema=MyToolInput,
 )
 ```
 

--- a/ragtime/frontend/src/api/client.test.ts
+++ b/ragtime/frontend/src/api/client.test.ts
@@ -703,3 +703,64 @@ describe('workspace sqlite inspector owner routing', () => {
     );
   });
 });
+
+describe('workspace bridge credential client requests', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('gets bridge credential status for a workspace runtime session', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        state: 'expired',
+        bridge_url: 'https://bridge.example',
+        token_session_id: 'session-old',
+        current_session_id: 'session-new',
+        issued_at: '2026-08-05T18:00:00Z',
+        expires_at: '2026-08-05T19:00:00Z',
+        last_success_at: '2026-08-05T18:30:00Z',
+        detail: 'Bridge credentials expired.',
+      }),
+    );
+
+    const result = await api.getUserSpaceBridgeCredentialStatus('workspace/123');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/indexes/userspace/runtime/workspaces/workspace%2F123/bridge-credentials/status',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    expect(result.state).toBe('expired');
+    expect(result.detail).toBe('Bridge credentials expired.');
+  });
+
+  it('posts to refresh bridge credentials for a workspace runtime session', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        state: 'healthy',
+        bridge_url: 'https://bridge.example',
+        token_session_id: 'session-new',
+        current_session_id: 'session-new',
+        issued_at: '2026-08-05T19:00:00Z',
+        expires_at: '2026-08-05T20:00:00Z',
+        last_success_at: '2026-08-05T19:01:00Z',
+        detail: null,
+      }),
+    );
+
+    const result = await api.refreshUserSpaceBridgeCredentials('workspace/123');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/indexes/userspace/runtime/workspaces/workspace%2F123/bridge-credentials/refresh',
+      expect.objectContaining({ method: 'POST', credentials: 'include' }),
+    );
+    expect(result.state).toBe('healthy');
+    expect(result.token_session_id).toBe('session-new');
+  });
+});

--- a/ragtime/frontend/src/api/client.ts
+++ b/ragtime/frontend/src/api/client.ts
@@ -187,6 +187,7 @@ import type {
   ConversationBranchSearchResponse,
   ProviderPromptDebugListResponse,
   ProviderPromptDebugRecord,
+  UserSpaceBridgeStatus,
   CopilotAuthStatusResponse,
   CopilotDevicePollRequest,
   CopilotDevicePollResponse,
@@ -5915,6 +5916,23 @@ export const api = {
       `${API_BASE}/userspace/runtime/workspaces/${workspaceId}/tab-state${queryString ? `?${queryString}` : ''}`,
     );
     return handleResponse<UserSpaceWorkspaceTabStateResponse>(response);
+  },
+
+  async getUserSpaceBridgeCredentialStatus(workspaceId: string): Promise<UserSpaceBridgeStatus> {
+    const response = await apiFetch(
+      `${API_BASE}/userspace/runtime/workspaces/${encodeURIComponent(workspaceId)}/bridge-credentials/status`,
+    );
+    return handleResponse<UserSpaceBridgeStatus>(response);
+  },
+
+  async refreshUserSpaceBridgeCredentials(workspaceId: string): Promise<UserSpaceBridgeStatus> {
+    const response = await apiFetch(
+      `${API_BASE}/userspace/runtime/workspaces/${encodeURIComponent(workspaceId)}/bridge-credentials/refresh`,
+      {
+        method: 'POST',
+      },
+    );
+    return handleResponse<UserSpaceBridgeStatus>(response);
   },
 
   async restartUserSpaceRuntimeDevserver(

--- a/ragtime/frontend/src/components/UserSpacePanel.test.tsx
+++ b/ragtime/frontend/src/components/UserSpacePanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -34,6 +34,7 @@ const {
     authorizeUserSpaceBrowserSurfaces: vi.fn(),
     launchUserSpacePreview: vi.fn(),
     subscribeWorkspaceEvents: vi.fn(),
+    refreshUserSpaceBridgeCredentials: vi.fn(),
     listUsersDirectory: vi.fn(),
     getLdapConfig: vi.fn(),
     discoverLdapWithStoredCredentials: vi.fn(),
@@ -194,6 +195,16 @@ const STARTING_RUNTIME_STATUS = {
   devserver_port: 4173,
   last_error: null,
   live_data_warning: null,
+  bridge_status: {
+    state: 'healthy',
+    bridge_url: 'https://bridge.example',
+    token_session_id: 'session-1',
+    current_session_id: 'session-1',
+    issued_at: '2026-08-05T18:00:00Z',
+    expires_at: '2026-08-05T19:00:00Z',
+    last_success_at: '2026-08-05T18:30:00Z',
+    detail: null,
+  },
 } as const;
 
 const DEFAULT_CHAT_STATE = {
@@ -400,6 +411,9 @@ beforeEach(() => {
     removeEventListener: vi.fn(),
     onmessage: null,
     onerror: null,
+  });
+  previewApiMock.refreshUserSpaceBridgeCredentials.mockResolvedValue({
+    ...STARTING_RUNTIME_STATUS.bridge_status,
   });
   previewApiMock.listUsersDirectory.mockResolvedValue([]);
   previewApiMock.getLdapConfig.mockResolvedValue({ discovered_groups: [] });
@@ -636,6 +650,236 @@ describe('UserSpacePanel workspace tool descriptions', () => {
     const openInspectorButtonAfter = screen.getByLabelText('Open SQLite inspector');
     expect(openInspectorButtonAfter.className.includes('userspace-sqlite-mode-excluded')).toBe(
       true,
+    );
+  });
+
+  it('shows unhealthy bridge status details to viewers without a refresh action', async () => {
+    const viewerWorkspace = {
+      ...WORKSPACE,
+      owner_user_id: 'owner-1',
+    };
+    previewApiMock.listUserSpaceWorkspaces.mockResolvedValue({
+      items: [{ ...viewerWorkspace }],
+      total: 1,
+    });
+    previewApiMock.getUserSpaceWorkspace.mockResolvedValue({ ...viewerWorkspace });
+    previewApiMock.getUserSpaceWorkspaceTabState.mockResolvedValue({
+      workspace_id: WORKSPACE.id,
+      runtime_status: {
+        ...STARTING_RUNTIME_STATUS,
+        bridge_status: {
+          state: 'expired',
+          bridge_url: 'https://bridge.example',
+          token_session_id: 'session-old',
+          current_session_id: 'session-new',
+          issued_at: '2026-08-05T18:00:00Z',
+          expires_at: '2026-08-05T19:00:00Z',
+          last_success_at: '2026-08-05T18:30:00Z',
+          detail: 'Bridge credentials expired.',
+        },
+      },
+      chat_state: { ...DEFAULT_CHAT_STATE },
+    });
+
+    render(
+      <UserSpacePanel
+        currentUser={{
+          ...CURRENT_USER,
+          id: 'viewer-1',
+          username: 'viewer',
+          display_name: 'Viewer',
+          role: 'user',
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Bridge expired')).toBeTruthy();
+    });
+
+    expect(screen.getByText(/Bridge credentials expired\./)).toBeTruthy();
+    expect(screen.getByText(/Expired /)).toBeTruthy();
+    expect(screen.getByText(/Last success /)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Refresh bridge credentials' })).toBeNull();
+  });
+
+  it('labels a future invalid bridge expiry as Expires instead of Expired', async () => {
+    previewApiMock.getUserSpaceWorkspaceTabState.mockResolvedValue({
+      workspace_id: WORKSPACE.id,
+      runtime_status: {
+        ...STARTING_RUNTIME_STATUS,
+        bridge_status: {
+          ...STARTING_RUNTIME_STATUS.bridge_status,
+          state: 'invalid',
+          expires_at: '2099-08-05T19:00:00Z',
+          detail: 'Bridge credentials are invalid.',
+        },
+      },
+      chat_state: { ...DEFAULT_CHAT_STATE },
+    });
+
+    await renderPanelWithRuntimeOverlay(false);
+
+    expect(screen.getByText('Bridge invalid')).toBeTruthy();
+    expect(screen.getByText(/Expires /)).toBeTruthy();
+    expect(screen.queryByText(/Expired /)).toBeNull();
+  });
+
+  it('shows a low-noise healthy bridge label without status details', async () => {
+    await renderPanelWithRuntimeOverlay(false);
+
+    expect(screen.getByText('Bridge healthy')).toBeTruthy();
+    expect(screen.queryByText(/Last success /)).toBeNull();
+    expect(screen.queryByText(/Expired /)).toBeNull();
+  });
+
+  it('shows editors a bridge refresh action in the runtime controls', async () => {
+    await renderPanelWithRuntimeOverlay(false);
+
+    expect(screen.getByRole('button', { name: 'Refresh bridge credentials' })).toBeTruthy();
+  });
+
+  it('hides the bridge refresh action when the runtime is not running', async () => {
+    previewApiMock.getUserSpaceWorkspaceTabState.mockResolvedValue({
+      workspace_id: WORKSPACE.id,
+      runtime_status: {
+        ...STARTING_RUNTIME_STATUS,
+        session_state: 'stopped',
+        bridge_status: {
+          ...STARTING_RUNTIME_STATUS.bridge_status,
+          state: 'not_running',
+          detail: 'Runtime session is not running.',
+        },
+      },
+      chat_state: { ...DEFAULT_CHAT_STATE },
+    });
+
+    render(<UserSpacePanel currentUser={{ ...CURRENT_USER }} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Bridge not running')).toBeTruthy();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Refresh bridge credentials' })).toBeNull();
+  });
+
+  it('refreshes bridge credentials, disables runtime actions while busy, and reloads workspace state', async () => {
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    previewApiMock.getUserSpaceWorkspaceTabState
+      .mockResolvedValueOnce({
+        workspace_id: WORKSPACE.id,
+        runtime_status: {
+          ...STARTING_RUNTIME_STATUS,
+          bridge_status: {
+            ...STARTING_RUNTIME_STATUS.bridge_status,
+            state: 'session_mismatch',
+            token_session_id: 'session-old',
+            current_session_id: 'session-1',
+            expires_at: '2099-08-05T19:00:00Z',
+            detail: 'Bridge session mismatch.',
+          },
+        },
+        chat_state: { ...DEFAULT_CHAT_STATE },
+      })
+      .mockResolvedValueOnce({
+        workspace_id: WORKSPACE.id,
+        runtime_status: {
+          ...STARTING_RUNTIME_STATUS,
+          devserver_running: true,
+          bridge_status: {
+            ...STARTING_RUNTIME_STATUS.bridge_status,
+            state: 'healthy',
+            token_session_id: 'session-1',
+            current_session_id: 'session-1',
+            detail: null,
+          },
+        },
+        chat_state: { ...DEFAULT_CHAT_STATE },
+      });
+    previewApiMock.refreshUserSpaceBridgeCredentials.mockImplementationOnce(async () => {
+      await refreshGate;
+      return {
+        state: 'healthy' as const,
+        bridge_url: 'https://bridge.example',
+        token_session_id: 'session-1',
+        current_session_id: 'session-1',
+        issued_at: '2026-08-05T18:00:00Z',
+        expires_at: '2026-08-05T19:00:00Z',
+        last_success_at: '2026-08-05T18:45:00Z',
+        detail: null,
+      };
+    });
+
+    await renderPanelWithRuntimeOverlay(false);
+    const tabStateCallsBeforeRefresh =
+      previewApiMock.getUserSpaceWorkspaceTabState.mock.calls.length;
+
+    const refreshButton = screen.getByRole('button', { name: 'Refresh bridge credentials' });
+    const stopButton = screen.getByTitle('Stop runtime');
+
+    fireEvent.click(refreshButton);
+
+    expect(previewApiMock.refreshUserSpaceBridgeCredentials).toHaveBeenCalledWith('ws-1');
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole('button', {
+            name: 'Refreshing bridge credentials…',
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(true);
+    });
+    expect((stopButton as HTMLButtonElement).disabled).toBe(true);
+
+    releaseRefresh();
+
+    await waitFor(() => {
+      expect(screen.getByText('Bridge healthy')).toBeTruthy();
+    });
+    expect(previewApiMock.getUserSpaceWorkspaceTabState.mock.calls.length).toBeGreaterThan(
+      tabStateCallsBeforeRefresh,
+    );
+    expect(
+      (screen.getByRole('button', { name: 'Refresh bridge credentials' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
+  it('shows a refresh error and re-enables bridge controls when the refresh fails', async () => {
+    previewApiMock.getUserSpaceWorkspaceTabState.mockResolvedValue({
+      workspace_id: WORKSPACE.id,
+      runtime_status: {
+        ...STARTING_RUNTIME_STATUS,
+        bridge_status: {
+          ...STARTING_RUNTIME_STATUS.bridge_status,
+          state: 'invalid',
+          detail: 'Bridge credentials are invalid.',
+        },
+      },
+      chat_state: { ...DEFAULT_CHAT_STATE },
+    });
+    previewApiMock.refreshUserSpaceBridgeCredentials.mockRejectedValueOnce(
+      new Error('Refresh bridge failed'),
+    );
+
+    await renderPanelWithRuntimeOverlay(false);
+    const tabStateCallsBeforeRefresh =
+      previewApiMock.getUserSpaceWorkspaceTabState.mock.calls.length;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh bridge credentials' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Refresh bridge failed')).toBeTruthy();
+    });
+    expect(
+      (screen.getByRole('button', { name: 'Refresh bridge credentials' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+    expect(previewApiMock.getUserSpaceWorkspaceTabState.mock.calls.length).toBe(
+      tabStateCallsBeforeRefresh,
     );
   });
 });

--- a/ragtime/frontend/src/components/UserSpacePanel.tsx
+++ b/ragtime/frontend/src/components/UserSpacePanel.tsx
@@ -113,6 +113,7 @@ import type {
   UserSpaceArtifactType,
   UserSpaceAvailableTool,
   UserSpaceBrowserSurface,
+  UserSpaceBridgeStatus,
   UserSpaceCollabMessage,
   UserSpaceCollabPresenceUser,
   UserSpaceFileInfo,
@@ -749,6 +750,69 @@ function formatSnapshotTimestamp(value: string): string {
   });
 }
 
+function getBridgeStatusLabel(bridgeStatus: UserSpaceBridgeStatus): string {
+  switch (bridgeStatus.state) {
+    case 'healthy':
+      return 'Bridge healthy';
+    case 'not_running':
+      return 'Bridge not running';
+    case 'missing':
+      return 'Bridge missing';
+    case 'expired':
+      return 'Bridge expired';
+    case 'invalid':
+      return 'Bridge invalid';
+    case 'session_mismatch':
+      return 'Bridge session mismatch';
+    case 'unavailable':
+      return 'Bridge unavailable';
+    default:
+      return 'Bridge status';
+  }
+}
+
+function getBridgeStatusPillClass(bridgeStatus: UserSpaceBridgeStatus): string {
+  switch (bridgeStatus.state) {
+    case 'healthy':
+      return 'userspace-status-pill-muted';
+    case 'not_running':
+      return 'userspace-status-pill-warning';
+    case 'missing':
+    case 'expired':
+    case 'invalid':
+    case 'session_mismatch':
+      return 'userspace-status-pill-danger';
+    case 'unavailable':
+    default:
+      return 'userspace-status-pill-warning';
+  }
+}
+
+function getBridgeStatusDetail(bridgeStatus: UserSpaceBridgeStatus): string | null {
+  if (bridgeStatus.state === 'healthy') {
+    return null;
+  }
+
+  const parts: string[] = [];
+  const detail = bridgeStatus.detail?.trim();
+  if (detail) {
+    parts.push(detail);
+  }
+  if (bridgeStatus.expires_at) {
+    const expiresAt = parseUtcTimestamp(bridgeStatus.expires_at);
+    const isExpired =
+      bridgeStatus.state === 'expired' || (expiresAt !== null && expiresAt.getTime() <= Date.now());
+    parts.push(
+      `${isExpired ? 'Expired' : 'Expires'} ${formatSnapshotTimestamp(bridgeStatus.expires_at)}`,
+    );
+  }
+  if (bridgeStatus.last_success_at) {
+    parts.push(`Last success ${formatSnapshotTimestamp(bridgeStatus.last_success_at)}`);
+  }
+
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
 function getSnapshotDiffFileKey(snapshotId: string, filePath: string): string {
   return `${snapshotId}:${filePath}`;
 }
@@ -1045,6 +1109,7 @@ export function UserSpacePanel({
   } | null>(null);
   const [runtimeStatus, setRuntimeStatus] = useState<UserSpaceRuntimeStatusResponse | null>(null);
   const [runtimeBusy, setRuntimeBusy] = useState(false);
+  const [refreshingBridgeCredentials, setRefreshingBridgeCredentials] = useState(false);
   const [activeRightTab, setActiveRightTab] = useState<'preview' | 'console'>('preview');
   const [collabReadOnly, setCollabReadOnly] = useState(false);
   const [collabVersion, setCollabVersion] = useState(0);
@@ -2382,6 +2447,12 @@ export function UserSpacePanel({
   const showRestartRuntimeButton = runtimeDisplayState === 'running';
   const showStopRuntimeButton =
     runtimeDisplayState === 'running' || runtimeDisplayState === 'starting';
+  const bridgeStatus = runtimeStatus?.bridge_status ?? null;
+  const bridgeStatusLabel = bridgeStatus ? getBridgeStatusLabel(bridgeStatus) : null;
+  const bridgeStatusDetail = bridgeStatus ? getBridgeStatusDetail(bridgeStatus) : null;
+  const bridgeStatusPillClass = bridgeStatus ? getBridgeStatusPillClass(bridgeStatus) : null;
+  const showRefreshBridgeCredentialsButton =
+    bridgeStatus !== null && bridgeStatus.state !== 'not_running';
   const allUsersById = useMemo(() => new Map(allUsers.map((user) => [user.id, user])), [allUsers]);
 
   const formatUserLabel = useCallback(
@@ -5054,6 +5125,20 @@ export function UserSpacePanel({
       setError(err instanceof Error ? err.message : 'Failed to restart runtime');
     } finally {
       setRuntimeBusy(false);
+    }
+  }, [activeWorkspaceId, canEditWorkspace, refreshActiveWorkspaceState]);
+
+  const handleRefreshBridgeCredentials = useCallback(async () => {
+    if (!activeWorkspaceId || !canEditWorkspace) return;
+    setRefreshingBridgeCredentials(true);
+    try {
+      await api.refreshUserSpaceBridgeCredentials(activeWorkspaceId);
+      await refreshActiveWorkspaceState();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to refresh bridge credentials');
+    } finally {
+      setRefreshingBridgeCredentials(false);
     }
   }, [activeWorkspaceId, canEditWorkspace, refreshActiveWorkspaceState]);
 
@@ -8971,6 +9056,21 @@ export function UserSpacePanel({
                     : runtimeDisplayState}
               </span>
             )}
+            {bridgeStatus && bridgeStatusLabel && bridgeStatusPillClass && (
+              <>
+                <span
+                  className={`userspace-status-pill ${bridgeStatusPillClass}`}
+                  title={bridgeStatus.bridge_url || bridgeStatusLabel}
+                >
+                  {bridgeStatusLabel}
+                </span>
+                {bridgeStatusDetail && (
+                  <span className="userspace-muted" title={bridgeStatusDetail}>
+                    {bridgeStatusDetail}
+                  </span>
+                )}
+              </>
+            )}
           </div>
 
           {activeWorkspaceId && (
@@ -9000,7 +9100,7 @@ export function UserSpacePanel({
                 <button
                   className="btn btn-secondary btn-sm btn-icon"
                   onClick={handleStartRuntime}
-                  disabled={runtimeBusy}
+                  disabled={runtimeBusy || refreshingBridgeCredentials}
                   title="Start runtime"
                 >
                   {runtimeBusy ? (
@@ -9014,7 +9114,7 @@ export function UserSpacePanel({
                 <button
                   className="btn btn-secondary btn-sm btn-icon"
                   onClick={handleRestartRuntime}
-                  disabled={runtimeBusy}
+                  disabled={runtimeBusy || refreshingBridgeCredentials}
                   title="Restart runtime"
                 >
                   {runtimeBusy ? (
@@ -9028,7 +9128,7 @@ export function UserSpacePanel({
                 <button
                   className="btn btn-secondary btn-sm btn-icon"
                   onClick={handleStopRuntime}
-                  disabled={runtimeBusy}
+                  disabled={runtimeBusy || refreshingBridgeCredentials}
                   title="Stop runtime"
                 >
                   {runtimeBusy ? (
@@ -9036,6 +9136,18 @@ export function UserSpacePanel({
                   ) : (
                     <Square size={14} />
                   )}
+                </button>
+              )}
+              {showRefreshBridgeCredentialsButton && (
+                <button
+                  className="btn btn-secondary btn-sm"
+                  onClick={handleRefreshBridgeCredentials}
+                  disabled={runtimeBusy || refreshingBridgeCredentials}
+                  title="Refresh bridge credentials"
+                >
+                  {refreshingBridgeCredentials
+                    ? 'Refreshing bridge credentials…'
+                    : 'Refresh bridge credentials'}
                 </button>
               )}
             </div>

--- a/ragtime/frontend/src/types/api.ts
+++ b/ragtime/frontend/src/types/api.ts
@@ -4162,6 +4162,26 @@ export interface UserSpaceRuntimeSessionResponse {
   session?: UserSpaceRuntimeSession | null;
 }
 
+export type UserSpaceBridgeStatusState =
+  | 'healthy'
+  | 'not_running'
+  | 'missing'
+  | 'expired'
+  | 'invalid'
+  | 'session_mismatch'
+  | 'unavailable';
+
+export interface UserSpaceBridgeStatus {
+  state: UserSpaceBridgeStatusState;
+  bridge_url?: string | null;
+  token_session_id?: string | null;
+  current_session_id?: string | null;
+  issued_at?: string | null;
+  expires_at?: string | null;
+  last_success_at?: string | null;
+  detail?: string | null;
+}
+
 export interface UserSpaceRuntimeStatusResponse {
   workspace_id: string;
   session_state: UserSpaceRuntimeSessionState;
@@ -4177,6 +4197,7 @@ export interface UserSpaceRuntimeStatusResponse {
   runtime_operation_phase?: UserSpaceRuntimeOperationPhase | null;
   runtime_operation_started_at?: string | null;
   runtime_operation_updated_at?: string | null;
+  bridge_status?: UserSpaceBridgeStatus | null;
 }
 
 export interface UserSpaceWorkspaceTabStateResponse {

--- a/ragtime/userspace/models.py
+++ b/ragtime/userspace/models.py
@@ -1160,6 +1160,25 @@ class UserSpaceRuntimeSessionResponse(BaseModel):
     session: UserSpaceRuntimeSession | None = None
 
 
+class UserSpaceRuntimeBridgeStatus(BaseModel):
+    state: Literal[
+        "healthy",
+        "not_running",
+        "missing",
+        "expired",
+        "invalid",
+        "session_mismatch",
+        "unavailable",
+    ]
+    bridge_url: str | None = None
+    token_session_id: str | None = None
+    current_session_id: str | None = None
+    issued_at: datetime | None = None
+    expires_at: datetime | None = None
+    last_success_at: datetime | None = None
+    detail: str | None = None
+
+
 class UserSpaceRuntimeStatusResponse(BaseModel):
     workspace_id: str
     session_state: RuntimeSessionState
@@ -1174,6 +1193,7 @@ class UserSpaceRuntimeStatusResponse(BaseModel):
     preview_url: str | None = None
     last_error: str | None = None
     live_data_warning: str | None = None
+    bridge_status: UserSpaceRuntimeBridgeStatus | None = None
     runtime_operation_id: str | None = None
     runtime_operation_phase: RuntimeOperationPhase | None = None
     runtime_operation_started_at: datetime | None = None

--- a/ragtime/userspace/runtime_routes.py
+++ b/ragtime/userspace/runtime_routes.py
@@ -64,6 +64,7 @@ from ragtime.userspace.models import (
     UserSpacePreviewLaunchRequest,
     UserSpacePreviewLaunchResponse,
     UserSpaceRuntimeActionResponse,
+    UserSpaceRuntimeBridgeStatus,
     UserSpaceRuntimeSessionResponse,
     UserSpaceRuntimeStatusResponse,
     UserSpaceWorkspaceTabStateResponse,
@@ -2218,6 +2219,28 @@ async def workspace_events_sse(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+@router.get(
+    "/runtime/workspaces/{workspace_id}/bridge-credentials/status",
+    response_model=UserSpaceRuntimeBridgeStatus,
+)
+async def get_runtime_bridge_status(
+    workspace_id: str,
+    user: Any = Depends(get_current_user),
+):
+    return await _runtime_service().get_runtime_bridge_status(workspace_id, user.id)
+
+
+@router.post(
+    "/runtime/workspaces/{workspace_id}/bridge-credentials/refresh",
+    response_model=UserSpaceRuntimeBridgeStatus,
+)
+async def refresh_runtime_bridge_credentials(
+    workspace_id: str,
+    user: Any = Depends(get_current_user),
+):
+    return await _runtime_service().refresh_runtime_bridge_credentials(workspace_id, user.id)
 
 
 @router.get(

--- a/ragtime/userspace/runtime_service.py
+++ b/ragtime/userspace/runtime_service.py
@@ -11,7 +11,7 @@ import socket
 import time as _time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, cast
+from typing import Any, Callable, TypedDict, cast
 from urllib.parse import quote, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
@@ -62,6 +62,16 @@ from ragtime.userspace.service import userspace_service
 from ragtime.userspace.workspace_code_index_service import workspace_code_index_service
 
 logger = get_logger(__name__)
+
+
+class _RuntimeBridgeStatusBaseKwargs(TypedDict):
+    bridge_url: str | None
+    token_session_id: str | None
+    current_session_id: str | None
+    issued_at: datetime | None
+    expires_at: datetime | None
+    last_success_at: datetime | None
+
 
 _RUNTIME_CAPABILITY_TTL_SECONDS = 900
 _RUNTIME_PREVIEW_BOOTSTRAP_TTL_SECONDS = 300
@@ -605,11 +615,7 @@ class UserSpaceRuntimeService:
         ).hexdigest()
         now_ts = _time.monotonic()
         async with self._runtime_bridge_auth_failure_audit_lock:
-            expired_keys = [
-                key
-                for key, expiry in self._runtime_bridge_auth_failure_audit_dedupe.items()
-                if expiry <= now_ts
-            ]
+            expired_keys = [key for key, expiry in self._runtime_bridge_auth_failure_audit_dedupe.items() if expiry <= now_ts]
             for key in expired_keys:
                 self._runtime_bridge_auth_failure_audit_dedupe.pop(key, None)
             existing_expiry = self._runtime_bridge_auth_failure_audit_dedupe.get(dedupe_key)
@@ -777,7 +783,7 @@ class UserSpaceRuntimeService:
         expires_at = self._parse_runtime_bridge_datetime(raw_credential.get("expires_at"))
         last_success_at = await self._get_latest_runtime_bridge_success_at(session.workspace_id, session.id)
 
-        base_kwargs = {
+        base_kwargs: _RuntimeBridgeStatusBaseKwargs = {
             "bridge_url": bridge_url,
             "token_session_id": token_session_id,
             "current_session_id": session.id,

--- a/ragtime/userspace/runtime_service.py
+++ b/ragtime/userspace/runtime_service.py
@@ -46,6 +46,7 @@ from ragtime.userspace.models import (
     UserSpacePreviewLaunchResponse,
     UserSpacePreviewWarning,
     UserSpaceRuntimeActionResponse,
+    UserSpaceRuntimeBridgeStatus,
     UserSpaceRuntimeSession,
     UserSpaceRuntimeSessionResponse,
     UserSpaceRuntimeStatusResponse,
@@ -81,6 +82,9 @@ _DEFAULT_USERSPACE_PREVIEW_BASE_DOMAIN = "userspace-preview.lvh.me"
 _RUNTIME_PREVIEW_UPSTREAM_CACHE_TTL_SECONDS = 300
 _RUNTIME_PROVIDER_STATUS_CACHE_TTL_SECONDS = 2.0
 _RUNTIME_PROVIDER_STATUS_STALE_FALLBACK_SECONDS = 8.0
+_RUNTIME_BRIDGE_AUTH_FAILURE_AUDIT_WINDOW_SECONDS = 30.0
+_RUNTIME_BRIDGE_AUTH_FAILURE_AUDIT_CACHE_MAX = 1024
+_RUNTIME_BRIDGE_AUDIT_SUCCESS_SCAN_LIMIT = 10
 _RUNTIME_PREVIEW_PROBE_CACHE_TTL_SECONDS = 3.0
 _RUNTIME_PUBLIC_PREVIEW_DNS_CACHE_TTL_SECONDS = 30.0
 _RUNTIME_PUBLIC_PREVIEW_PROBE_CACHE_TTL_SECONDS = 30.0
@@ -136,6 +140,8 @@ class UserSpaceRuntimeService:
         self._preview_base_domains: set[str] = set()
         self._preview_upstream_cache: dict[str, _PreviewUpstreamCacheEntry] = {}
         self._provider_status_cache: dict[str, _ProviderStatusCacheEntry] = {}
+        self._runtime_bridge_auth_failure_audit_dedupe: dict[str, float] = {}
+        self._runtime_bridge_auth_failure_audit_lock = asyncio.Lock()
         self._runtime_mount_spec_signatures: dict[str, str] = {}
         self._preview_probe_cache: dict[str, _PreviewProbeCacheEntry] = {}
         self._public_preview_dns_cache: dict[str, _PreviewProbeCacheEntry] = {}
@@ -549,6 +555,94 @@ class UserSpaceRuntimeService:
         except JWTError as exc:
             raise HTTPException(status_code=401, detail=invalid_detail) from exc
 
+    @staticmethod
+    def _parse_runtime_bridge_datetime(value: Any) -> datetime | None:
+        if isinstance(value, datetime):
+            return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        text = str(value or "").strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+    async def _log_runtime_bridge_auth_failure(
+        self,
+        *,
+        reason: str,
+        claims: dict[str, Any] | None = None,
+        current_session_id: str | None = None,
+    ) -> None:
+        payload = {
+            "reason": reason,
+            "workspace_id": str((claims or {}).get("workspace_id") or "").strip() or None,
+            "token_session_id": str((claims or {}).get("session_id") or "").strip() or None,
+            "current_session_id": str(current_session_id or "").strip() or None,
+        }
+        sanitized_payload = {key: value for key, value in payload.items() if value is not None}
+        logger.warning("Runtime bridge auth failed: %s", sanitized_payload)
+        if claims is None:
+            return
+        workspace_id = str(claims.get("workspace_id") or "").strip()
+        token_session_id = str(claims.get("session_id") or "").strip() or None
+        if not workspace_id:
+            return
+        dedupe_key = hashlib.sha256(
+            json.dumps(
+                {
+                    "workspace_id": workspace_id,
+                    "token_session_id": token_session_id,
+                    "reason": reason,
+                    "current_session_id": str(current_session_id or "").strip() or None,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        now_ts = _time.monotonic()
+        async with self._runtime_bridge_auth_failure_audit_lock:
+            expired_keys = [
+                key
+                for key, expiry in self._runtime_bridge_auth_failure_audit_dedupe.items()
+                if expiry <= now_ts
+            ]
+            for key in expired_keys:
+                self._runtime_bridge_auth_failure_audit_dedupe.pop(key, None)
+            existing_expiry = self._runtime_bridge_auth_failure_audit_dedupe.get(dedupe_key)
+            if existing_expiry is not None and existing_expiry > now_ts:
+                return
+            if len(self._runtime_bridge_auth_failure_audit_dedupe) >= _RUNTIME_BRIDGE_AUTH_FAILURE_AUDIT_CACHE_MAX:
+                oldest_key = min(
+                    self._runtime_bridge_auth_failure_audit_dedupe,
+                    key=lambda key: self._runtime_bridge_auth_failure_audit_dedupe[key],
+                )
+                self._runtime_bridge_auth_failure_audit_dedupe.pop(oldest_key, None)
+            self._runtime_bridge_auth_failure_audit_dedupe[dedupe_key] = now_ts + _RUNTIME_BRIDGE_AUTH_FAILURE_AUDIT_WINDOW_SECONDS
+        await self._audit(
+            workspace_id,
+            "runtime_bridge_auth_failure",
+            user_id=None,
+            session_id=token_session_id,
+            payload=sanitized_payload,
+        )
+
+    @staticmethod
+    def _runtime_bridge_audit_payload_error(payload: Any) -> Any:
+        if isinstance(payload, dict):
+            return payload.get("error")
+        if isinstance(payload, str):
+            try:
+                decoded = json.loads(payload)
+            except ValueError:
+                return payload
+            if isinstance(decoded, dict):
+                return decoded.get("error")
+        return None
+
     def _finalize_workspace_env(
         self,
         workspace_id: str,
@@ -577,20 +671,40 @@ class UserSpaceRuntimeService:
 
     async def verify_runtime_bridge_token(self, token: str | None) -> dict[str, Any]:
         if not token:
+            await self._log_runtime_bridge_auth_failure(reason="missing_token")
             raise HTTPException(status_code=401, detail="Runtime bridge token required")
-        claims = self._decode_signed_token(token, invalid_detail="Invalid runtime bridge token")
+        try:
+            claims = self._decode_signed_token(token, invalid_detail="Invalid runtime bridge token")
+        except HTTPException:
+            await self._log_runtime_bridge_auth_failure(reason="invalid_or_expired_token")
+            raise
 
         workspace_id = str(claims.get("workspace_id") or "").strip()
         session_id = str(claims.get("session_id") or "").strip()
         if claims.get("kind") != _RUNTIME_BRIDGE_TOKEN_KIND or not workspace_id or not session_id:
+            await self._log_runtime_bridge_auth_failure(reason="invalid_claims", claims=claims)
             raise HTTPException(status_code=401, detail="Invalid runtime bridge token")
 
         session = await self._get_runtime_session_record(session_id)
+        current_session = await self._get_active_session_row(workspace_id)
+        current_session_id = str(getattr(current_session, "id", "") or "").strip() or None
+        if current_session_id and current_session_id != session_id:
+            await self._log_runtime_bridge_auth_failure(
+                reason="session_mismatch",
+                claims=claims,
+                current_session_id=current_session_id,
+            )
+            raise HTTPException(status_code=401, detail="Runtime bridge session mismatch")
         if (
             session is None
             or str(getattr(session, "workspaceId", "") or "") != workspace_id
             or str(getattr(session, "state", "") or "") not in _RUNTIME_BRIDGE_ACTIVE_SESSION_STATES
         ):
+            await self._log_runtime_bridge_auth_failure(
+                reason="session_inactive",
+                claims=claims,
+                current_session_id=current_session_id,
+            )
             raise HTTPException(status_code=401, detail="Runtime bridge session is not active")
 
         leased_by_user_id = str(getattr(session, "leasedByUserId", "") or "").strip()
@@ -600,6 +714,129 @@ class UserSpaceRuntimeService:
         claims["leased_by_user_id"] = leased_by_user_id
 
         return claims
+
+    async def _get_latest_runtime_bridge_success_at(
+        self,
+        workspace_id: str,
+        session_id: str,
+    ) -> datetime | None:
+        db = await get_db()
+        model = self._runtime_audit_model(db)
+        try:
+            rows = await model.find_many(
+                where={
+                    "workspaceId": workspace_id,
+                    "sessionId": session_id,
+                    "eventType": "runtime_bridge_execute",
+                },
+                order={"createdAt": "desc"},
+                take=_RUNTIME_BRIDGE_AUDIT_SUCCESS_SCAN_LIMIT,
+            )
+        except Exception:
+            return None
+        for row in rows or []:
+            payload = getattr(row, "eventPayload", getattr(row, "event_payload", None))
+            if self._runtime_bridge_audit_payload_error(payload) not in {None, "", False}:
+                continue
+            value = getattr(row, "createdAt", getattr(row, "created_at", None))
+            parsed = self._parse_runtime_bridge_datetime(value)
+            if parsed is not None:
+                return parsed
+        return None
+
+    async def _get_runtime_bridge_status_for_session(
+        self,
+        session: UserSpaceRuntimeSession | None,
+        provider_status: dict[str, Any] | None,
+    ) -> UserSpaceRuntimeBridgeStatus:
+        if session is None or session.state not in {"starting", "running"}:
+            return UserSpaceRuntimeBridgeStatus(
+                state="not_running",
+                current_session_id=getattr(session, "id", None) if session else None,
+                detail="Runtime session is not active",
+            )
+        if provider_status is None:
+            return UserSpaceRuntimeBridgeStatus(
+                state="unavailable",
+                current_session_id=session.id,
+                detail="Runtime provider status unavailable",
+            )
+        raw_credential = provider_status.get("bridge_credential")
+        if not isinstance(raw_credential, dict):
+            return UserSpaceRuntimeBridgeStatus(
+                state="missing",
+                current_session_id=session.id,
+                detail="Runtime bridge credential metadata unavailable",
+            )
+
+        bridge_url = str(raw_credential.get("bridge_url") or "").strip() or None
+        token_kind = str(raw_credential.get("token_kind") or "").strip() or None
+        workspace_id = str(raw_credential.get("workspace_id") or "").strip() or None
+        token_session_id = str(raw_credential.get("session_id") or "").strip() or None
+        issued_at = self._parse_runtime_bridge_datetime(raw_credential.get("issued_at"))
+        expires_at = self._parse_runtime_bridge_datetime(raw_credential.get("expires_at"))
+        last_success_at = await self._get_latest_runtime_bridge_success_at(session.workspace_id, session.id)
+
+        base_kwargs = {
+            "bridge_url": bridge_url,
+            "token_session_id": token_session_id,
+            "current_session_id": session.id,
+            "issued_at": issued_at,
+            "expires_at": expires_at,
+            "last_success_at": last_success_at,
+        }
+
+        if token_kind != _RUNTIME_BRIDGE_TOKEN_KIND or workspace_id != session.workspace_id or not bridge_url or not token_session_id:
+            return UserSpaceRuntimeBridgeStatus(
+                state="invalid",
+                detail="Runtime bridge credential metadata is invalid",
+                **base_kwargs,
+            )
+        if expires_at is not None and expires_at <= utc_now():
+            return UserSpaceRuntimeBridgeStatus(
+                state="expired",
+                detail="Runtime bridge credential has expired",
+                **base_kwargs,
+            )
+        if token_session_id != session.id:
+            return UserSpaceRuntimeBridgeStatus(
+                state="session_mismatch",
+                detail="Runtime bridge credential is bound to a different session",
+                **base_kwargs,
+            )
+        return UserSpaceRuntimeBridgeStatus(state="healthy", **base_kwargs)
+
+    async def get_runtime_bridge_status(
+        self,
+        workspace_id: str,
+        user_id: str,
+    ) -> UserSpaceRuntimeBridgeStatus:
+        await userspace_service.enforce_workspace_role(workspace_id, user_id, "viewer")
+        active = await self._get_active_session_row(workspace_id)
+        session = self._to_runtime_session(active) if active else None
+        provider_status = None
+        if session is not None:
+            try:
+                provider_status = await self._runtime_provider_get_status(
+                    session.provider_session_id,
+                    max_age_seconds=_RUNTIME_PROVIDER_STATUS_CACHE_TTL_SECONDS,
+                    allow_stale_on_error=True,
+                )
+            except HTTPException:
+                provider_status = None
+        return await self._get_runtime_bridge_status_for_session(session, provider_status)
+
+    async def refresh_runtime_bridge_credentials(
+        self,
+        workspace_id: str,
+        user_id: str,
+    ) -> UserSpaceRuntimeBridgeStatus:
+        await userspace_service.enforce_workspace_role(workspace_id, user_id, "editor")
+        await self.restart_runtime_env_vars_and_wait(
+            workspace_id,
+            timeout_seconds=60.0,
+        )
+        return await self.get_runtime_bridge_status(workspace_id, user_id)
 
     async def consume_preview_grant(self, claims: dict[str, Any]) -> None:
         """Enforce single-use semantics for preview bootstrap grants.
@@ -2136,16 +2373,30 @@ class UserSpaceRuntimeService:
                 runtime_has_cap_sys_admin=None,
                 preview_url=self._build_preview_origin(workspace_id),
                 live_data_warning=live_data_warning,
+                bridge_status=UserSpaceRuntimeBridgeStatus(
+                    state="not_running",
+                    detail="Runtime session is not active",
+                ),
             )
 
         session = self._to_runtime_session(active)
-        provider_status = await self._runtime_provider_get_status(
-            session.provider_session_id,
-            max_age_seconds=_RUNTIME_PROVIDER_STATUS_CACHE_TTL_SECONDS,
-            allow_stale_on_error=True,
-        )
+        provider_status_fetch_failed = False
+        try:
+            provider_status = await self._runtime_provider_get_status(
+                session.provider_session_id,
+                max_age_seconds=_RUNTIME_PROVIDER_STATUS_CACHE_TTL_SECONDS,
+                allow_stale_on_error=True,
+            )
+        except HTTPException:
+            provider_status = None
+            provider_status_fetch_failed = True
 
-        if provider_status is None and session.runtime_provider == self._runtime_provider_name() and session.state in {"starting", "running"}:
+        if (
+            provider_status is None
+            and not provider_status_fetch_failed
+            and session.runtime_provider == self._runtime_provider_name()
+            and session.state in {"starting", "running"}
+        ):
             # Re-read the DB row to guard against a concurrent stop_runtime_session
             # that set the state to "stopped" after our initial read.
             fresh_row = await self._get_active_session_row(workspace_id)
@@ -2160,6 +2411,11 @@ class UserSpaceRuntimeService:
                     runtime_has_cap_sys_admin=None,
                     preview_url=self._build_preview_origin(workspace_id),
                     live_data_warning=live_data_warning,
+                    bridge_status=UserSpaceRuntimeBridgeStatus(
+                        state="not_running",
+                        current_session_id=session.id,
+                        detail="Runtime session is not active",
+                    ),
                 )
             logger.warning(
                 "Runtime provider status missing for workspace %s; auto-recovering session",
@@ -2251,6 +2507,8 @@ class UserSpaceRuntimeService:
             runtime_operation_started_at = provider_status.get("runtime_operation_started_at")
             runtime_operation_updated_at = provider_status.get("runtime_operation_updated_at")
 
+        bridge_status = await self._get_runtime_bridge_status_for_session(session, provider_status)
+
         return UserSpaceRuntimeStatusResponse(
             workspace_id=workspace_id,
             session_state=state_for_response,
@@ -2265,6 +2523,7 @@ class UserSpaceRuntimeService:
             preview_url=self._build_preview_origin(workspace_id),
             last_error=last_error,
             live_data_warning=live_data_warning,
+            bridge_status=bridge_status,
             runtime_operation_id=runtime_operation_id,
             runtime_operation_phase=runtime_operation_phase,
             runtime_operation_started_at=runtime_operation_started_at,

--- a/runtime/manager/models.py
+++ b/runtime/manager/models.py
@@ -29,6 +29,7 @@ class ManagerSession:
     runtime_operation_phase: str | None
     runtime_operation_started_at: datetime | None
     runtime_operation_updated_at: datetime | None
+    bridge_credential: RuntimeBridgeCredentialMetadata | None
     updated_at: datetime
     lease_expires_at: datetime
 
@@ -57,6 +58,15 @@ class StartSessionRequest(BaseModel):
             "source_type, mount_backend, read_only, and optional runtime_mount_mode."
         ),
     )
+
+
+class RuntimeBridgeCredentialMetadata(BaseModel):
+    bridge_url: str = Field(description="Runtime bridge URL")
+    token_kind: str = Field(description="Decoded bridge token kind")
+    workspace_id: str = Field(description="Workspace ID bound to the bridge token")
+    session_id: str = Field(description="Workspace session ID bound to the bridge token")
+    issued_at: datetime = Field(description="Token issued-at timestamp")
+    expires_at: datetime = Field(description="Token expiration timestamp")
 
 
 class _BaseSessionFields(BaseModel):
@@ -102,6 +112,10 @@ class _BaseSessionFields(BaseModel):
     runtime_operation_updated_at: datetime | None = Field(
         default=None,
         description="Timestamp when current runtime operation phase was last updated",
+    )
+    bridge_credential: RuntimeBridgeCredentialMetadata | None = Field(
+        default=None,
+        description="Safe runtime bridge credential metadata derived from workspace env",
     )
     updated_at: datetime = Field(description="Session update time")
 

--- a/runtime/manager/service.py
+++ b/runtime/manager/service.py
@@ -106,6 +106,7 @@ class SessionManager:
             runtime_operation_phase=session.runtime_operation_phase,
             runtime_operation_started_at=session.runtime_operation_started_at,
             runtime_operation_updated_at=session.runtime_operation_updated_at,
+            bridge_credential=session.bridge_credential,
             updated_at=session.updated_at,
         )
 
@@ -217,6 +218,7 @@ class SessionManager:
         session.runtime_operation_phase = worker_data.runtime_operation_phase
         session.runtime_operation_started_at = worker_data.runtime_operation_started_at
         session.runtime_operation_updated_at = worker_data.runtime_operation_updated_at
+        session.bridge_credential = worker_data.bridge_credential
 
     def _create_session(
         self,
@@ -246,6 +248,7 @@ class SessionManager:
             runtime_operation_phase=worker_data.runtime_operation_phase,
             runtime_operation_started_at=worker_data.runtime_operation_started_at,
             runtime_operation_updated_at=worker_data.runtime_operation_updated_at,
+            bridge_credential=worker_data.bridge_credential,
             updated_at=now,
             lease_expires_at=now + timedelta(seconds=self._lease_ttl_seconds),
         )
@@ -368,24 +371,50 @@ class SessionManager:
                         pty_access_token = uuid4().hex
 
             if existing_provider_id:
-                session = await self._sync_session_from_worker_by_provider_id(existing_provider_id)
-                if session is None:
-                    raise HTTPException(
-                        status_code=404,
-                        detail="Runtime session not found",
+                async with self._provider_lock(existing_provider_id):
+                    async with self._lock:
+                        session = self._sessions.get(existing_provider_id)
+                        if not session:
+                            raise HTTPException(
+                                status_code=404,
+                                detail="Runtime session not found",
+                            )
+                        if session.workspace_id != request.workspace_id:
+                            raise HTTPException(
+                                status_code=409,
+                                detail="Runtime session workspace does not match requested workspace",
+                            )
+                        worker_session_id = session.worker_session_id
+                        pty_access_token = session.pty_access_token
+
+                    worker_data = await asyncio.wait_for(
+                        self._worker_service.start_session(
+                            WorkerStartSessionRequest(
+                                workspace_id=request.workspace_id,
+                                provider_session_id=existing_provider_id,
+                                pty_access_token=pty_access_token,
+                                workspace_env=request.workspace_env,
+                                workspace_env_visibility=request.workspace_env_visibility,
+                                workspace_mounts=request.workspace_mounts,
+                            )
+                        ),
+                        timeout=self._worker_call_timeout,
                     )
-                async with self._lock:
-                    session = self._sessions.get(existing_provider_id)
-                    if not session:
-                        raise HTTPException(
-                            status_code=404,
-                            detail="Runtime session not found",
-                        )
-                    now = utc_now()
-                    session.leased_by_user_id = request.leased_by_user_id
-                    session.lease_expires_at = now + timedelta(seconds=self._lease_ttl_seconds)
-                    session.updated_at = now
-                    return self._as_response(session)
+
+                    async with self._lock:
+                        session = self._sessions.get(existing_provider_id)
+                        if not session or session.worker_session_id != worker_session_id:
+                            raise HTTPException(
+                                status_code=404,
+                                detail="Runtime session not found",
+                            )
+                        session.worker_session_id = worker_data.worker_session_id
+                        self._apply_worker_state(session, worker_data)
+                        now = utc_now()
+                        session.leased_by_user_id = request.leased_by_user_id
+                        session.lease_expires_at = now + timedelta(seconds=self._lease_ttl_seconds)
+                        session.updated_at = now
+                        return self._as_response(session)
 
             if not provider_session_id or pty_access_token is None:
                 raise HTTPException(status_code=500, detail="Runtime session start failed")

--- a/runtime/worker/service.py
+++ b/runtime/worker/service.py
@@ -15,7 +15,7 @@ import sys
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -24,6 +24,7 @@ import httpx
 from fastapi import HTTPException
 
 from runtime.manager.models import (
+    RuntimeBridgeCredentialMetadata,
     RuntimeContentProbeRequest,
     RuntimeContentProbeResponse,
     RuntimeExecResponse,
@@ -919,6 +920,56 @@ class WorkerService:
                 clear_targets=clear_targets,
             )
 
+    @staticmethod
+    def _decode_jwt_payload_metadata(token: str) -> dict[str, Any] | None:
+        parts = str(token or "").split(".")
+        if len(parts) != 3:
+            return None
+        payload_segment = parts[1]
+        padding = "=" * (-len(payload_segment) % 4)
+        try:
+            decoded = base64.urlsafe_b64decode(f"{payload_segment}{padding}")
+            payload = json.loads(decoded)
+        except Exception:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    @staticmethod
+    def _coerce_datetime_claim(value: Any) -> datetime | None:
+        if value is None:
+            return None
+        try:
+            return datetime.fromtimestamp(float(value), tz=UTC)
+        except Exception:
+            return None
+
+    def _bridge_credential_metadata(
+        self,
+        session: WorkerSession,
+    ) -> RuntimeBridgeCredentialMetadata | None:
+        bridge_url = str(session.workspace_env.get("RAGTIME_BRIDGE_URL") or "").strip()
+        token = str(session.workspace_env.get("RAGTIME_BRIDGE_TOKEN") or "").strip()
+        if not bridge_url or not token:
+            return None
+        payload = self._decode_jwt_payload_metadata(token)
+        if payload is None:
+            return None
+        token_kind = str(payload.get("kind") or "").strip()
+        workspace_id = str(payload.get("workspace_id") or "").strip()
+        session_id = str(payload.get("session_id") or "").strip()
+        issued_at = self._coerce_datetime_claim(payload.get("iat"))
+        expires_at = self._coerce_datetime_claim(payload.get("exp"))
+        if not token_kind or not workspace_id or not session_id or issued_at is None or expires_at is None:
+            return None
+        return RuntimeBridgeCredentialMetadata(
+            bridge_url=bridge_url,
+            token_kind=token_kind,
+            workspace_id=workspace_id,
+            session_id=session_id,
+            issued_at=issued_at,
+            expires_at=expires_at,
+        )
+
     def _session_response(self, session: WorkerSession) -> WorkerSessionResponse:
         return WorkerSessionResponse(
             worker_session_id=session.id,
@@ -936,6 +987,7 @@ class WorkerService:
             runtime_operation_phase=session.runtime_operation_phase,
             runtime_operation_started_at=session.runtime_operation_started_at,
             runtime_operation_updated_at=session.runtime_operation_updated_at,
+            bridge_credential=self._bridge_credential_metadata(session),
             updated_at=session.updated_at,
         )
 
@@ -2331,6 +2383,11 @@ class WorkerService:
             existing_session_id = self._provider_to_session.get(request.provider_session_id)
             if existing_session_id and existing_session_id in self._sessions:
                 session = self._sessions[existing_session_id]
+                if session.workspace_id != request.workspace_id:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Worker session workspace does not match requested workspace",
+                    )
                 session.pty_access_token = request.pty_access_token
                 session.workspace_env = self._normalize_workspace_env(request.workspace_env)
                 session.workspace_env_visibility = self._normalize_workspace_env_visibility(

--- a/tests/test_runtime_bridge_credential_metadata.py
+++ b/tests/test_runtime_bridge_credential_metadata.py
@@ -17,7 +17,7 @@ def _jwt_segment(payload: dict[str, object]) -> str:
 
 
 def _unsigned_jwt(payload: dict[str, object]) -> str:
-    header = {"alg": "HS256", "typ": "JWT"}
+    header: dict[str, object] = {"alg": "HS256", "typ": "JWT"}
     return f"{_jwt_segment(header)}.{_jwt_segment(payload)}.signature"
 
 

--- a/tests/test_runtime_bridge_credential_metadata.py
+++ b/tests/test_runtime_bridge_credential_metadata.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import base64
+import importlib
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from unittest import mock
+
+from fastapi import HTTPException
+
+
+def _jwt_segment(payload: dict[str, object]) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("ascii")
+
+
+def _unsigned_jwt(payload: dict[str, object]) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    return f"{_jwt_segment(header)}.{_jwt_segment(payload)}.signature"
+
+
+class RuntimeBridgeCredentialMetadataTests(unittest.TestCase):
+    def _load_modules(self):
+        models_module = importlib.import_module("runtime.manager.models")
+        worker_service_module = importlib.import_module("runtime.worker.service")
+        return models_module, worker_service_module
+
+    def _build_session(self, worker_service_module, *, token: str | None):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"RUNTIME_WORKSPACE_ROOT": tmpdir}, clear=False):
+                service = worker_service_module.WorkerService()
+                workspace_root, workspace_files_path, sandbox_spec = service._resolve_workspace_root("ws-1")
+                now = datetime.now(timezone.utc)
+                session = worker_service_module.WorkerSession(
+                    id="worker-1",
+                    workspace_id="ws-1",
+                    provider_session_id="provider-1",
+                    workspace_root=workspace_root,
+                    workspace_files_path=workspace_files_path,
+                    sandbox_spec=sandbox_spec,
+                    pty_access_token="pty-token",
+                    workspace_env={
+                        "RAGTIME_BRIDGE_URL": "http://bridge.example/runtime-bridge",
+                        **({"RAGTIME_BRIDGE_TOKEN": token} if token is not None else {}),
+                    },
+                    workspace_env_visibility={},
+                    workspace_mounts=[],
+                    mount_targets_to_clear=set(),
+                    state="running",
+                    devserver_running=True,
+                    devserver_port=4173,
+                    devserver_command=["npm", "run", "dev"],
+                    launch_framework="vite",
+                    launch_cwd=".",
+                    last_error=None,
+                    runtime_operation_id=None,
+                    runtime_operation_phase=None,
+                    runtime_operation_started_at=None,
+                    runtime_operation_updated_at=None,
+                    updated_at=now,
+                )
+                return service, session
+
+    def test_session_response_decodes_safe_bridge_credential_metadata(self) -> None:
+        _, worker_service_module = self._load_modules()
+        token = _unsigned_jwt(
+            {
+                "kind": "userspace_runtime_bridge",
+                "workspace_id": "ws-1",
+                "session_id": "runtime-session-1",
+                "iat": 1735689600,
+                "exp": 1735693200,
+            }
+        )
+        service, session = self._build_session(worker_service_module, token=token)
+
+        response = service._session_response(session)
+        dumped = response.model_dump_json()
+
+        self.assertIsNotNone(response.bridge_credential)
+        self.assertEqual(response.bridge_credential.bridge_url, "http://bridge.example/runtime-bridge")
+        self.assertEqual(response.bridge_credential.token_kind, "userspace_runtime_bridge")
+        self.assertEqual(response.bridge_credential.workspace_id, "ws-1")
+        self.assertEqual(response.bridge_credential.session_id, "runtime-session-1")
+        self.assertEqual(
+            response.bridge_credential.issued_at,
+            datetime.fromtimestamp(1735689600, tz=timezone.utc),
+        )
+        self.assertEqual(
+            response.bridge_credential.expires_at,
+            datetime.fromtimestamp(1735693200, tz=timezone.utc),
+        )
+        self.assertNotIn(token, dumped)
+        self.assertNotIn("RAGTIME_BRIDGE_TOKEN", dumped)
+
+    def test_session_response_returns_none_for_malformed_bridge_token(self) -> None:
+        _, worker_service_module = self._load_modules()
+        service, session = self._build_session(worker_service_module, token="not-a-jwt")
+
+        response = service._session_response(session)
+
+        self.assertIsNone(response.bridge_credential)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class RuntimeWorkerWorkspaceIdentityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_worker_reuse_rejects_cross_workspace_identity_mismatch(self) -> None:
+        worker_service_module = importlib.import_module("runtime.worker.service")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"RUNTIME_WORKSPACE_ROOT": tmpdir}, clear=False):
+                service = worker_service_module.WorkerService()
+                first = await service.start_session(
+                    worker_service_module.WorkerStartSessionRequest(
+                        workspace_id="ws-1",
+                        provider_session_id="provider-1",
+                        pty_access_token="pty-token",
+                        workspace_env={"FIRST": "one"},
+                        workspace_env_visibility={"FIRST": True},
+                        workspace_mounts=[{"target_path": "/workspace/one"}],
+                    )
+                )
+
+                stored_session = service._sessions[first.worker_session_id]
+                original_updated_at = stored_session.updated_at
+
+                with self.assertRaises(HTTPException) as mismatched:
+                    await service.start_session(
+                        worker_service_module.WorkerStartSessionRequest(
+                            workspace_id="ws-2",
+                            provider_session_id="provider-1",
+                            pty_access_token="new-pty-token",
+                            workspace_env={"SECOND": "two"},
+                            workspace_env_visibility={"SECOND": False},
+                            workspace_mounts=[{"target_path": "/workspace/two"}],
+                        )
+                    )
+
+                self.assertEqual(mismatched.exception.status_code, 409)
+                self.assertIn("workspace", str(mismatched.exception.detail).lower())
+
+                unchanged_session = service._sessions[first.worker_session_id]
+                self.assertEqual(unchanged_session.workspace_id, "ws-1")
+                self.assertEqual(unchanged_session.pty_access_token, "pty-token")
+                self.assertEqual(unchanged_session.workspace_env, {"FIRST": "one"})
+                self.assertEqual(unchanged_session.workspace_env_visibility, {"FIRST": True})
+                self.assertEqual(unchanged_session.workspace_mounts, [{"target_path": "/workspace/one"}])
+                self.assertEqual(unchanged_session.updated_at, original_updated_at)

--- a/tests/test_runtime_manager_session_reuse.py
+++ b/tests/test_runtime_manager_session_reuse.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import importlib
+import unittest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest import mock
+
+from fastapi import HTTPException
+
+
+def _bridge_credential(models_module, *, workspace_id: str, session_id: str):
+    now = datetime.now(timezone.utc)
+    return models_module.RuntimeBridgeCredentialMetadata(
+        bridge_url="http://bridge.example/runtime-bridge",
+        token_kind="userspace_runtime_bridge",
+        workspace_id=workspace_id,
+        session_id=session_id,
+        issued_at=now,
+        expires_at=now,
+    )
+
+
+def _worker_session_response(
+    models_module,
+    *,
+    workspace_id: str,
+    worker_session_id: str,
+    launch_port: int | None = None,
+    bridge_session_id: str = "runtime-session-1",
+):
+    now = datetime.now(timezone.utc)
+    return models_module.WorkerSessionResponse(
+        worker_session_id=worker_session_id,
+        workspace_id=workspace_id,
+        state="starting",
+        preview_internal_url=f"http://runtime/{workspace_id}",
+        launch_framework="vite",
+        launch_command="npm run dev",
+        launch_cwd=".",
+        launch_port=launch_port,
+        runtime_capabilities=None,
+        devserver_running=False,
+        last_error=None,
+        runtime_operation_id="op-1",
+        runtime_operation_phase="starting",
+        runtime_operation_started_at=now,
+        runtime_operation_updated_at=now,
+        updated_at=now,
+        bridge_credential=_bridge_credential(
+            models_module,
+            workspace_id=workspace_id,
+            session_id=bridge_session_id,
+        ),
+    )
+
+
+class RuntimeManagerSessionReuseTests(unittest.IsolatedAsyncioTestCase):
+    def _load_modules(self):
+        service_module = importlib.import_module("runtime.manager.service")
+        models_module = importlib.import_module("runtime.manager.models")
+        return service_module, models_module
+
+    async def test_reused_provider_session_restarts_worker_with_fresh_runtime_inputs(self) -> None:
+        service_module, models_module = self._load_modules()
+        start_requests = []
+
+        async def start_session(request):
+            start_requests.append(request)
+            if len(start_requests) == 1:
+                return _worker_session_response(
+                    models_module,
+                    workspace_id=request.workspace_id,
+                    worker_session_id="worker-1",
+                    launch_port=3000,
+                    bridge_session_id="runtime-session-1",
+                )
+            return _worker_session_response(
+                models_module,
+                workspace_id=request.workspace_id,
+                worker_session_id="worker-1",
+                launch_port=4173,
+                bridge_session_id="runtime-session-2",
+            )
+
+        worker_service = SimpleNamespace(
+            start_session=mock.AsyncMock(side_effect=start_session),
+            get_session=mock.AsyncMock(),
+            stop_session=mock.AsyncMock(),
+        )
+
+        with mock.patch.object(service_module, "get_worker_service", return_value=worker_service):
+            manager = service_module.SessionManager()
+            first = await manager.start_session(
+                models_module.StartSessionRequest(
+                    workspace_id="workspace-1",
+                    leased_by_user_id="user-1",
+                    workspace_env={"FIRST": "one"},
+                    workspace_env_visibility={"FIRST": True},
+                    workspace_mounts=[{"target_path": "/workspace/one"}],
+                )
+            )
+            second = await manager.start_session(
+                models_module.StartSessionRequest(
+                    workspace_id="workspace-1",
+                    leased_by_user_id="user-2",
+                    provider_session_id=first.provider_session_id,
+                    workspace_env={"SECOND": "two"},
+                    workspace_env_visibility={"SECOND": False},
+                    workspace_mounts=[{"target_path": "/workspace/two"}],
+                )
+            )
+
+        self.assertEqual(worker_service.start_session.await_count, 2)
+        worker_service.get_session.assert_not_awaited()
+        reused_request = start_requests[1]
+        self.assertEqual(reused_request.provider_session_id, first.provider_session_id)
+        self.assertEqual(reused_request.workspace_env, {"SECOND": "two"})
+        self.assertEqual(reused_request.workspace_env_visibility, {"SECOND": False})
+        self.assertEqual(reused_request.workspace_mounts, [{"target_path": "/workspace/two"}])
+        self.assertEqual(second.provider_session_id, first.provider_session_id)
+        self.assertEqual(second.launch_port, 4173)
+        self.assertIsNotNone(second.bridge_credential)
+        self.assertEqual(second.bridge_credential.session_id, "runtime-session-2")
+
+    async def test_reused_provider_session_rejects_cross_workspace_identity_mismatch(self) -> None:
+        service_module, models_module = self._load_modules()
+
+        async def start_session(request):
+            return _worker_session_response(
+                models_module,
+                workspace_id=request.workspace_id,
+                worker_session_id="worker-1",
+                launch_port=3000,
+                bridge_session_id="runtime-session-1",
+            )
+
+        worker_service = SimpleNamespace(
+            start_session=mock.AsyncMock(side_effect=start_session),
+            get_session=mock.AsyncMock(),
+            stop_session=mock.AsyncMock(),
+        )
+
+        with mock.patch.object(service_module, "get_worker_service", return_value=worker_service):
+            manager = service_module.SessionManager()
+            first = await manager.start_session(
+                models_module.StartSessionRequest(
+                    workspace_id="workspace-1",
+                    leased_by_user_id="user-1",
+                    workspace_env={"FIRST": "one"},
+                )
+            )
+
+            with self.assertRaises(HTTPException) as mismatched:
+                await manager.start_session(
+                    models_module.StartSessionRequest(
+                        workspace_id="workspace-2",
+                        leased_by_user_id="user-2",
+                        provider_session_id=first.provider_session_id,
+                        workspace_env={"SECOND": "two"},
+                        workspace_env_visibility={"SECOND": False},
+                        workspace_mounts=[{"target_path": "/workspace/two"}],
+                    )
+                )
+
+        self.assertEqual(mismatched.exception.status_code, 409)
+        self.assertIn("workspace", str(mismatched.exception.detail).lower())
+        self.assertEqual(worker_service.start_session.await_count, 1)
+        worker_service.get_session.assert_not_awaited()
+
+        session = manager._sessions[first.provider_session_id]
+        self.assertEqual(session.workspace_id, "workspace-1")
+        self.assertEqual(session.leased_by_user_id, "user-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_userspace_runtime_bridge_route.py
+++ b/tests/test_userspace_runtime_bridge_route.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import cast
 from unittest import mock
@@ -19,9 +20,12 @@ from ragtime.userspace.models import (
     RuntimeBridgeSqliteMutationResponse,
     RuntimeBridgeSqliteQueryRequest,
     RuntimeBridgeSqliteQueryResponse,
+    UserSpaceRuntimeBridgeStatus,
 )
 
 runtime_bridge_execute_component = _RUNTIME_ROUTES.runtime_bridge_execute_component
+get_runtime_bridge_status = _RUNTIME_ROUTES.get_runtime_bridge_status
+refresh_runtime_bridge_credentials = _RUNTIME_ROUTES.refresh_runtime_bridge_credentials
 
 
 def _build_request(path: str, authorization: str | None = None) -> Request:
@@ -360,6 +364,39 @@ class RuntimeBridgeRouteTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ctx.exception.status_code, 500)
         self.assertEqual(ctx.exception.detail, "Runtime bridge SQLite request failed.")
         logger_exception.assert_called_once()
+
+    async def test_bridge_status_route_returns_service_status(self) -> None:
+        expected = UserSpaceRuntimeBridgeStatus(
+            state="healthy",
+            bridge_url="https://ragtime.example/indexes/userspace/runtime-bridge",
+            token_session_id="sess-1",
+            current_session_id="sess-1",
+            last_success_at=datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc),
+        )
+        runtime_service = SimpleNamespace(get_runtime_bridge_status=mock.AsyncMock(return_value=expected))
+        user = SimpleNamespace(id="user-1")
+
+        with mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service):
+            response = await get_runtime_bridge_status("ws-1", user)
+
+        self.assertIs(response, expected)
+        runtime_service.get_runtime_bridge_status.assert_awaited_once_with("ws-1", "user-1")
+
+    async def test_bridge_refresh_route_returns_refreshed_status(self) -> None:
+        expected = UserSpaceRuntimeBridgeStatus(
+            state="healthy",
+            bridge_url="https://ragtime.example/indexes/userspace/runtime-bridge",
+            token_session_id="sess-1",
+            current_session_id="sess-1",
+        )
+        runtime_service = SimpleNamespace(refresh_runtime_bridge_credentials=mock.AsyncMock(return_value=expected))
+        user = SimpleNamespace(id="user-1")
+
+        with mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service):
+            response = await refresh_runtime_bridge_credentials("ws-1", user)
+
+        self.assertIs(response, expected)
+        runtime_service.refresh_runtime_bridge_credentials.assert_awaited_once_with("ws-1", "user-1")
 
 
 if __name__ == "__main__":

--- a/tests/test_userspace_runtime_bridge_status.py
+++ b/tests/test_userspace_runtime_bridge_status.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest import mock
+
+from fastapi import HTTPException
+
+from ragtime.userspace.models import UserSpaceRuntimeBridgeStatus
+from ragtime.userspace.runtime_service import UserSpaceRuntimeService
+
+
+def _session_row(*, session_id: str, state: str = "running") -> SimpleNamespace:
+    now = datetime.now(UTC)
+    return SimpleNamespace(
+        id=session_id,
+        workspaceId="ws-1",
+        leasedByUserId="user-1",
+        state=state,
+        runtimeProvider="microvm_pool_v1",
+        providerSessionId="provider-1",
+        previewInternalUrl="http://preview",
+        launchFramework=None,
+        launchCommand=None,
+        launchCwd=None,
+        launchPort=5173,
+        createdAt=now,
+        updatedAt=now,
+        lastHeartbeatAt=None,
+        idleExpiresAt=None,
+        ttlExpiresAt=None,
+        lastError=None,
+    )
+
+
+class RuntimeBridgeStatusTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.service = UserSpaceRuntimeService()
+
+    async def test_get_bridge_status_reports_session_mismatch_and_last_success(self) -> None:
+        last_success = datetime(2026, 8, 5, 12, 30, tzinfo=UTC)
+        current_row = _session_row(session_id="sess-current")
+        enforce_role = mock.AsyncMock()
+
+        with (
+            mock.patch("ragtime.userspace.runtime_service.userspace_service.enforce_workspace_role", enforce_role),
+            mock.patch.object(
+                self.service,
+                "_get_active_session_row",
+                mock.AsyncMock(return_value=current_row),
+            ),
+            mock.patch.object(
+                self.service,
+                "_runtime_provider_get_status",
+                mock.AsyncMock(
+                    return_value={
+                        "bridge_credential": {
+                            "bridge_url": "https://ragtime.example/indexes/userspace/runtime-bridge",
+                            "token_kind": "userspace_runtime_bridge",
+                            "workspace_id": "ws-1",
+                            "session_id": "sess-stale",
+                            "issued_at": "2026-08-05T12:00:00+00:00",
+                            "expires_at": "2099-08-05T16:00:00+00:00",
+                        }
+                    }
+                ),
+            ),
+            mock.patch.object(
+                self.service,
+                "_get_latest_runtime_bridge_success_at",
+                mock.AsyncMock(return_value=last_success),
+            ),
+        ):
+            status = await self.service.get_runtime_bridge_status("ws-1", "user-1")
+
+        self.assertEqual(status.state, "session_mismatch")
+        self.assertEqual(status.bridge_url, "https://ragtime.example/indexes/userspace/runtime-bridge")
+        self.assertEqual(status.token_session_id, "sess-stale")
+        self.assertEqual(status.current_session_id, "sess-current")
+        self.assertEqual(status.last_success_at, last_success)
+        enforce_role.assert_awaited_once_with("ws-1", "user-1", "viewer")
+
+    async def test_get_devserver_status_includes_bridge_status(self) -> None:
+        current_row = _session_row(session_id="sess-current")
+        bridge_status = UserSpaceRuntimeBridgeStatus(
+            state="healthy",
+            bridge_url="https://ragtime.example/indexes/userspace/runtime-bridge",
+            token_session_id="sess-current",
+            current_session_id="sess-current",
+        )
+
+        with (
+            mock.patch.object(
+                self.service,
+                "_get_active_session_row",
+                mock.AsyncMock(return_value=current_row),
+            ),
+            mock.patch.object(
+                self.service,
+                "_runtime_provider_get_status",
+                mock.AsyncMock(return_value={"devserver_running": True}),
+            ),
+            mock.patch.object(
+                self.service,
+                "_get_runtime_bridge_status_for_session",
+                mock.AsyncMock(return_value=bridge_status),
+            ),
+        ):
+            status = await self.service._get_devserver_status_authorized("ws-1", "user-1")
+
+        self.assertEqual(status.bridge_status, bridge_status)
+
+    async def test_latest_runtime_bridge_success_skips_failed_newest_row(self) -> None:
+        successful_at = datetime(2026, 8, 5, 11, 0, tzinfo=UTC)
+        rows = [
+            SimpleNamespace(createdAt=datetime(2026, 8, 5, 12, 0, tzinfo=UTC), eventPayload={"error": "boom"}),
+            SimpleNamespace(createdAt=successful_at, eventPayload={"error": None}),
+        ]
+        db = SimpleNamespace(userspaceruntimeauditevent=SimpleNamespace(find_many=mock.AsyncMock(return_value=rows)))
+
+        with mock.patch("ragtime.userspace.runtime_service.get_db", mock.AsyncMock(return_value=db)):
+            last_success = await self.service._get_latest_runtime_bridge_success_at("ws-1", "sess-1")
+
+        self.assertEqual(last_success, successful_at)
+        db.userspaceruntimeauditevent.find_many.assert_awaited_once()
+        self.assertEqual(db.userspaceruntimeauditevent.find_many.await_args.kwargs["take"], 10)
+
+    async def test_get_runtime_bridge_status_maps_provider_failure_to_unavailable(self) -> None:
+        current_row = _session_row(session_id="sess-current")
+
+        with (
+            mock.patch(
+                "ragtime.userspace.runtime_service.userspace_service.enforce_workspace_role",
+                mock.AsyncMock(),
+            ),
+            mock.patch.object(
+                self.service,
+                "_get_active_session_row",
+                mock.AsyncMock(return_value=current_row),
+            ),
+            mock.patch.object(
+                self.service,
+                "_runtime_provider_get_status",
+                mock.AsyncMock(side_effect=HTTPException(status_code=502, detail="upstream unavailable")),
+            ),
+        ):
+            status = await self.service.get_runtime_bridge_status("ws-1", "user-1")
+
+        self.assertEqual(status.state, "unavailable")
+        self.assertEqual(status.current_session_id, "sess-current")
+
+    async def test_runtime_bridge_status_derives_not_running(self) -> None:
+        status = await self.service._get_runtime_bridge_status_for_session(None, None)
+        self.assertEqual(status.state, "not_running")
+
+    async def test_runtime_bridge_status_derives_missing(self) -> None:
+        session = self.service._to_runtime_session(_session_row(session_id="sess-1"))
+        status = await self.service._get_runtime_bridge_status_for_session(session, {"devserver_running": True})
+        self.assertEqual(status.state, "missing")
+
+    async def test_runtime_bridge_status_derives_expired(self) -> None:
+        session = self.service._to_runtime_session(_session_row(session_id="sess-1"))
+        with mock.patch.object(self.service, "_get_latest_runtime_bridge_success_at", mock.AsyncMock(return_value=None)):
+            status = await self.service._get_runtime_bridge_status_for_session(
+                session,
+                {
+                    "bridge_credential": {
+                        "bridge_url": "https://ragtime.example/indexes/userspace/runtime-bridge",
+                        "token_kind": "userspace_runtime_bridge",
+                        "workspace_id": "ws-1",
+                        "session_id": "sess-1",
+                        "issued_at": "2026-08-05T12:00:00+00:00",
+                        "expires_at": "2000-08-05T16:00:00+00:00",
+                    }
+                },
+            )
+        self.assertEqual(status.state, "expired")
+
+    async def test_runtime_bridge_status_derives_invalid(self) -> None:
+        session = self.service._to_runtime_session(_session_row(session_id="sess-1"))
+        with mock.patch.object(self.service, "_get_latest_runtime_bridge_success_at", mock.AsyncMock(return_value=None)):
+            status = await self.service._get_runtime_bridge_status_for_session(
+                session,
+                {
+                    "bridge_credential": {
+                        "bridge_url": "",
+                        "token_kind": "wrong-kind",
+                        "workspace_id": "ws-2",
+                        "session_id": "sess-1",
+                    }
+                },
+            )
+        self.assertEqual(status.state, "invalid")
+
+    async def test_refresh_runtime_bridge_credentials_waits_then_fetches_status(self) -> None:
+        expected = UserSpaceRuntimeBridgeStatus(state="healthy")
+        enforce_role = mock.AsyncMock()
+
+        with (
+            mock.patch("ragtime.userspace.runtime_service.userspace_service.enforce_workspace_role", enforce_role),
+            mock.patch.object(
+                self.service,
+                "restart_runtime_env_vars_and_wait",
+                mock.AsyncMock(),
+            ) as restart_wait,
+            mock.patch.object(
+                self.service,
+                "get_runtime_bridge_status",
+                mock.AsyncMock(return_value=expected),
+            ) as get_status,
+        ):
+            result = await self.service.refresh_runtime_bridge_credentials("ws-1", "user-1")
+
+        self.assertIs(result, expected)
+        enforce_role.assert_awaited_once_with("ws-1", "user-1", "editor")
+        restart_wait.assert_awaited_once_with("ws-1", timeout_seconds=60.0)
+        get_status.assert_awaited_once_with("ws-1", "user-1")

--- a/tests/test_userspace_runtime_bridge_token.py
+++ b/tests/test_userspace_runtime_bridge_token.py
@@ -196,7 +196,10 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ctx.exception.status_code, 401)
         self.assertEqual(ctx.exception.detail, "Runtime bridge session mismatch")
         audit.assert_awaited_once()
-        payload = audit.await_args.kwargs["payload"]
+        await_args = audit.await_args
+        self.assertIsNotNone(await_args)
+        assert await_args is not None
+        payload = await_args.kwargs["payload"]
         self.assertEqual(payload["reason"], "session_mismatch")
         self.assertEqual(payload["workspace_id"], "ws-1")
         self.assertEqual(payload["token_session_id"], "sess-stale")

--- a/tests/test_userspace_runtime_bridge_token.py
+++ b/tests/test_userspace_runtime_bridge_token.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 import unittest
 from unittest import mock
@@ -48,7 +49,10 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
             settings.encryption_key,
             algorithm=settings.jwt_algorithm,
         )
-        with self.assertRaises(HTTPException):
+        with (
+            mock.patch.object(self.service, "_audit", mock.AsyncMock()),
+            self.assertRaises(HTTPException),
+        ):
             await self.service.verify_runtime_bridge_token(wrong)
 
     async def test_verify_rejects_stopped_or_mismatched_session(self) -> None:
@@ -58,10 +62,22 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
         stopped.state = "stopped"
         stopped.workspaceId = "ws-1"
         stopped.leasedByUserId = "user-1"
-        with mock.patch.object(
-            self.service,
-            "_get_runtime_session_record",
-            mock.AsyncMock(return_value=stopped),
+        current = mock.Mock()
+        current.id = "sess-1"
+        current.state = "running"
+        current.workspaceId = "ws-1"
+        with (
+            mock.patch.object(
+                self.service,
+                "_get_runtime_session_record",
+                mock.AsyncMock(return_value=stopped),
+            ),
+            mock.patch.object(
+                self.service,
+                "_get_active_session_row",
+                mock.AsyncMock(return_value=current),
+            ),
+            mock.patch.object(self.service, "_audit", mock.AsyncMock()),
         ):
             with self.assertRaises(HTTPException):
                 await self.service.verify_runtime_bridge_token(token)
@@ -70,18 +86,34 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
         other.state = "running"
         other.workspaceId = "ws-2"
         other.leasedByUserId = "user-1"
-        with mock.patch.object(
-            self.service,
-            "_get_runtime_session_record",
-            mock.AsyncMock(return_value=other),
+        with (
+            mock.patch.object(
+                self.service,
+                "_get_runtime_session_record",
+                mock.AsyncMock(return_value=other),
+            ),
+            mock.patch.object(
+                self.service,
+                "_get_active_session_row",
+                mock.AsyncMock(return_value=current),
+            ),
+            mock.patch.object(self.service, "_audit", mock.AsyncMock()),
         ):
             with self.assertRaises(HTTPException):
                 await self.service.verify_runtime_bridge_token(token)
 
-        with mock.patch.object(
-            self.service,
-            "_get_runtime_session_record",
-            mock.AsyncMock(return_value=None),
+        with (
+            mock.patch.object(
+                self.service,
+                "_get_runtime_session_record",
+                mock.AsyncMock(return_value=None),
+            ),
+            mock.patch.object(
+                self.service,
+                "_get_active_session_row",
+                mock.AsyncMock(return_value=current),
+            ),
+            mock.patch.object(self.service, "_audit", mock.AsyncMock()),
         ):
             with self.assertRaises(HTTPException):
                 await self.service.verify_runtime_bridge_token(token)
@@ -92,10 +124,18 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
         active.state = "running"
         active.workspaceId = "ws-1"
         active.leasedByUserId = "   "
-        with mock.patch.object(
-            self.service,
-            "_get_runtime_session_record",
-            mock.AsyncMock(return_value=active),
+        active.id = "sess-1"
+        with (
+            mock.patch.object(
+                self.service,
+                "_get_runtime_session_record",
+                mock.AsyncMock(return_value=active),
+            ),
+            mock.patch.object(
+                self.service,
+                "_get_active_session_row",
+                mock.AsyncMock(return_value=active),
+            ),
         ):
             with self.assertRaises(HTTPException) as ctx:
                 await self.service.verify_runtime_bridge_token(token)
@@ -104,15 +144,128 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
     async def test_verify_accepts_active_session(self) -> None:
         token = self.service.build_runtime_bridge_token("ws-1", "sess-1")
         active = mock.Mock()
+        active.id = "sess-1"
         active.state = "running"
         active.workspaceId = "ws-1"
         active.leasedByUserId = "user-7"
-        with mock.patch.object(
-            self.service,
-            "_get_runtime_session_record",
-            mock.AsyncMock(return_value=active),
+        with (
+            mock.patch.object(
+                self.service,
+                "_get_runtime_session_record",
+                mock.AsyncMock(return_value=active),
+            ),
+            mock.patch.object(
+                self.service,
+                "_get_active_session_row",
+                mock.AsyncMock(return_value=active),
+            ),
         ):
             claims = await self.service.verify_runtime_bridge_token(token)
         self.assertEqual(claims["workspace_id"], "ws-1")
         self.assertEqual(claims["session_id"], "sess-1")
         self.assertEqual(claims["leased_by_user_id"], "user-7")
+
+    async def test_verify_rejects_mismatched_current_session_and_audits_sanitized_failure(self) -> None:
+        token = self.service.build_runtime_bridge_token("ws-1", "sess-stale")
+        stale = mock.Mock()
+        stale.id = "sess-stale"
+        stale.state = "running"
+        stale.workspaceId = "ws-1"
+        stale.leasedByUserId = "user-1"
+        current = mock.Mock()
+        current.id = "sess-current"
+        current.state = "running"
+        current.workspaceId = "ws-1"
+
+        with (
+            mock.patch.object(
+                self.service,
+                "_get_runtime_session_record",
+                mock.AsyncMock(return_value=stale),
+            ),
+            mock.patch.object(
+                self.service,
+                "_get_active_session_row",
+                mock.AsyncMock(return_value=current),
+            ),
+            mock.patch.object(self.service, "_audit", mock.AsyncMock()) as audit,
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await self.service.verify_runtime_bridge_token(token)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertEqual(ctx.exception.detail, "Runtime bridge session mismatch")
+        audit.assert_awaited_once()
+        payload = audit.await_args.kwargs["payload"]
+        self.assertEqual(payload["reason"], "session_mismatch")
+        self.assertEqual(payload["workspace_id"], "ws-1")
+        self.assertEqual(payload["token_session_id"], "sess-stale")
+        self.assertEqual(payload["current_session_id"], "sess-current")
+        self.assertNotIn(token, str(payload))
+
+    async def test_verify_logs_but_does_not_audit_expired_token(self) -> None:
+        expired = jwt.encode(
+            {
+                "kind": _RUNTIME_BRIDGE_TOKEN_KIND,
+                "workspace_id": "ws-1",
+                "session_id": "sess-1",
+                "iat": int(time.time()) - 120,
+                "exp": int(time.time()) - 60,
+            },
+            settings.encryption_key,
+            algorithm=settings.jwt_algorithm,
+        )
+        with (
+            mock.patch.object(self.service, "_audit", mock.AsyncMock()) as audit,
+            mock.patch("ragtime.userspace.runtime_service.logger.warning") as log_warning,
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await self.service.verify_runtime_bridge_token(expired)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+        audit.assert_not_awaited()
+        log_warning.assert_called_once()
+        self.assertNotIn(expired, str(log_warning.call_args))
+
+    async def test_runtime_bridge_auth_failure_audit_deduplicates_repeated_failures(self) -> None:
+        claims = {"workspace_id": "ws-1", "session_id": "sess-1"}
+        with (
+            mock.patch.object(self.service, "_audit", mock.AsyncMock()) as audit,
+            mock.patch("ragtime.userspace.runtime_service.logger.warning") as log_warning,
+        ):
+            await self.service._log_runtime_bridge_auth_failure(
+                reason="session_mismatch",
+                claims=claims,
+                current_session_id="sess-current",
+            )
+            await self.service._log_runtime_bridge_auth_failure(
+                reason="session_mismatch",
+                claims=claims,
+                current_session_id="sess-current",
+            )
+
+        audit.assert_awaited_once()
+        self.assertEqual(log_warning.call_count, 2)
+        self.assertNotIn("Bearer", str(log_warning.call_args_list))
+        self.assertNotIn(".", next(iter(self.service._runtime_bridge_auth_failure_audit_dedupe.keys())))
+
+    async def test_runtime_bridge_auth_failure_audit_deduplicates_concurrent_failures(self) -> None:
+        claims = {"workspace_id": "ws-1", "session_id": "sess-1"}
+        audit = mock.AsyncMock()
+
+        with (
+            mock.patch.object(self.service, "_audit", audit),
+            mock.patch("ragtime.userspace.runtime_service.logger.warning"),
+        ):
+            await asyncio.gather(
+                *[
+                    self.service._log_runtime_bridge_auth_failure(
+                        reason="session_mismatch",
+                        claims=claims,
+                        current_session_id="sess-current",
+                    )
+                    for _ in range(5)
+                ]
+            )
+
+        audit.assert_awaited_once()


### PR DESCRIPTION
## Summary
- refresh reused runtime provider sessions with newly minted workspace environment and bridge credentials
- expose non-secret bridge credential health, bounded auth-failure diagnostics, and an editor-only refresh API
- add workspace bridge status and self-service recovery controls with permission and interaction coverage

## Verification
- 152 focused Python runtime and bridge tests
- 31 focused frontend tests
- Ruff and Pyright (0 errors; environment import warnings only)
- frontend typecheck, production build, ESLint, and Prettier
- `git diff --check`

## Residual risks
- bridge tokens still have a four-hour TTL and require manual refresh after expiry; automatic renewal remains follow-up work
- bridge health uses unsigned payload metadata for diagnostics only; authorization continues to verify the signed token
- last-success lookup intentionally scans a bounded recent audit window and returns no timestamp rather than a false success when none is found