### PR TITLE
feat: add grant-driven cross-workspace SQLite

### DIFF
--- a/prisma/migrations/20260805000000_add_workspace_sqlite_grant_mode/migration.sql
+++ b/prisma/migrations/20260805000000_add_workspace_sqlite_grant_mode/migration.sql
@@ -1,0 +1,24 @@
+-- CreateEnum
+DO $$
+BEGIN
+  CREATE TYPE "workspace_sqlite_grant_mode" AS ENUM ('none', 'read', 'read_write');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+-- AddColumn
+ALTER TABLE "workspace_agent_grants"
+ADD COLUMN IF NOT EXISTS "sqlite_access_mode" "workspace_sqlite_grant_mode";
+
+-- Backfill legacy rows
+UPDATE "workspace_agent_grants"
+SET "sqlite_access_mode" = 'none'
+WHERE "sqlite_access_mode" IS NULL;
+
+-- Enforce default + non-null
+ALTER TABLE "workspace_agent_grants"
+ALTER COLUMN "sqlite_access_mode" SET DEFAULT 'none';
+
+ALTER TABLE "workspace_agent_grants"
+ALTER COLUMN "sqlite_access_mode" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1747,6 +1747,14 @@ enum WorkspaceAgentGrantMode {
   @@map("workspace_agent_grant_mode")
 }
 
+enum WorkspaceSqliteGrantMode {
+  none
+  read
+  read_write
+
+  @@map("workspace_sqlite_grant_mode")
+}
+
 /// Grant from a source workspace's agent to access another (target) workspace's
 /// runtime files. The grant is owned/managed by the target workspace owner.
 model WorkspaceAgentGrant {
@@ -1754,6 +1762,7 @@ model WorkspaceAgentGrant {
   sourceWorkspaceId String                  @map("source_workspace_id")
   targetWorkspaceId String                  @map("target_workspace_id")
   accessMode        WorkspaceAgentGrantMode @default(read) @map("access_mode")
+  sqliteAccessMode  WorkspaceSqliteGrantMode @default(none) @map("sqlite_access_mode")
   grantedByUserId   String                  @map("granted_by_user_id")
   expiresAt         DateTime?               @map("expires_at")
   createdAt         DateTime                @default(now()) @map("created_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,12 +98,12 @@ model IndexJob {
   gitToken   String? @map("git_token") // Token for private repo access (kept in DB for job recovery)
 
   // Progress tracking
-  totalFiles      Int     @default(0) @map("total_files")
-  processedFiles  Int     @default(0) @map("processed_files")
-  totalChunks     Int     @default(0) @map("total_chunks")
-  processedChunks Int     @default(0) @map("processed_chunks")
+  totalFiles      Int           @default(0) @map("total_files")
+  processedFiles  Int           @default(0) @map("processed_files")
+  totalChunks     Int           @default(0) @map("total_chunks")
+  processedChunks Int           @default(0) @map("processed_chunks")
   phase           IndexJobPhase @default(preparing)
-  errorMessage    String? @map("error_message")
+  errorMessage    String?       @map("error_message")
 
   // Timestamps
   createdAt   DateTime  @default(now()) @map("created_at")
@@ -140,13 +140,13 @@ model IndexMetadata {
   loadTimeSeconds    Float?  @map("load_time_seconds") // Time to load this index
 
   // Source info
-  sourceType String  @map("source_type")
-  source     String?
-  gitBranch  String? @map("git_branch") // Branch for git sources
-  gitToken   String? @map("git_token") // Token for private repo access (stored for re-indexing)
-  webhookId  String? @unique @map("webhook_id")
-  webhookSecret String? @map("webhook_secret")
-  webhookPaused Boolean @default(false) @map("webhook_paused")
+  sourceType       String    @map("source_type")
+  source           String?
+  gitBranch        String?   @map("git_branch") // Branch for git sources
+  gitToken         String?   @map("git_token") // Token for private repo access (stored for re-indexing)
+  webhookId        String?   @unique @map("webhook_id")
+  webhookSecret    String?   @map("webhook_secret")
+  webhookPaused    Boolean   @default(false) @map("webhook_paused")
   webhookCreatedAt DateTime? @map("webhook_created_at")
 
   // OCR settings (per-index)
@@ -158,8 +158,8 @@ model IndexMetadata {
   configSnapshot Json? @map("config_snapshot")
 
   // Timestamps
-  createdAt    DateTime              @default(now()) @map("created_at")
-  lastModified DateTime              @default(now()) @map("last_modified")
+  createdAt         DateTime             @default(now()) @map("created_at")
+  lastModified      DateTime             @default(now()) @map("last_modified")
   webhookDeliveries GitWebhookDelivery[]
 
   @@map("index_metadata")
@@ -231,49 +231,49 @@ model AppSettings {
   omlxApiKey          String? @map("omlx_api_key")
 
   // LLM Configuration (for chat/RAG responses)
-  llmProvider                    String    @default("openai") @map("llm_provider") // "openai", "anthropic", "openrouter", "ollama", "llama_cpp", "lmstudio", "omlx", "github_copilot", or "github_models"
-  llmModel                       String    @default("gpt-4-turbo") @map("llm_model")
-  llmMaxTokens                   Int       @default(4096) @map("llm_max_tokens") // Max output tokens
-  chatCompactionThresholdPercent Int       @default(80) @map("chat_compaction_threshold_percent") // Show the chat compact button once conversation context reaches this percentage
-  chatAutoCompactionThresholdPercent Int   @default(99) @map("chat_auto_compaction_threshold_percent") // Automatically compact once conversation context reaches this percentage; 100 disables auto-compaction
-  imagePayloadMaxWidth           Int       @default(1024) @map("image_payload_max_width") // Max width (px) for image attachments
-  imagePayloadMaxHeight          Int       @default(1024) @map("image_payload_max_height") // Max height (px) for image attachments
-  imagePayloadMaxPixels          Int       @default(786432) @map("image_payload_max_pixels") // Max total pixels for image attachments
-  imagePayloadMaxBytes           Int       @default(350000) @map("image_payload_max_bytes") // Max compressed bytes for image attachments
-  llmOllamaProtocol              String    @default("http") @map("llm_ollama_protocol")
-  llmOllamaHost                  String    @default("localhost") @map("llm_ollama_host")
-  llmOllamaPort                  Int       @default(11434) @map("llm_ollama_port")
-  llmOllamaBaseUrl               String    @default("http://localhost:11434") @map("llm_ollama_base_url")
-  llmLlamaCppProtocol            String    @default("http") @map("llm_llama_cpp_protocol")
-  llmLlamaCppHost                String    @default("host.docker.internal") @map("llm_llama_cpp_host")
-  llmLlamaCppPort                Int       @default(8080) @map("llm_llama_cpp_port")
-  llmLlamaCppBaseUrl             String    @default("http://host.docker.internal:8080") @map("llm_llama_cpp_base_url")
-  llmLmstudioProtocol            String    @default("http") @map("llm_lmstudio_protocol")
-  llmLmstudioHost                String    @default("host.docker.internal") @map("llm_lmstudio_host")
-  llmLmstudioPort                Int       @default(1234) @map("llm_lmstudio_port")
-  llmLmstudioBaseUrl             String    @default("http://host.docker.internal:1234") @map("llm_lmstudio_base_url")
-  llmOmlxProtocol                String    @default("http") @map("llm_omlx_protocol")
-  llmOmlxHost                    String    @default("host.docker.internal") @map("llm_omlx_host")
-  llmOmlxPort                    Int       @default(8000) @map("llm_omlx_port")
-  llmOmlxBaseUrl                 String    @default("http://host.docker.internal:8000") @map("llm_omlx_base_url")
-  openaiApiKey                   String    @default("") @map("openai_api_key")
-  anthropicApiKey                String    @default("") @map("anthropic_api_key")
-  openrouterApiKey               String    @default("") @map("openrouter_api_key")
-  githubModelsApiToken           String    @default("") @map("github_models_api_token")
-  githubCopilotAccessToken       String    @default("") @map("github_copilot_access_token")
-  githubCopilotRefreshToken      String    @default("") @map("github_copilot_refresh_token")
-  githubCopilotOauthRefreshToken String    @default("") @map("github_copilot_oauth_refresh_token") // ghr_* token for refreshing expired ghu_* access tokens
-  githubCopilotTokenExpiresAt    DateTime? @map("github_copilot_token_expires_at")
-  githubCopilotEnterpriseUrl     String?   @map("github_copilot_enterprise_url")
-  githubCopilotBaseUrl           String    @default("https://api.githubcopilot.com") @map("github_copilot_base_url")
-  openaiCodexAccessToken         String    @default("") @map("openai_codex_access_token")
-  openaiCodexRefreshToken        String    @default("") @map("openai_codex_refresh_token")
-  openaiCodexTokenExpiresAt      DateTime? @map("openai_codex_token_expires_at")
-  openaiCodexAccountId           String    @default("") @map("openai_codex_account_id")
-  openaiCodexBaseUrl             String    @default("https://chatgpt.com/backend-api/codex") @map("openai_codex_base_url")
-  includeCopilotThirdPartyModels Boolean   @default(false) @map("include_copilot_third_party_models")
-  allowedChatModels              String[]  @default([]) @map("allowed_chat_models") // Empty = all models allowed
-  defaultChatModel               String?   @map("default_chat_model") // Optional manual override for chat default model selection
+  llmProvider                        String    @default("openai") @map("llm_provider") // "openai", "anthropic", "openrouter", "ollama", "llama_cpp", "lmstudio", "omlx", "github_copilot", or "github_models"
+  llmModel                           String    @default("gpt-4-turbo") @map("llm_model")
+  llmMaxTokens                       Int       @default(4096) @map("llm_max_tokens") // Max output tokens
+  chatCompactionThresholdPercent     Int       @default(80) @map("chat_compaction_threshold_percent") // Show the chat compact button once conversation context reaches this percentage
+  chatAutoCompactionThresholdPercent Int       @default(99) @map("chat_auto_compaction_threshold_percent") // Automatically compact once conversation context reaches this percentage; 100 disables auto-compaction
+  imagePayloadMaxWidth               Int       @default(1024) @map("image_payload_max_width") // Max width (px) for image attachments
+  imagePayloadMaxHeight              Int       @default(1024) @map("image_payload_max_height") // Max height (px) for image attachments
+  imagePayloadMaxPixels              Int       @default(786432) @map("image_payload_max_pixels") // Max total pixels for image attachments
+  imagePayloadMaxBytes               Int       @default(350000) @map("image_payload_max_bytes") // Max compressed bytes for image attachments
+  llmOllamaProtocol                  String    @default("http") @map("llm_ollama_protocol")
+  llmOllamaHost                      String    @default("localhost") @map("llm_ollama_host")
+  llmOllamaPort                      Int       @default(11434) @map("llm_ollama_port")
+  llmOllamaBaseUrl                   String    @default("http://localhost:11434") @map("llm_ollama_base_url")
+  llmLlamaCppProtocol                String    @default("http") @map("llm_llama_cpp_protocol")
+  llmLlamaCppHost                    String    @default("host.docker.internal") @map("llm_llama_cpp_host")
+  llmLlamaCppPort                    Int       @default(8080) @map("llm_llama_cpp_port")
+  llmLlamaCppBaseUrl                 String    @default("http://host.docker.internal:8080") @map("llm_llama_cpp_base_url")
+  llmLmstudioProtocol                String    @default("http") @map("llm_lmstudio_protocol")
+  llmLmstudioHost                    String    @default("host.docker.internal") @map("llm_lmstudio_host")
+  llmLmstudioPort                    Int       @default(1234) @map("llm_lmstudio_port")
+  llmLmstudioBaseUrl                 String    @default("http://host.docker.internal:1234") @map("llm_lmstudio_base_url")
+  llmOmlxProtocol                    String    @default("http") @map("llm_omlx_protocol")
+  llmOmlxHost                        String    @default("host.docker.internal") @map("llm_omlx_host")
+  llmOmlxPort                        Int       @default(8000) @map("llm_omlx_port")
+  llmOmlxBaseUrl                     String    @default("http://host.docker.internal:8000") @map("llm_omlx_base_url")
+  openaiApiKey                       String    @default("") @map("openai_api_key")
+  anthropicApiKey                    String    @default("") @map("anthropic_api_key")
+  openrouterApiKey                   String    @default("") @map("openrouter_api_key")
+  githubModelsApiToken               String    @default("") @map("github_models_api_token")
+  githubCopilotAccessToken           String    @default("") @map("github_copilot_access_token")
+  githubCopilotRefreshToken          String    @default("") @map("github_copilot_refresh_token")
+  githubCopilotOauthRefreshToken     String    @default("") @map("github_copilot_oauth_refresh_token") // ghr_* token for refreshing expired ghu_* access tokens
+  githubCopilotTokenExpiresAt        DateTime? @map("github_copilot_token_expires_at")
+  githubCopilotEnterpriseUrl         String?   @map("github_copilot_enterprise_url")
+  githubCopilotBaseUrl               String    @default("https://api.githubcopilot.com") @map("github_copilot_base_url")
+  openaiCodexAccessToken             String    @default("") @map("openai_codex_access_token")
+  openaiCodexRefreshToken            String    @default("") @map("openai_codex_refresh_token")
+  openaiCodexTokenExpiresAt          DateTime? @map("openai_codex_token_expires_at")
+  openaiCodexAccountId               String    @default("") @map("openai_codex_account_id")
+  openaiCodexBaseUrl                 String    @default("https://chatgpt.com/backend-api/codex") @map("openai_codex_base_url")
+  includeCopilotThirdPartyModels     Boolean   @default(false) @map("include_copilot_third_party_models")
+  allowedChatModels                  String[]  @default([]) @map("allowed_chat_models") // Empty = all models allowed
+  defaultChatModel                   String?   @map("default_chat_model") // Optional manual override for chat default model selection
 
   // OpenAPI-compatible endpoint model configuration
   allowedOpenapiModels  String[] @default([]) @map("allowed_openapi_models") // Models exposed via /v1/models; empty = use chat models
@@ -302,13 +302,13 @@ model AppSettings {
   scratchpadWindowSize Int @default(6) @map("scratchpad_window_size") // Keep last N tool calls in full detail; older ones are summarized (0=keep all)
 
   // Search Configuration
-  searchResultsK              Int                        @default(5) @map("search_results_k") // Number of results per vector search (k)
-  aggregateSearch             Boolean                    @default(true) @map("aggregate_search") // If true, use single search_knowledge; if false, create per-index tools
-  searchUseMmr                Boolean                    @default(false) @map("search_use_mmr") // Use Max Marginal Relevance for result diversification
-  searchMmrLambda             Float                      @default(0.5) @map("search_mmr_lambda") // MMR diversity/relevance tradeoff (0=max diversity, 1=max relevance)
-  contextTokenBudget          Int                        @default(4000) @map("context_token_budget") // Max tokens for retrieved context (0=unlimited)
-  chunkingUseTokens           Boolean                    @default(true) @map("chunking_use_tokens") // Use token-based chunking instead of character-based
-  faissSearchConcurrencyMode  FaissSearchConcurrencyMode @default(per_index) @map("faiss_search_concurrency_mode")
+  searchResultsK             Int                        @default(5) @map("search_results_k") // Number of results per vector search (k)
+  aggregateSearch            Boolean                    @default(true) @map("aggregate_search") // If true, use single search_knowledge; if false, create per-index tools
+  searchUseMmr               Boolean                    @default(false) @map("search_use_mmr") // Use Max Marginal Relevance for result diversification
+  searchMmrLambda            Float                      @default(0.5) @map("search_mmr_lambda") // MMR diversity/relevance tradeoff (0=max diversity, 1=max relevance)
+  contextTokenBudget         Int                        @default(4000) @map("context_token_budget") // Max tokens for retrieved context (0=unlimited)
+  chunkingUseTokens          Boolean                    @default(true) @map("chunking_use_tokens") // Use token-based chunking instead of character-based
+  faissSearchConcurrencyMode FaissSearchConcurrencyMode @default(per_index) @map("faiss_search_concurrency_mode")
 
   // pgvector Index Configuration
   ivfflatLists Int @default(100) @map("ivfflat_lists") // IVFFlat index lists parameter (higher=slower build, faster query)
@@ -356,28 +356,28 @@ model AppSettings {
   ollamaEmbeddingTimeoutSeconds Int @default(180) @map("ollama_embedding_timeout_seconds") // Per sub-batch timeout (seconds) for embedding calls across providers
 
   // User Space Configuration
-  snapshotRetentionDays                 Int      @default(0) @map("snapshot_retention_days") // Snapshot retention in days (0 = unlimited)
-  snapshotStaleBranchThreshold          Int      @default(50) @map("snapshot_stale_branch_threshold") // Hide branches whose head is >= N commits behind the active head (0 = show all, 10-500)
-  userspacePreviewSandboxFlags          String[] @default(["allow-scripts", "allow-same-origin", "allow-forms", "allow-popups", "allow-popups-to-escape-sandbox", "allow-modals", "allow-downloads"]) @map("userspace_preview_sandbox_flags") // Allowed iframe sandbox flags for User Space previews
-  userspaceDuplicateCopyFilesDefault    Boolean  @default(true) @map("userspace_duplicate_copy_files_default")
-  userspaceDuplicateCopyMetadataDefault Boolean  @default(true) @map("userspace_duplicate_copy_metadata_default")
-  userspaceDuplicateCopyChatsDefault    Boolean  @default(false) @map("userspace_duplicate_copy_chats_default")
-  userspaceDuplicateCopyMountsDefault   Boolean  @default(false) @map("userspace_duplicate_copy_mounts_default")
-  userspaceMountSyncIntervalSeconds     Int      @default(30) @map("userspace_mount_sync_interval_seconds")
-  userspaceMountSyncStartMinute         Int?     @map("userspace_mount_sync_start_minute")
-  userspaceMountSyncTimezone            String?  @map("userspace_mount_sync_timezone")
-  userspaceSqliteImportMaxBytes         BigInt   @default(104857600) @map("userspace_sqlite_import_max_bytes")
-  userspacePrimitiveUploadMaxBytes      Int      @default(104857600) @map("userspace_primitive_upload_max_bytes")
-  userspacePrimitiveArchiveMaxEntries   Int      @default(500) @map("userspace_primitive_archive_max_entries")
-  userspaceCodeIndexEnabled                Boolean  @default(true) @map("userspace_code_index_enabled")
-  userspaceCodeIndexDebounceSeconds        Int      @default(2) @map("userspace_code_index_debounce_seconds")
-  userspaceCodeIndexReconcileIntervalSeconds Int    @default(300) @map("userspace_code_index_reconcile_interval_seconds")
-  userspaceCodeIndexMaxAttempts            Int      @default(3) @map("userspace_code_index_max_attempts")
-  userspaceCodeIndexMaxConcurrency         Int      @default(1) @map("userspace_code_index_max_concurrency")
+  snapshotRetentionDays                      Int      @default(0) @map("snapshot_retention_days") // Snapshot retention in days (0 = unlimited)
+  snapshotStaleBranchThreshold               Int      @default(50) @map("snapshot_stale_branch_threshold") // Hide branches whose head is >= N commits behind the active head (0 = show all, 10-500)
+  userspacePreviewSandboxFlags               String[] @default(["allow-scripts", "allow-same-origin", "allow-forms", "allow-popups", "allow-popups-to-escape-sandbox", "allow-modals", "allow-downloads"]) @map("userspace_preview_sandbox_flags") // Allowed iframe sandbox flags for User Space previews
+  userspaceDuplicateCopyFilesDefault         Boolean  @default(true) @map("userspace_duplicate_copy_files_default")
+  userspaceDuplicateCopyMetadataDefault      Boolean  @default(true) @map("userspace_duplicate_copy_metadata_default")
+  userspaceDuplicateCopyChatsDefault         Boolean  @default(false) @map("userspace_duplicate_copy_chats_default")
+  userspaceDuplicateCopyMountsDefault        Boolean  @default(false) @map("userspace_duplicate_copy_mounts_default")
+  userspaceMountSyncIntervalSeconds          Int      @default(30) @map("userspace_mount_sync_interval_seconds")
+  userspaceMountSyncStartMinute              Int?     @map("userspace_mount_sync_start_minute")
+  userspaceMountSyncTimezone                 String?  @map("userspace_mount_sync_timezone")
+  userspaceSqliteImportMaxBytes              BigInt   @default(104857600) @map("userspace_sqlite_import_max_bytes")
+  userspacePrimitiveUploadMaxBytes           Int      @default(104857600) @map("userspace_primitive_upload_max_bytes")
+  userspacePrimitiveArchiveMaxEntries        Int      @default(500) @map("userspace_primitive_archive_max_entries")
+  userspaceCodeIndexEnabled                  Boolean  @default(true) @map("userspace_code_index_enabled")
+  userspaceCodeIndexDebounceSeconds          Int      @default(2) @map("userspace_code_index_debounce_seconds")
+  userspaceCodeIndexReconcileIntervalSeconds Int      @default(300) @map("userspace_code_index_reconcile_interval_seconds")
+  userspaceCodeIndexMaxAttempts              Int      @default(3) @map("userspace_code_index_max_attempts")
+  userspaceCodeIndexMaxConcurrency           Int      @default(1) @map("userspace_code_index_max_concurrency")
 
   // Index Archive Extraction Limits
-  archiveMaxTotalSizeBytes             BigInt   @default(5368709120) @map("archive_max_total_size_bytes") // 5 GB max extracted archive size
-  archiveMaxFileCount                  Int      @default(100000) @map("archive_max_file_count")
+  archiveMaxTotalSizeBytes BigInt @default(5368709120) @map("archive_max_total_size_bytes") // 5 GB max extracted archive size
+  archiveMaxFileCount      Int    @default(100000) @map("archive_max_file_count")
 
   // Timestamps
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
@@ -546,8 +546,8 @@ model ToolConfig {
   mcpDefaultRouteFilterTools McpDefaultRouteFilterToolSelection[]
 
   // Relation to conversation tool selections and options
-  conversationSelections ConversationToolSelection[]
-  conversationToolOptions  ConversationToolOption[]
+  conversationSelections  ConversationToolSelection[]
+  conversationToolOptions ConversationToolOption[]
 
   // Relation to userspace mount sources backed by this tool
   mountSources UserspaceMountSource[]
@@ -565,7 +565,7 @@ model ToolAccessPolicy {
   createdAt              DateTime        @default(now()) @map("created_at")
   updatedAt              DateTime        @default(now()) @updatedAt @map("updated_at")
 
-  toolConfig  ToolConfig             @relation(fields: [toolConfigId], references: [id], onDelete: Cascade)
+  toolConfig  ToolConfig            @relation(fields: [toolConfigId], references: [id], onDelete: Cascade)
   userAccess  ToolUserAccess[]
   groupAccess ToolAuthGroupAccess[]
 
@@ -993,23 +993,23 @@ enum WorkspaceScmAutoSyncPolicy {
 
 /// User account (synced from LDAP or local admin)
 model User {
-  id              String        @id @default(uuid())
-  username        String        @unique // For LDAP: samAccountName/uid, for local: prefixed with "local:"
-  authProvider    AuthProvider  @default(ldap) @map("auth_provider")
-  ldapDn          String?       @map("ldap_dn") // LDAP distinguished name (null for local users)
-  sourceProvider  AuthProvider? @map("source_provider") // Original upstream provider for cached/synced identities
-  sourceId        String?       @map("source_id") // Provider-specific immutable identifier when available
-  passwordHash    String?       @map("password_hash") // PBKDF2 hash for local_managed users only
-  cachedGroups    Json          @default("[]") @map("cached_groups") // Provider-neutral projected group keys/DNs
-  sourceSyncedAt  DateTime?     @map("source_synced_at")
-  sourceExpiresAt DateTime?     @map("source_expires_at")
-  email           String?
-  displayName     String?       @map("display_name")
-  role            UserRole      @default(user)
-  roleManuallySet Boolean       @default(false) @map("role_manually_set") // True when admin manually changed role; cleared on LDAP login
-  themePack       String?       @map("theme_pack") // Per-user app theme pack; null means inherit the global default
-  mfaPreferredMethod String?    @map("mfa_preferred_method") // Preferred 2FA method presented first at login; null means inherit the global default
-  lastLoginAt     DateTime?     @map("last_login_at")
+  id                 String        @id @default(uuid())
+  username           String        @unique // For LDAP: samAccountName/uid, for local: prefixed with "local:"
+  authProvider       AuthProvider  @default(ldap) @map("auth_provider")
+  ldapDn             String?       @map("ldap_dn") // LDAP distinguished name (null for local users)
+  sourceProvider     AuthProvider? @map("source_provider") // Original upstream provider for cached/synced identities
+  sourceId           String?       @map("source_id") // Provider-specific immutable identifier when available
+  passwordHash       String?       @map("password_hash") // PBKDF2 hash for local_managed users only
+  cachedGroups       Json          @default("[]") @map("cached_groups") // Provider-neutral projected group keys/DNs
+  sourceSyncedAt     DateTime?     @map("source_synced_at")
+  sourceExpiresAt    DateTime?     @map("source_expires_at")
+  email              String?
+  displayName        String?       @map("display_name")
+  role               UserRole      @default(user)
+  roleManuallySet    Boolean       @default(false) @map("role_manually_set") // True when admin manually changed role; cleared on LDAP login
+  themePack          String?       @map("theme_pack") // Per-user app theme pack; null means inherit the global default
+  mfaPreferredMethod String?       @map("mfa_preferred_method") // Preferred 2FA method presented first at login; null means inherit the global default
+  lastLoginAt        DateTime?     @map("last_login_at")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
@@ -1049,17 +1049,17 @@ model User {
 
 /// Global auth-provider behavior flags. Kept provider-neutral for future OIDC/SAML sources.
 model AuthProviderConfig {
-  id                     String   @id @default("default")
-  localUsersEnabled      Boolean  @default(true) @map("local_users_enabled")
-  ldapLazySyncEnabled    Boolean  @default(true) @map("ldap_lazy_sync_enabled")
-  manualRoleOverrideWins Boolean  @default(true) @map("manual_role_override_wins")
-  cacheTtlMinutes        Int      @default(240) @map("cache_ttl_minutes")
+  id                     String     @id @default("default")
+  localUsersEnabled      Boolean    @default(true) @map("local_users_enabled")
+  ldapLazySyncEnabled    Boolean    @default(true) @map("ldap_lazy_sync_enabled")
+  manualRoleOverrideWins Boolean    @default(true) @map("manual_role_override_wins")
+  cacheTtlMinutes        Int        @default(240) @map("cache_ttl_minutes")
   totpPolicy             TotpPolicy @default(optional) @map("totp_policy")
-  totpRequiredGroupIds   String[] @default([]) @map("totp_required_group_ids")
-  totpRememberDeviceDays Int      @default(30) @map("totp_remember_device_days")
-  mfaAllowedMethods      String[] @default(["totp"]) @map("mfa_allowed_methods")
-  mfaDefaultMethod       String?  @map("mfa_default_method") // Global default 2FA method presented first at login; null means no forced default
-  updatedAt              DateTime @default(now()) @updatedAt @map("updated_at")
+  totpRequiredGroupIds   String[]   @default([]) @map("totp_required_group_ids")
+  totpRememberDeviceDays Int        @default(30) @map("totp_remember_device_days")
+  mfaAllowedMethods      String[]   @default(["totp"]) @map("mfa_allowed_methods")
+  mfaDefaultMethod       String?    @map("mfa_default_method") // Global default 2FA method presented first at login; null means no forced default
+  updatedAt              DateTime   @default(now()) @updatedAt @map("updated_at")
 
   @@map("auth_provider_config")
 }
@@ -1159,7 +1159,7 @@ model AuthGroup {
   createdAt    DateTime     @default(now()) @map("created_at")
   updatedAt    DateTime     @default(now()) @updatedAt @map("updated_at")
 
-  memberships AuthGroupMembership[]
+  memberships         AuthGroupMembership[]
   toolAuthGroupAccess ToolAuthGroupAccess[]
 
   @@index([provider])
@@ -1207,14 +1207,14 @@ model AuthSyncEvent {
 
 /// User session with JWT token
 model Session {
-  id        String   @id @default(uuid())
-  userId    String   @map("user_id")
-  tokenHash String   @map("token_hash") // Hash of JWT for validation
-  expiresAt DateTime @map("expires_at")
+  id            String    @id @default(uuid())
+  userId        String    @map("user_id")
+  tokenHash     String    @map("token_hash") // Hash of JWT for validation
+  expiresAt     DateTime  @map("expires_at")
   mfaVerifiedAt DateTime? @map("mfa_verified_at")
-  authMethods Json @default("[]") @map("auth_methods")
-  userAgent String?  @map("user_agent")
-  ipAddress String?  @map("ip_address")
+  authMethods   Json      @default("[]") @map("auth_methods")
+  userAgent     String?   @map("user_agent")
+  ipAddress     String?   @map("ip_address")
 
   createdAt DateTime @default(now()) @map("created_at")
 
@@ -1324,8 +1324,8 @@ model Conversation {
   subagentsEnabled Boolean @default(true) @map("subagents_enabled")
 
   // Parent conversation for read-only subagent child conversations.
-  parentConversationId String?        @map("parent_conversation_id")
-  parentConversation   Conversation?  @relation("ConversationSubagents", fields: [parentConversationId], references: [id], onDelete: Cascade)
+  parentConversationId  String?        @map("parent_conversation_id")
+  parentConversation    Conversation?  @relation("ConversationSubagents", fields: [parentConversationId], references: [id], onDelete: Cascade)
   subagentConversations Conversation[] @relation("ConversationSubagents")
 
   // Subagent display metadata.
@@ -1596,22 +1596,22 @@ model WorkspaceCodeIndexState {
 }
 
 model WorkspaceCodeIndexJob {
-  id              String                    @id @default(uuid())
-  workspaceId     String                    @map("workspace_id")
-  indexName       String                    @map("index_name")
+  id              String                      @id @default(uuid())
+  workspaceId     String                      @map("workspace_id")
+  indexName       String                      @map("index_name")
   status          WorkspaceCodeIndexJobStatus @default(pending)
   phase           WorkspaceCodeIndexJobPhase  @default(collecting)
-  totalFiles      Int                       @default(0) @map("total_files")
-  processedFiles  Int                       @default(0) @map("processed_files")
-  totalChunks     Int                       @default(0) @map("total_chunks")
-  processedChunks Int                       @default(0) @map("processed_chunks")
-  currentFile     String?                   @map("current_file")
-  errorMessage    String?                   @map("error_message")
-  waitingForJobId String?                   @map("waiting_for_job_id")
-  cancelRequested Boolean                   @default(false) @map("cancel_requested")
-  createdAt       DateTime                  @default(now()) @map("created_at")
-  startedAt       DateTime?                 @map("started_at")
-  completedAt     DateTime?                 @map("completed_at")
+  totalFiles      Int                         @default(0) @map("total_files")
+  processedFiles  Int                         @default(0) @map("processed_files")
+  totalChunks     Int                         @default(0) @map("total_chunks")
+  processedChunks Int                         @default(0) @map("processed_chunks")
+  currentFile     String?                     @map("current_file")
+  errorMessage    String?                     @map("error_message")
+  waitingForJobId String?                     @map("waiting_for_job_id")
+  cancelRequested Boolean                     @default(false) @map("cancel_requested")
+  createdAt       DateTime                    @default(now()) @map("created_at")
+  startedAt       DateTime?                   @map("started_at")
+  completedAt     DateTime?                   @map("completed_at")
 
   workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
@@ -1758,15 +1758,15 @@ enum WorkspaceSqliteGrantMode {
 /// Grant from a source workspace's agent to access another (target) workspace's
 /// runtime files. The grant is owned/managed by the target workspace owner.
 model WorkspaceAgentGrant {
-  id                String                  @id @default(uuid())
-  sourceWorkspaceId String                  @map("source_workspace_id")
-  targetWorkspaceId String                  @map("target_workspace_id")
-  accessMode        WorkspaceAgentGrantMode @default(read) @map("access_mode")
+  id                String                   @id @default(uuid())
+  sourceWorkspaceId String                   @map("source_workspace_id")
+  targetWorkspaceId String                   @map("target_workspace_id")
+  accessMode        WorkspaceAgentGrantMode  @default(read) @map("access_mode")
   sqliteAccessMode  WorkspaceSqliteGrantMode @default(none) @map("sqlite_access_mode")
-  grantedByUserId   String                  @map("granted_by_user_id")
-  expiresAt         DateTime?               @map("expires_at")
-  createdAt         DateTime                @default(now()) @map("created_at")
-  updatedAt         DateTime                @default(now()) @updatedAt @map("updated_at")
+  grantedByUserId   String                   @map("granted_by_user_id")
+  expiresAt         DateTime?                @map("expires_at")
+  createdAt         DateTime                 @default(now()) @map("created_at")
+  updatedAt         DateTime                 @default(now()) @updatedAt @map("updated_at")
 
   sourceWorkspace Workspace @relation("AgentGrantSource", fields: [sourceWorkspaceId], references: [id], onDelete: Cascade)
   targetWorkspace Workspace @relation("AgentGrantTarget", fields: [targetWorkspaceId], references: [id], onDelete: Cascade)

--- a/ragtime/frontend/src/api/client.test.ts
+++ b/ragtime/frontend/src/api/client.test.ts
@@ -330,3 +330,82 @@ describe('HTTP API OAuth client request shapes', () => {
     );
   });
 });
+
+describe('workspace agent grant client request shapes', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('serializes an explicit sqlite_access_mode when present', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        id: 'grant-1',
+        source_workspace_id: 'ws-source',
+        target_workspace_id: 'ws-target',
+        target_workspace_name: 'Target',
+        access_mode: 'read',
+        sqlite_access_mode: 'read_write',
+        granted_by_user_id: 'user-1',
+        created_at: '2026-08-05T12:00:00Z',
+        updated_at: '2026-08-05T12:00:00Z',
+      }),
+    );
+
+    await api.upsertUserSpaceWorkspaceAgentGrant('ws-source', {
+      target_workspace_id: 'ws-target',
+      access_mode: 'read',
+      sqlite_access_mode: 'read_write',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/indexes/userspace/workspaces/ws-source/agent-grants',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          target_workspace_id: 'ws-target',
+          access_mode: 'read',
+          sqlite_access_mode: 'read_write',
+        }),
+      }),
+    );
+  });
+
+  it('preserves omission when sqlite_access_mode is absent', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        id: 'grant-1',
+        source_workspace_id: 'ws-source',
+        target_workspace_id: 'ws-target',
+        target_workspace_name: 'Target',
+        access_mode: 'read_write',
+        sqlite_access_mode: 'read',
+        granted_by_user_id: 'user-1',
+        created_at: '2026-08-05T12:00:00Z',
+        updated_at: '2026-08-05T12:00:00Z',
+      }),
+    );
+
+    await api.upsertUserSpaceWorkspaceAgentGrant('ws-source', {
+      target_workspace_id: 'ws-target',
+      access_mode: 'read_write',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/indexes/userspace/workspaces/ws-source/agent-grants',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          target_workspace_id: 'ws-target',
+          access_mode: 'read_write',
+        }),
+      }),
+    );
+  });
+});

--- a/ragtime/frontend/src/api/client.test.ts
+++ b/ragtime/frontend/src/api/client.test.ts
@@ -409,3 +409,297 @@ describe('workspace agent grant client request shapes', () => {
     );
   });
 });
+
+describe('workspace sqlite inspector owner routing', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      name: 'initializes a database with owner selection',
+      run: async () => {
+        fetchMock.mockResolvedValueOnce(
+          jsonResponse({
+            workspace_id: 'source-ws',
+            database: {
+              name: 'app.sqlite3',
+              relative_path: '.ragtime/db/app.sqlite3',
+              size_bytes: 0,
+              table_count: 0,
+              last_modified_ms: null,
+              owner_workspace_id: 'target/ws',
+              owner_workspace_name: 'Target',
+              ownership: 'linked',
+              access_mode: 'read_write',
+              persistence_mode: 'exclude',
+              initialized: false,
+            },
+            mode_promoted: false,
+            persistence_mode: 'exclude',
+          }),
+        );
+
+        await api.initializeUserSpaceSqliteDatabase(
+          'source-ws',
+          { database_name: 'app.sqlite3' },
+          'target/ws',
+        );
+      },
+      expectedUrl:
+        '/indexes/userspace/workspaces/source-ws/sqlite/databases?owner_workspace_id=target%2Fws',
+      expectedOptions: expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ database_name: 'app.sqlite3' }),
+      }),
+    },
+    {
+      name: 'imports a database with owner selection',
+      run: async () => {
+        fetchMock.mockResolvedValueOnce(
+          jsonResponse({
+            workspace_id: 'source-ws',
+            database: {
+              name: 'app.sqlite3',
+              relative_path: '.ragtime/db/app.sqlite3',
+              size_bytes: 0,
+              table_count: 0,
+              last_modified_ms: null,
+              owner_workspace_id: 'target/ws',
+              owner_workspace_name: 'Target',
+              ownership: 'linked',
+              access_mode: 'read_write',
+              persistence_mode: 'exclude',
+              initialized: true,
+            },
+            mode_promoted: false,
+          }),
+        );
+
+        await api.importUserSpaceSqliteDatabase(
+          'source-ws',
+          'app.sqlite3',
+          new FormData(),
+          'target/ws',
+        );
+      },
+      expectedUrl:
+        '/indexes/userspace/workspaces/source-ws/sqlite/databases/app.sqlite3/import?owner_workspace_id=target%2Fws',
+      expectedOptions: expect.objectContaining({ method: 'POST', body: expect.any(FormData) }),
+    },
+    {
+      name: 'lists tables with owner selection',
+      run: async () => {
+        fetchMock.mockResolvedValueOnce(
+          jsonResponse({
+            workspace_id: 'source-ws',
+            database: {
+              name: 'app.sqlite3',
+              relative_path: '.ragtime/db/app.sqlite3',
+              size_bytes: 0,
+              table_count: 0,
+              last_modified_ms: null,
+              owner_workspace_id: 'target/ws',
+              owner_workspace_name: 'Target',
+              ownership: 'linked',
+              access_mode: 'read',
+              persistence_mode: 'exclude',
+              initialized: true,
+            },
+            tables: [],
+            persistence_mode: 'exclude',
+            mode_promoted: false,
+          }),
+        );
+
+        await api.listUserSpaceSqliteTables('source-ws', 'app.sqlite3', 'target/ws');
+      },
+      expectedUrl:
+        '/indexes/userspace/workspaces/source-ws/sqlite/databases/app.sqlite3/tables?owner_workspace_id=target%2Fws',
+      expectedOptions: expect.objectContaining({ credentials: 'include' }),
+    },
+    {
+      name: 'imports a table with owner selection',
+      run: async () => {
+        fetchMock.mockResolvedValueOnce(
+          jsonResponse({
+            workspace_id: 'source-ws',
+            database_name: 'app.sqlite3',
+            table: { name: 'items', type: 'table', row_count: 1 },
+            mode_promoted: false,
+          }),
+        );
+
+        await api.importUserSpaceSqliteTable(
+          'source-ws',
+          'app.sqlite3',
+          'items',
+          new FormData(),
+          'target/ws',
+        );
+      },
+      expectedUrl:
+        '/indexes/userspace/workspaces/source-ws/sqlite/databases/app.sqlite3/tables/items/import?owner_workspace_id=target%2Fws',
+      expectedOptions: expect.objectContaining({ method: 'POST', body: expect.any(FormData) }),
+    },
+    {
+      name: 'patches a row with owner selection',
+      run: async () => {
+        fetchMock.mockResolvedValueOnce(
+          jsonResponse({
+            workspace_id: 'source-ws',
+            database_name: 'app.sqlite3',
+            table_name: 'items',
+            row: { id: 1 },
+            mode_promoted: false,
+          }),
+        );
+
+        await api.updateUserSpaceSqliteRow(
+          'source-ws',
+          'app.sqlite3',
+          'items',
+          { row_key: { id: 1 }, values: { name: 'updated' } },
+          'target/ws',
+        );
+      },
+      expectedUrl:
+        '/indexes/userspace/workspaces/source-ws/sqlite/databases/app.sqlite3/tables/items/rows?owner_workspace_id=target%2Fws',
+      expectedOptions: expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ row_key: { id: 1 }, values: { name: 'updated' } }),
+      }),
+    },
+    {
+      name: 'deletes a row with owner selection',
+      run: async () => {
+        fetchMock.mockResolvedValueOnce(
+          jsonResponse({
+            workspace_id: 'source-ws',
+            database_name: 'app.sqlite3',
+            table_name: 'items',
+            deleted: true,
+            mode_promoted: false,
+          }),
+        );
+
+        await api.deleteUserSpaceSqliteRow(
+          'source-ws',
+          'app.sqlite3',
+          'items',
+          { row_key: { id: 1 } },
+          'target/ws',
+        );
+      },
+      expectedUrl:
+        '/indexes/userspace/workspaces/source-ws/sqlite/databases/app.sqlite3/tables/items/rows?owner_workspace_id=target%2Fws',
+      expectedOptions: expect.objectContaining({
+        method: 'DELETE',
+        body: JSON.stringify({ row_key: { id: 1 } }),
+      }),
+    },
+    {
+      name: 'queries a database with owner selection',
+      run: async () => {
+        fetchMock.mockResolvedValueOnce(
+          jsonResponse({
+            workspace_id: 'source-ws',
+            database_name: 'app.sqlite3',
+            columns: ['id'],
+            rows: [{ id: 1 }],
+            row_count: 1,
+            truncated: false,
+          }),
+        );
+
+        await api.queryUserSpaceSqliteDatabase(
+          'source-ws',
+          'app.sqlite3',
+          { sql: 'select * from items' },
+          'target/ws',
+        );
+      },
+      expectedUrl:
+        '/indexes/userspace/workspaces/source-ws/sqlite/databases/app.sqlite3/query?owner_workspace_id=target%2Fws',
+      expectedOptions: expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ sql: 'select * from items' }),
+      }),
+    },
+  ])('$name', async ({ run, expectedUrl, expectedOptions }) => {
+    await run();
+
+    expect(fetchMock).toHaveBeenLastCalledWith(expectedUrl, expectedOptions);
+  });
+
+  it('appends owner selection to existing row pagination query parameters', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        workspace_id: 'source-ws',
+        database_name: 'app.sqlite3',
+        table_name: 'items',
+        columns: [],
+        rows: [],
+        total: 0,
+        limit: 25,
+        offset: 10,
+      }),
+    );
+
+    await api.listUserSpaceSqliteRows(
+      'source-ws',
+      'app.sqlite3',
+      'items',
+      {
+        limit: 25,
+        offset: 10,
+        order_by: 'id',
+        order_direction: 'desc',
+      },
+      'target/ws',
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/indexes/userspace/workspaces/source-ws/sqlite/databases/app.sqlite3/tables/items/rows?limit=25&offset=10&order_by=id&order_direction=desc&owner_workspace_id=target%2Fws',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('preserves owned URLs when owner selection is omitted', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        workspace_id: 'source-ws',
+        database: {
+          name: 'app.sqlite3',
+          relative_path: '.ragtime/db/app.sqlite3',
+          size_bytes: 12,
+          table_count: 1,
+          last_modified_ms: 123,
+          owner_workspace_id: 'source-ws',
+          owner_workspace_name: 'Source',
+          ownership: 'owned',
+          access_mode: 'read_write',
+          persistence_mode: 'include',
+          initialized: true,
+        },
+        tables: [],
+        persistence_mode: 'include',
+        mode_promoted: false,
+      }),
+    );
+
+    await api.listUserSpaceSqliteTables('source-ws', 'app.sqlite3');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/indexes/userspace/workspaces/source-ws/sqlite/databases/app.sqlite3/tables',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+});

--- a/ragtime/frontend/src/api/client.ts
+++ b/ragtime/frontend/src/api/client.ts
@@ -481,6 +481,12 @@ async function downloadBlobResponse(
   window.URL.revokeObjectURL(url);
 }
 
+function withSqliteOwner(path: string, ownerWorkspaceId?: string): string {
+  if (!ownerWorkspaceId) return path;
+  const params = new URLSearchParams({ owner_workspace_id: ownerWorkspaceId });
+  return `${path}?${params.toString()}`;
+}
+
 function startNativeDownload(url: string): void {
   const iframe = document.createElement('iframe');
   iframe.hidden = true;
@@ -4227,9 +4233,13 @@ export const api = {
   async initializeUserSpaceSqliteDatabase(
     workspaceId: string,
     request: SqliteInspectorInitializeRequest = {},
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorInitializeResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases`,
+        ownerWorkspaceId,
+      ),
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -4242,17 +4252,28 @@ export const api = {
   async deleteUserSpaceSqliteDatabase(
     workspaceId: string,
     databaseName: string,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorDeleteDatabaseResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}`,
+        ownerWorkspaceId,
+      ),
       { method: 'DELETE' },
     );
     return handleResponse<SqliteInspectorDeleteDatabaseResponse>(response);
   },
 
-  async exportUserSpaceSqliteDatabase(workspaceId: string, databaseName: string): Promise<void> {
+  async exportUserSpaceSqliteDatabase(
+    workspaceId: string,
+    databaseName: string,
+    ownerWorkspaceId?: string,
+  ): Promise<void> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/export`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/export`,
+        ownerWorkspaceId,
+      ),
     );
     await downloadBlobResponse(response, `${databaseName}.sqlite3`, 'Database export failed');
   },
@@ -4261,9 +4282,13 @@ export const api = {
     workspaceId: string,
     databaseName: string,
     formData: FormData,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorImportDatabaseResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/import`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/import`,
+        ownerWorkspaceId,
+      ),
       { method: 'POST', body: formData },
     );
     return handleResponse<SqliteInspectorImportDatabaseResponse>(response);
@@ -4272,9 +4297,13 @@ export const api = {
   async listUserSpaceSqliteTables(
     workspaceId: string,
     databaseName: string,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorTableListResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables`,
+        ownerWorkspaceId,
+      ),
     );
     return handleResponse<SqliteInspectorTableListResponse>(response);
   },
@@ -4283,9 +4312,13 @@ export const api = {
     workspaceId: string,
     databaseName: string,
     request: SqliteInspectorCreateTableRequest,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorCreateTableResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables`,
+        ownerWorkspaceId,
+      ),
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -4299,9 +4332,13 @@ export const api = {
     workspaceId: string,
     databaseName: string,
     tableName: string,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorTableSchemaResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/schema`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/schema`,
+        ownerWorkspaceId,
+      ),
     );
     return handleResponse<SqliteInspectorTableSchemaResponse>(response);
   },
@@ -4311,9 +4348,13 @@ export const api = {
     databaseName: string,
     tableName: string,
     request: SqliteInspectorAlterTableRequest,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorAlterTableResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/schema`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/schema`,
+        ownerWorkspaceId,
+      ),
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -4327,9 +4368,13 @@ export const api = {
     workspaceId: string,
     databaseName: string,
     tableName: string,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorDropTableResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}`,
+        ownerWorkspaceId,
+      ),
       { method: 'DELETE' },
     );
     return handleResponse<SqliteInspectorDropTableResponse>(response);
@@ -4339,9 +4384,13 @@ export const api = {
     workspaceId: string,
     databaseName: string,
     tableName: string,
+    ownerWorkspaceId?: string,
   ): Promise<void> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/export`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/export`,
+        ownerWorkspaceId,
+      ),
     );
     await downloadBlobResponse(response, `${tableName}.csv`, 'Table export failed');
   },
@@ -4351,9 +4400,13 @@ export const api = {
     databaseName: string,
     tableName: string,
     formData: FormData,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorImportTableResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/import`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/import`,
+        ownerWorkspaceId,
+      ),
       { method: 'POST', body: formData },
     );
     return handleResponse<SqliteInspectorImportTableResponse>(response);
@@ -4364,12 +4417,14 @@ export const api = {
     databaseName: string,
     tableName: string,
     params: SqliteInspectorRowListParams = {},
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorRowPage> {
     const search = new URLSearchParams();
     if (params.limit !== undefined) search.set('limit', String(params.limit));
     if (params.offset !== undefined) search.set('offset', String(params.offset));
     if (params.order_by) search.set('order_by', params.order_by);
     if (params.order_direction) search.set('order_direction', params.order_direction);
+    if (ownerWorkspaceId) search.set('owner_workspace_id', ownerWorkspaceId);
     const qs = search.toString();
     const response = await apiFetch(
       `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/rows${qs ? `?${qs}` : ''}`,
@@ -4382,9 +4437,13 @@ export const api = {
     databaseName: string,
     tableName: string,
     request: SqliteInspectorRowMutationRequest,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorRowMutationResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/rows`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/rows`,
+        ownerWorkspaceId,
+      ),
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -4399,9 +4458,13 @@ export const api = {
     databaseName: string,
     tableName: string,
     request: SqliteInspectorRowUpdateRequest,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorRowMutationResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/rows`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/rows`,
+        ownerWorkspaceId,
+      ),
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -4416,9 +4479,13 @@ export const api = {
     databaseName: string,
     tableName: string,
     request: SqliteInspectorRowDeleteRequest,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorRowDeleteResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/rows`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/tables/${encodeURIComponent(tableName)}/rows`,
+        ownerWorkspaceId,
+      ),
       {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
@@ -4432,9 +4499,13 @@ export const api = {
     workspaceId: string,
     databaseName: string,
     request: SqliteInspectorSqlQueryRequest,
+    ownerWorkspaceId?: string,
   ): Promise<SqliteInspectorSqlQueryResponse> {
     const response = await apiFetch(
-      `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/query`,
+      withSqliteOwner(
+        `${API_BASE}/userspace/workspaces/${workspaceId}/sqlite/databases/${encodeURIComponent(databaseName)}/query`,
+        ownerWorkspaceId,
+      ),
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/ragtime/frontend/src/components/SettingsPanel.test.tsx
+++ b/ragtime/frontend/src/components/SettingsPanel.test.tsx
@@ -5,8 +5,19 @@ import type { ChatModelsSettingsSectionProps } from './settings/ChatModelsSettin
 
 const modalRenderSpy = vi.hoisted(() => vi.fn());
 const searchFilterBarSpy = vi.hoisted(() => vi.fn());
+const searchFilterState = vi.hoisted(() => ({ queries: [] as string[] }));
 const toastSuccessSpy = vi.hoisted(() => vi.fn());
 const toastErrorSpy = vi.hoisted(() => vi.fn());
+const toastInfoSpy = vi.hoisted(() => vi.fn());
+const toastClearSpy = vi.hoisted(() => vi.fn());
+const toastDismissSpy = vi.hoisted(() => vi.fn());
+const toastActions = vi.hoisted(() => ({
+  success: toastSuccessSpy,
+  error: toastErrorSpy,
+  info: toastInfoSpy,
+  clear: toastClearSpy,
+  dismiss: toastDismissSpy,
+}));
 const modalState = vi.hoisted(() => ({
   latestAllowedChatModelsProps: null as null | {
     title?: string;
@@ -15,6 +26,8 @@ const modalState = vi.hoisted(() => ({
 }));
 const chatModelsSectionState = vi.hoisted(() => ({
   latestProps: null as null | ChatModelsSettingsSectionProps,
+  openedModal: false,
+  autoOpenModal: true,
 }));
 const serverBackupSectionSpy = vi.hoisted(() => vi.fn());
 const mcpSectionState = vi.hoisted(() => ({
@@ -60,8 +73,11 @@ vi.mock('./settings/ChatModelsSettingsSection', () => ({
     const { openModelFilterModal } = props;
 
     useEffect(() => {
-      void openModelFilterModal();
-    }, [openModelFilterModal]);
+      if (chatModelsSectionState.autoOpenModal && !chatModelsSectionState.openedModal) {
+        chatModelsSectionState.openedModal = true;
+        void openModelFilterModal();
+      }
+    }, []);
 
     return (
       <section data-settings-accordion-section="chat-models">
@@ -106,11 +122,7 @@ vi.mock('./ModelFilterModal', () => ({
 
 vi.mock('./shared/Toast', () => ({
   ToastContainer: () => null,
-  useToast: () =>
-    [
-      [],
-      { success: toastSuccessSpy, error: toastErrorSpy, clear: vi.fn(), dismiss: vi.fn() },
-    ] as const,
+  useToast: () => [[], toastActions] as const,
 }));
 
 vi.mock('./settings/AgentBehaviorSettingsSection', () => ({
@@ -302,7 +314,7 @@ vi.mock('./shared/SearchFilterBar', () => ({
   },
   normalizeSearchFilterText: (value: string) => value,
   searchFilterTextMatchesQuery: () => true,
-  useUrlSearchFilterState: () => ({ queries: [] }),
+  useUrlSearchFilterState: () => searchFilterState,
 }));
 vi.mock('./shared/AuthAdminModals', () => ({ AuthAdminModalHost: () => null }));
 
@@ -344,6 +356,8 @@ beforeEach(() => {
   serverBackupSectionSpy.mockClear();
   modalState.latestAllowedChatModelsProps = null;
   chatModelsSectionState.latestProps = null;
+  chatModelsSectionState.openedModal = false;
+  chatModelsSectionState.autoOpenModal = true;
   mcpSectionState.latestProps = null;
   mcpSectionState.run = null;
   agentBehaviorSectionState.latestProps = null;
@@ -352,6 +366,9 @@ beforeEach(() => {
   sectionRenderOrder.length = 0;
   toastSuccessSpy.mockClear();
   toastErrorSpy.mockClear();
+  toastInfoSpy.mockClear();
+  toastClearSpy.mockClear();
+  toastDismissSpy.mockClear();
 
   apiMock.getSettings.mockResolvedValue(buildSettingsResponse());
   apiMock.getUserSpacePreviewSettings.mockResolvedValue({});
@@ -394,35 +411,38 @@ beforeEach(() => {
   apiMock.listMcpRoutes.mockResolvedValue({ routes: [] });
   apiMock.listCloudOAuthProviders.mockResolvedValue([]);
   apiMock.getLdapConfig.mockResolvedValue({ server_url: '', allow_self_signed: false });
-  apiMock.updateSettings.mockImplementation(async (payload: Record<string, unknown>) => ({
-    id: 'settings-1',
-    server_name: 'Ragtime',
-    default_theme_pack: 'default',
-    authenticated_webgl_background_enabled: true,
-    tool_skills_enabled:
-      typeof payload.tool_skills_enabled === 'boolean' ? payload.tool_skills_enabled : true,
-    max_iterations: typeof payload.max_iterations === 'number' ? payload.max_iterations : 30,
-    max_tool_output_chars:
-      typeof payload.max_tool_output_chars === 'number' ? payload.max_tool_output_chars : 5000,
-    scratchpad_window_size:
-      typeof payload.scratchpad_window_size === 'number' ? payload.scratchpad_window_size : 6,
-    openapi_model_prefix_enabled: true,
-    show_tool_card_footer_actions: false,
-    llm_provider: 'openai',
-    mcp_enabled: true,
-    mcp_default_route_auth: true,
-    mcp_default_route_auth_method: 'oauth2',
-    mcp_default_route_allowed_group: null,
-    mcp_default_route_client_id: '',
-    has_mcp_default_password: payload.mcp_default_route_password !== '',
-    mcp_default_route_password:
-      typeof payload.mcp_default_route_password === 'string'
-        ? payload.mcp_default_route_password
-        : '',
-    faiss_search_concurrency_mode:
-      payload.faiss_search_concurrency_mode === 'global' ? 'global' : 'per_index',
-    updated_at: null,
-  }));
+  apiMock.updateSettings.mockImplementation(async (payload: Record<string, unknown>) => {
+    const current = buildSettingsResponse().settings;
+    return {
+      ...current,
+      ...payload,
+      tool_skills_enabled:
+        typeof payload.tool_skills_enabled === 'boolean'
+          ? payload.tool_skills_enabled
+          : current.tool_skills_enabled,
+      max_iterations:
+        typeof payload.max_iterations === 'number' ? payload.max_iterations : current.max_iterations,
+      max_tool_output_chars:
+        typeof payload.max_tool_output_chars === 'number'
+          ? payload.max_tool_output_chars
+          : current.max_tool_output_chars,
+      scratchpad_window_size:
+        typeof payload.scratchpad_window_size === 'number'
+          ? payload.scratchpad_window_size
+          : current.scratchpad_window_size,
+      mcp_default_route_password:
+        typeof payload.mcp_default_route_password === 'string'
+          ? payload.mcp_default_route_password
+          : current.mcp_default_route_password,
+      has_mcp_default_password:
+        typeof payload.mcp_default_route_password === 'string'
+          ? payload.mcp_default_route_password !== ''
+          : current.has_mcp_default_password,
+      faiss_search_concurrency_mode:
+        payload.faiss_search_concurrency_mode === 'global' ? 'global' : current.faiss_search_concurrency_mode,
+      updated_at: null,
+    };
+  });
 });
 
 afterEach(() => {
@@ -663,9 +683,12 @@ describe('SettingsPanel', () => {
 
     render(<SettingsPanel />);
 
-    await waitFor(() => {
-      expect(apiMock.updateSettings).toHaveBeenCalledTimes(1);
-    });
+    await waitFor(
+      () => {
+        expect(apiMock.updateSettings).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 3000 },
+    );
 
     expect(apiMock.updateSettings.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
@@ -673,7 +696,7 @@ describe('SettingsPanel', () => {
         mcp_default_route_password: 'fallback-pass1',
       }),
     );
-  });
+  }, 10000);
 
   it('retains an existing OAuth2 fallback password when the admin saves without changing it', async () => {
     const { SettingsPanel } = await import('./SettingsPanel');
@@ -687,14 +710,17 @@ describe('SettingsPanel', () => {
 
     render(<SettingsPanel />);
 
-    await waitFor(() => {
-      expect(apiMock.updateSettings).toHaveBeenCalledTimes(1);
-    });
+    await waitFor(
+      () => {
+        expect(apiMock.updateSettings).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 3000 },
+    );
 
     expect(apiMock.updateSettings.mock.calls[0]?.[0]).not.toHaveProperty(
       'mcp_default_route_password',
     );
-  });
+  }, 10000);
 
   it('clears an existing OAuth2 fallback password when the admin removes it and saves', async () => {
     const { SettingsPanel } = await import('./SettingsPanel');
@@ -730,9 +756,12 @@ describe('SettingsPanel', () => {
 
     render(<SettingsPanel />);
 
-    await waitFor(() => {
-      expect(apiMock.updateSettings).toHaveBeenCalledTimes(1);
-    });
+    await waitFor(
+      () => {
+        expect(apiMock.updateSettings).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 3000 },
+    );
 
     expect(apiMock.updateSettings.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
@@ -740,7 +769,7 @@ describe('SettingsPanel', () => {
         mcp_default_route_password: '',
       }),
     );
-  });
+  }, 10000);
 
   it('hydrates and saves the FAISS concurrency mode through the search configuration flow', async () => {
     const { SettingsPanel } = await import('./SettingsPanel');
@@ -777,14 +806,17 @@ describe('SettingsPanel', () => {
 
     render(<SettingsPanel />);
 
-    await waitFor(() => {
-      expect(apiMock.updateSettings).toHaveBeenCalledTimes(1);
-    });
+    await waitFor(
+      () => {
+        expect(apiMock.updateSettings).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 3000 },
+    );
 
     expect(apiMock.updateSettings.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({ faiss_search_concurrency_mode: 'global' }),
     );
-  });
+  }, 10000);
 
   it('shows the updated default MCP route tooltip for OAuth2 routes with a password fallback', async () => {
     apiMock.listMcpRoutes.mockResolvedValue({

--- a/ragtime/frontend/src/components/SettingsPanel.test.tsx
+++ b/ragtime/frontend/src/components/SettingsPanel.test.tsx
@@ -421,7 +421,9 @@ beforeEach(() => {
           ? payload.tool_skills_enabled
           : current.tool_skills_enabled,
       max_iterations:
-        typeof payload.max_iterations === 'number' ? payload.max_iterations : current.max_iterations,
+        typeof payload.max_iterations === 'number'
+          ? payload.max_iterations
+          : current.max_iterations,
       max_tool_output_chars:
         typeof payload.max_tool_output_chars === 'number'
           ? payload.max_tool_output_chars
@@ -439,7 +441,9 @@ beforeEach(() => {
           ? payload.mcp_default_route_password !== ''
           : current.has_mcp_default_password,
       faiss_search_concurrency_mode:
-        payload.faiss_search_concurrency_mode === 'global' ? 'global' : current.faiss_search_concurrency_mode,
+        payload.faiss_search_concurrency_mode === 'global'
+          ? 'global'
+          : current.faiss_search_concurrency_mode,
       updated_at: null,
     };
   });

--- a/ragtime/frontend/src/components/UserSpacePanel.test.tsx
+++ b/ragtime/frontend/src/components/UserSpacePanel.test.tsx
@@ -8,7 +8,14 @@ vi.mock('@uiw/react-codemirror', () => ({
   default: () => <div data-testid="code-editor" />,
 }));
 
-const { previewApiMock } = vi.hoisted(() => ({
+const {
+  previewApiMock,
+  panelToastMock,
+  availableModelsMock,
+  diffHoverTimersMock,
+  workspaceChatSearchMock,
+  workspaceScmActivityMock,
+} = vi.hoisted(() => ({
   previewApiMock: {
     listUserSpaceWorkspaces: vi.fn(),
     getUserSpaceWorkspace: vi.fn(),
@@ -34,14 +41,33 @@ const { previewApiMock } = vi.hoisted(() => ({
     deleteUserSpaceWorkspaceShareLink: vi.fn(),
     subscribeUserSpaceWorkspaceShareLinkAnalytics: vi.fn(),
   },
+  panelToastMock: [[], { error: vi.fn(), success: vi.fn(), info: vi.fn() }],
+  availableModelsMock: {
+    refresh: vi.fn(),
+    awaitReady: vi.fn().mockResolvedValue(undefined),
+  },
+  diffHoverTimersMock: {
+    registerHoverTarget: vi.fn(),
+    clearHoverTarget: vi.fn(),
+    dismiss: vi.fn(),
+  },
+  workspaceChatSearchMock: {
+    query: '',
+    setQuery: vi.fn(),
+    results: [],
+    activeIndex: -1,
+    setActiveIndex: vi.fn(),
+    clear: vi.fn(),
+  },
+  workspaceScmActivityMock: { hasActivity: false, syncState: null },
 }));
+
+let latestSqliteInspectorModalProps: unknown = null;
+let sqliteInspectorModalRender: (props: unknown) => unknown = () => null;
 
 vi.mock('@/api', () => ({ api: previewApiMock, ApiError: class ApiError extends Error {} }));
 vi.mock('@/contexts/AvailableModelsContext', () => ({
-  useAvailableModels: () => ({
-    refresh: vi.fn(),
-    awaitReady: vi.fn().mockResolvedValue(undefined),
-  }),
+  useAvailableModels: () => availableModelsMock,
 }));
 vi.mock('@/utils/codemirrorLanguage', () => ({
   useCodeMirrorLanguageExtension: () => null,
@@ -50,21 +76,10 @@ vi.mock('@/utils/useUserSpaceToolHealthEvents', () => ({
   useUserSpaceToolHealthEvents: () => undefined,
 }));
 vi.mock('@/utils/useDiffHoverTimers', () => ({
-  useDiffHoverTimers: () => ({
-    registerHoverTarget: vi.fn(),
-    clearHoverTarget: vi.fn(),
-    dismiss: vi.fn(),
-  }),
+  useDiffHoverTimers: () => diffHoverTimersMock,
 }));
 vi.mock('@/utils/useWorkspaceChatSearch', () => ({
-  useWorkspaceChatSearch: () => ({
-    query: '',
-    setQuery: vi.fn(),
-    results: [],
-    activeIndex: -1,
-    setActiveIndex: vi.fn(),
-    clear: vi.fn(),
-  }),
+  useWorkspaceChatSearch: () => workspaceChatSearchMock,
 }));
 vi.mock('./ChatPanel', () => ({
   ChatPanel: () => <div data-testid="chat-panel" />,
@@ -76,14 +91,17 @@ vi.mock('./shared/FileDiffOverlay', () => ({
   FileDiffOverlay: () => null,
 }));
 vi.mock('./shared/Toast', () => ({
-  useToast: () => [[], { error: vi.fn(), success: vi.fn(), info: vi.fn() }],
+  useToast: () => panelToastMock,
   ToastContainer: () => null,
 }));
 vi.mock('./shared/UserSpaceEnvVarsModal', () => ({
   UserSpaceEnvVarsModal: () => null,
 }));
 vi.mock('./shared/WorkspaceSqliteInspectorModal', () => ({
-  WorkspaceSqliteInspectorModal: () => null,
+  WorkspaceSqliteInspectorModal: (props: unknown) => {
+    latestSqliteInspectorModalProps = props;
+    return sqliteInspectorModalRender(props);
+  },
 }));
 vi.mock('./shared/WorkspaceObjectStorageExplorer', () => ({
   WorkspaceObjectStorageExplorer: () => null,
@@ -117,8 +135,10 @@ vi.mock('./shared/ShareLinkModal', () => ({
     ) : null,
 }));
 vi.mock('./WorkspaceScmWizard', () => ({
-  useWorkspaceScmWizardActivity: () => ({ hasActivity: false, syncState: null }),
-  WorkspaceScmWizard: () => null,
+  useWorkspaceScmWizardActivity: () => workspaceScmActivityMock,
+  WorkspaceScmWizard: ({ workspace }: { workspace?: { sqlite_persistence_mode?: string } }) => (
+    <div data-testid="workspace-scm-mode">{workspace?.sqlite_persistence_mode ?? 'missing'}</div>
+  ),
 }));
 vi.mock('./shared/AdminWorkspaceModal', () => ({ default: () => null }));
 vi.mock('./shared/AgentAccessButton', () => ({ AgentAccessButton: () => null }));
@@ -232,6 +252,28 @@ const SHARE_LINKS_RESPONSE = {
   ],
 } as const;
 
+const SQLITE_LIST_RESPONSE = {
+  workspace_id: 'ws-1',
+  databases: [
+    {
+      name: 'app.sqlite3',
+      relative_path: '.ragtime/db/app.sqlite3',
+      size_bytes: 1024,
+      table_count: 0,
+      last_modified_ms: 1_786_032_000_000,
+      owner_workspace_id: 'ws-1',
+      owner_workspace_name: 'Workspace One',
+      ownership: 'owned',
+      access_mode: 'read_write',
+      persistence_mode: 'exclude',
+      initialized: true,
+    },
+  ],
+  total_bytes: 1024,
+  default_database_name: 'app.sqlite3',
+  persistence_mode: 'exclude',
+} as const;
+
 function setLayoutCookie(rightPaneCollapsed: boolean): void {
   document.cookie = `userspace_layout_${encodeURIComponent(CURRENT_USER.id)}=${encodeURIComponent(
     JSON.stringify({
@@ -325,7 +367,10 @@ beforeEach(() => {
     users: [],
     read_only: false,
   });
-  previewApiMock.listUserSpaceSqliteDatabases.mockResolvedValue([]);
+  previewApiMock.listUserSpaceSqliteDatabases.mockResolvedValue({
+    ...SQLITE_LIST_RESPONSE,
+    databases: SQLITE_LIST_RESPONSE.databases.map((database) => ({ ...database })),
+  });
   previewApiMock.listUserSpaceAvailableTools.mockResolvedValue([]);
   previewApiMock.listUserSpaceToolGroups.mockResolvedValue([]);
   previewApiMock.listWorkspaceMounts.mockResolvedValue([]);
@@ -376,6 +421,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  latestSqliteInspectorModalProps = null;
+  sqliteInspectorModalRender = () => null;
   cleanup();
 });
 
@@ -533,5 +580,62 @@ describe('UserSpacePanel workspace tool descriptions', () => {
       'share-1',
     );
     expect(previewApiMock.listUserSpaceWorkspaceShareLinks).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats linked databases with tables as activating the SQLite inspector toolbar state', async () => {
+    previewApiMock.listUserSpaceSqliteDatabases.mockResolvedValueOnce({
+      ...SQLITE_LIST_RESPONSE,
+      databases: [
+        { ...SQLITE_LIST_RESPONSE.databases[0], table_count: 0 },
+        {
+          ...SQLITE_LIST_RESPONSE.databases[0],
+          owner_workspace_id: 'linked-ws',
+          owner_workspace_name: 'Reporting',
+          ownership: 'linked',
+          access_mode: 'read',
+          table_count: 3,
+        },
+      ],
+    });
+
+    await renderPanelWithRuntimeOverlay(false);
+
+    await waitFor(() => {
+      const button = screen.getByLabelText('Open SQLite inspector');
+      expect(button.getAttribute('title')).toBe('Open SQLite Inspector');
+      expect(button.className.includes('btn-primary')).toBe(true);
+    });
+  });
+
+  it('does not promote the active source workspace when a linked target promotion is reported', async () => {
+    const user = userEvent.setup();
+    sqliteInspectorModalRender = (props: unknown) => {
+      const { isOpen, onPersistencePromoted } = props as {
+        isOpen: boolean;
+        onPersistencePromoted?: (workspaceId: string) => void;
+      };
+      return isOpen ? (
+        <button type="button" onClick={() => onPersistencePromoted?.('linked-ws')}>
+          Trigger linked promotion
+        </button>
+      ) : null;
+    };
+
+    await renderPanelWithRuntimeOverlay(false);
+
+    const openInspectorButton = screen.getByLabelText('Open SQLite inspector');
+    await user.click(openInspectorButton);
+    await user.click(screen.getByRole('button', { name: 'Trigger linked promotion' }));
+
+    expect(latestSqliteInspectorModalProps).toEqual(
+      expect.objectContaining({
+        workspaceId: 'ws-1',
+        onPersistencePromoted: expect.any(Function),
+      }),
+    );
+    const openInspectorButtonAfter = screen.getByLabelText('Open SQLite inspector');
+    expect(openInspectorButtonAfter.className.includes('userspace-sqlite-mode-excluded')).toBe(
+      true,
+    );
   });
 });

--- a/ragtime/frontend/src/components/UserSpacePanel.tsx
+++ b/ragtime/frontend/src/components/UserSpacePanel.tsx
@@ -4559,8 +4559,13 @@ export function UserSpacePanel({
   const refreshSqliteHasTables = useCallback(async (workspaceId: string) => {
     try {
       const result = await api.listUserSpaceSqliteDatabases(workspaceId);
-      const appDb = result.databases.find((d) => d.name === result.default_database_name);
-      setSqliteHasTables(!!appDb && appDb.table_count > 0);
+      setSqliteHasTables(
+        result.databases.some(
+          (database) =>
+            (database as { initialized?: boolean }).initialized !== false &&
+            database.table_count > 0,
+        ),
+      );
     } catch {
       setSqliteHasTables(false);
     }
@@ -4586,14 +4591,17 @@ export function UserSpacePanel({
     }
   }, [activeWorkspaceId, refreshSqliteHasTables]);
 
-  const handleSqlitePersistencePromoted = useCallback(() => {
-    if (!activeWorkspaceId) return;
-    setWorkspaces((current) =>
-      current.map((ws) =>
-        ws.id === activeWorkspaceId ? { ...ws, sqlite_persistence_mode: 'include' } : ws,
-      ),
-    );
-  }, [activeWorkspaceId]);
+  const handleSqlitePersistencePromoted = useCallback(
+    (workspaceId: string) => {
+      if (!activeWorkspaceId || workspaceId !== activeWorkspaceId) return;
+      setWorkspaces((current) =>
+        current.map((ws) =>
+          ws.id === activeWorkspaceId ? { ...ws, sqlite_persistence_mode: 'include' } : ws,
+        ),
+      );
+    },
+    [activeWorkspaceId],
+  );
 
   const handleWorkspaceScmSyncComplete = useCallback(
     async (response: UserSpaceWorkspaceScmSyncResponse) => {
@@ -8226,7 +8234,7 @@ export function UserSpacePanel({
 
   const sqliteInspectorButtonTitle = sqliteHasTables
     ? 'Open SQLite Inspector'
-    : 'SQLite database is empty — open the inspector to initialize tables';
+    : 'Accessible SQLite databases are empty — open the inspector to initialize tables';
   const formattedError = useMemo(() => formatUserSpaceErrorMessage(error), [error]);
   const liveDataWarningMessage = runtimeStatus?.live_data_warning?.trim() || null;
   const visibleLiveDataWarningMessage =
@@ -9078,7 +9086,7 @@ export function UserSpacePanel({
               getToolStatusBadge={getWorkspaceToolStatusBadge}
             />
             <button
-              className={`btn btn-sm btn-icon userspace-toolbar-action-btn ${sqliteHasTables ? 'btn-primary' : 'btn-secondary'}`}
+              className={`btn btn-sm btn-icon userspace-toolbar-action-btn ${sqliteHasTables ? 'btn-primary' : 'btn-secondary'} ${activeWorkspace?.sqlite_persistence_mode === 'exclude' ? 'userspace-sqlite-mode-excluded' : ''}`.trim()}
               onClick={handleOpenSqliteInspector}
               disabled={!activeWorkspaceId}
               title={sqliteInspectorButtonTitle}

--- a/ragtime/frontend/src/components/UserSpacePanel.tsx
+++ b/ragtime/frontend/src/components/UserSpacePanel.tsx
@@ -11840,6 +11840,7 @@ export function UserSpacePanel({
           availableWorkspaces={agentGrantWorkspaces.map((workspace) => ({
             ...workspace,
             canGrantReadWrite: canEditUserSpaceWorkspace(workspace, currentUser),
+            canGrantSqlite: workspace.owner_user_id === currentUser?.id,
           }))}
           grants={agentGrants}
           onUpsert={handleUpsertAgentGrant}

--- a/ragtime/frontend/src/components/shared/AgentAccessModal.test.tsx
+++ b/ragtime/frontend/src/components/shared/AgentAccessModal.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -39,7 +39,7 @@ function renderModal({
   onUpsert?: ReturnType<typeof vi.fn>;
   onRevoke?: ReturnType<typeof vi.fn>;
 } = {}) {
-  render(
+  const renderResult = render(
     <AgentAccessModal
       isOpen
       onClose={vi.fn()}
@@ -51,7 +51,7 @@ function renderModal({
     />,
   );
 
-  return { onUpsert, onRevoke };
+  return { ...renderResult, onUpsert, onRevoke };
 }
 
 function getGrantRow(targetName: string): HTMLElement {
@@ -74,7 +74,7 @@ afterEach(() => {
 });
 
 describe('AgentAccessModal', () => {
-  it('renders the SQLite warning, accessible toggle groups, and fixture modes for none/read/read_write', () => {
+  it('renders one combined help note, keeps existing-row labels and groups, and removes add-form permission controls', () => {
     renderModal({
       grants: [
         createGrant({
@@ -104,15 +104,23 @@ describe('AgentAccessModal', () => {
       ],
     });
 
-    expect(screen.getByRole('note').textContent).toContain(
-      'A SQLite grant covers all data in app.sqlite3, including future data. Only the target workspace owner can change it.',
+    expect(screen.getByRole('note').textContent).toBe(
+      "Allow this workspace's agent to use file/runtime tools in another workspace you can access. A SQLite grant covers all data in app.sqlite3, including future data. Only the target workspace owner can change it.",
     );
+    expect(
+      screen.queryAllByText(
+        'A SQLite grant covers all data in app.sqlite3, including future data. Only the target workspace owner can change it.',
+      ),
+    ).toHaveLength(0);
+    expect(screen.getByText('Target workspace')).not.toBeNull();
 
     const modal = document.querySelector('.userspace-agent-access-modal');
     expect(modal).not.toBeNull();
 
     const alphaRow = getGrantRow('Alpha');
     expect(alphaRow.querySelector('.userspace-agent-access-control-row')).not.toBeNull();
+    expect(within(alphaRow).getByText('File/runtime')).not.toBeNull();
+    expect(within(alphaRow).getByText('Shared SQLite')).not.toBeNull();
     const alphaSqliteGroup = within(alphaRow).getByRole('group', {
       name: 'Shared SQLite access for Alpha',
     });
@@ -145,9 +153,26 @@ describe('AgentAccessModal', () => {
         .getByRole('button', { name: 'Read / Write' })
         .getAttribute('aria-pressed'),
     ).toBe('true');
+
+    const newGrantSection = screen
+      .getByLabelText('Target workspace')
+      .closest('.userspace-agent-access-add-row');
+    expect(newGrantSection).not.toBeNull();
+    if (!(newGrantSection instanceof HTMLElement)) {
+      throw new Error('Missing new grant section');
+    }
+    expect(
+      within(newGrantSection).queryByRole('group', { name: 'New grant file/runtime access' }),
+    ).toBeNull();
+    expect(
+      within(newGrantSection).queryByRole('group', { name: 'New grant Shared SQLite access' }),
+    ).toBeNull();
+    expect(within(newGrantSection).queryByText('File/runtime')).toBeNull();
+    expect(within(newGrantSection).queryByText('Shared SQLite')).toBeNull();
+    expect(within(newGrantSection).queryByText(/choose the permissions/i)).toBeNull();
   });
 
-  it('lets an owner change SQLite mode while preserving the current file mode', async () => {
+  it('keeps existing-grant edits local until Save is clicked and preserves the current file mode', async () => {
     const user = userEvent.setup();
     const { onUpsert } = renderModal({
       grants: [
@@ -167,8 +192,17 @@ describe('AgentAccessModal', () => {
     const sqliteGroup = within(row).getByRole('group', {
       name: 'Shared SQLite access for Owner Target',
     });
+    const saveButton = within(row).getByRole('button', { name: 'Save grant for Owner Target' });
+
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+    expect(saveButton.classList.contains('btn-sm')).toBe(true);
 
     await user.click(within(sqliteGroup).getByRole('button', { name: 'Read / Write' }));
+
+    expect(onUpsert).not.toHaveBeenCalled();
+    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+
+    await user.click(saveButton);
 
     expect(onUpsert).toHaveBeenCalledWith({
       target_workspace_id: 'ws-owner',
@@ -177,7 +211,7 @@ describe('AgentAccessModal', () => {
     });
   });
 
-  it('omits sqlite_access_mode during file-mode edits and keeps the current SQLite state visible', async () => {
+  it('enables Save only while a row draft differs and persists the full owner-capable draft on Save', async () => {
     const user = userEvent.setup();
     const { onUpsert } = renderModal({
       grants: [
@@ -200,12 +234,26 @@ describe('AgentAccessModal', () => {
     const sqliteGroup = within(row).getByRole('group', {
       name: 'Shared SQLite access for Owner Target',
     });
+    const saveButton = within(row).getByRole('button', { name: 'Save grant for Owner Target' });
+
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+    expect(saveButton.classList.contains('btn-sm')).toBe(true);
 
     await user.click(within(fileGroup).getByRole('button', { name: 'Read / Write' }));
+
+    expect(onUpsert).not.toHaveBeenCalled();
+    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+
+    await user.click(within(fileGroup).getByRole('button', { name: 'Read' }));
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+
+    await user.click(within(fileGroup).getByRole('button', { name: 'Read / Write' }));
+    await user.click(saveButton);
 
     expect(onUpsert).toHaveBeenCalledWith({
       target_workspace_id: 'ws-owner',
       access_mode: 'read_write',
+      sqlite_access_mode: 'read_write',
     });
     expect(
       within(sqliteGroup)
@@ -214,7 +262,80 @@ describe('AgentAccessModal', () => {
     ).toBe('true');
   });
 
-  it('shows current SQLite mode to a non-owner, disables SQLite changes, and blocks revoke when SQLite access exists', () => {
+  it('resynchronizes a dirty row draft when the persisted grant changes after rerender', async () => {
+    const user = userEvent.setup();
+    const onUpsert = vi.fn().mockResolvedValue(undefined);
+    const onRevoke = vi.fn().mockResolvedValue(undefined);
+    const initialGrant = createGrant({
+      target_workspace_id: 'ws-owner',
+      target_workspace_name: 'Owner Target',
+      access_mode: 'read',
+      sqlite_access_mode: 'none',
+    });
+    const updatedGrant = createGrant({
+      target_workspace_id: 'ws-owner',
+      target_workspace_name: 'Owner Target',
+      access_mode: 'read_write',
+      sqlite_access_mode: 'read',
+      updated_at: '2026-08-06T12:00:00Z',
+    });
+    const { rerender } = renderModal({
+      grants: [initialGrant],
+      availableWorkspaces: [
+        { id: 'ws-owner', name: 'Owner Target', canGrantReadWrite: true, canGrantSqlite: true },
+      ],
+      onUpsert,
+      onRevoke,
+    });
+
+    const row = getGrantRow('Owner Target');
+    const fileGroup = within(row).getByRole('group', {
+      name: 'File/runtime access for Owner Target',
+    });
+    const saveButton = within(row).getByRole('button', { name: 'Save grant for Owner Target' });
+
+    await user.click(within(fileGroup).getByRole('button', { name: 'Read / Write' }));
+    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+
+    rerender(
+      <AgentAccessModal
+        isOpen
+        onClose={vi.fn()}
+        sourceWorkspace={SOURCE_WORKSPACE}
+        availableWorkspaces={[
+          { id: 'ws-owner', name: 'Owner Target', canGrantReadWrite: true, canGrantSqlite: true },
+        ]}
+        grants={[updatedGrant]}
+        onUpsert={onUpsert}
+        onRevoke={onRevoke}
+      />,
+    );
+
+    const rerenderedRow = getGrantRow('Owner Target');
+    const rerenderedFileGroup = within(rerenderedRow).getByRole('group', {
+      name: 'File/runtime access for Owner Target',
+    });
+    const rerenderedSqliteGroup = within(rerenderedRow).getByRole('group', {
+      name: 'Shared SQLite access for Owner Target',
+    });
+    const rerenderedSaveButton = within(rerenderedRow).getByRole('button', {
+      name: 'Save grant for Owner Target',
+    });
+
+    expect(
+      within(rerenderedFileGroup)
+        .getByRole('button', { name: 'Read / Write' })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+    expect(
+      within(rerenderedSqliteGroup)
+        .getByRole('button', { name: 'Read' })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+    expect((rerenderedSaveButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows current SQLite mode to a non-owner, disables SQLite changes, and preserves revoke restrictions', () => {
     renderModal({
       grants: [
         createGrant({
@@ -265,19 +386,63 @@ describe('AgentAccessModal', () => {
     ).toBe(false);
   });
 
-  it('omits sqlite_access_mode when a non-owner adds or updates a file-only grant', async () => {
+  it('uses a blank placeholder, disables granted targets, and enables Add only for valid ungranted targets', async () => {
     const user = userEvent.setup();
     const { onUpsert } = renderModal({
+      grants: [
+        createGrant({
+          target_workspace_id: 'ws-granted',
+          target_workspace_name: 'Already Granted',
+        }),
+      ],
       availableWorkspaces: [
+        {
+          id: 'ws-granted',
+          name: 'Already Granted',
+          canGrantReadWrite: true,
+          canGrantSqlite: true,
+        },
         { id: 'ws-member', name: 'Member Target', canGrantReadWrite: true, canGrantSqlite: false },
       ],
     });
 
-    const sqliteGroup = screen.getByRole('group', { name: 'New grant Shared SQLite access' });
-    const sqliteButtons = within(sqliteGroup).getAllByRole('button');
-    expect(sqliteButtons.every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
+    const targetSelect = screen.getByLabelText('Target workspace') as HTMLSelectElement;
+    const addButton = screen.getByRole('button', { name: 'Add grant' });
+    const footer = document.querySelector('.modal-footer');
 
-    await user.click(screen.getByRole('button', { name: 'Add / Update Grant' }));
+    expect(
+      (screen.getByRole('option', { name: 'Select a workspace...' }) as HTMLOptionElement).value,
+    ).toBe('');
+    expect(targetSelect.value).toBe('');
+    expect((addButton as HTMLButtonElement).disabled).toBe(true);
+    expect(footer).not.toBeNull();
+    if (!(footer instanceof HTMLElement)) {
+      throw new Error('Missing modal footer');
+    }
+    expect(within(footer).getByRole('button', { name: 'Close' })).toBe(
+      screen.getByRole('button', { name: 'Close' }),
+    );
+    expect(within(footer).getByRole('button', { name: 'Add grant' })).toBe(addButton);
+    expect(
+      within(footer)
+        .getAllByRole('button')
+        .map((button) => button.textContent?.trim()),
+    ).toEqual(['Close', 'Add grant']);
+    expect(
+      (
+        screen.getByRole('option', {
+          name: 'Already Granted (already granted)',
+        }) as HTMLOptionElement
+      ).disabled,
+    ).toBe(true);
+    expect(screen.queryByRole('group', { name: 'New grant file/runtime access' })).toBeNull();
+    expect(screen.queryByRole('group', { name: 'New grant Shared SQLite access' })).toBeNull();
+
+    await user.selectOptions(targetSelect, 'ws-member');
+
+    expect((addButton as HTMLButtonElement).disabled).toBe(false);
+
+    await user.click(addButton);
 
     expect(onUpsert).toHaveBeenCalledWith({
       target_workspace_id: 'ws-member',
@@ -285,7 +450,7 @@ describe('AgentAccessModal', () => {
     });
   });
 
-  it('includes sqlite_access_mode for an owned target and resets the local SQLite choice when switching targets', async () => {
+  it('submits the least-privilege payload for an owned target and resets the target to the placeholder after Add succeeds', async () => {
     const user = userEvent.setup();
     const { onUpsert } = renderModal({
       availableWorkspaces: [
@@ -294,27 +459,90 @@ describe('AgentAccessModal', () => {
       ],
     });
 
-    const sqliteGroup = screen.getByRole('group', { name: 'New grant Shared SQLite access' });
+    const targetSelect = screen.getByLabelText('Target workspace') as HTMLSelectElement;
+    await user.selectOptions(targetSelect, 'ws-zulu');
+
+    await user.click(screen.getByRole('button', { name: 'Add grant' }));
+
+    expect(onUpsert).toHaveBeenLastCalledWith({
+      target_workspace_id: 'ws-zulu',
+      access_mode: 'read',
+    });
+    await waitFor(() => {
+      expect(targetSelect.value).toBe('');
+    });
+  });
+
+  it('keeps a persisted read_write mode active when write capability is unavailable and does not mark the row dirty', () => {
+    renderModal({
+      grants: [
+        createGrant({
+          target_workspace_id: 'ws-limited',
+          target_workspace_name: 'Limited Target',
+          access_mode: 'read_write',
+          sqlite_access_mode: 'none',
+        }),
+      ],
+      availableWorkspaces: [
+        {
+          id: 'ws-limited',
+          name: 'Limited Target',
+          canGrantReadWrite: false,
+          canGrantSqlite: true,
+        },
+      ],
+    });
+
+    const row = getGrantRow('Limited Target');
+    const fileGroup = within(row).getByRole('group', {
+      name: 'File/runtime access for Limited Target',
+    });
+
+    expect(
+      within(fileGroup).getByRole('button', { name: 'Read / Write' }).getAttribute('aria-pressed'),
+    ).toBe('true');
+    expect(
+      (
+        within(row).getByRole('button', {
+          name: 'Save grant for Limited Target',
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it('retains a dirty draft after a rejected Save and surfaces an in-modal error', async () => {
+    const user = userEvent.setup();
+    const onUpsert = vi.fn().mockRejectedValue(new Error('Save failed'));
+    renderModal({
+      grants: [
+        createGrant({
+          target_workspace_id: 'ws-owner',
+          target_workspace_name: 'Owner Target',
+          access_mode: 'read',
+          sqlite_access_mode: 'read',
+        }),
+      ],
+      availableWorkspaces: [
+        { id: 'ws-owner', name: 'Owner Target', canGrantReadWrite: true, canGrantSqlite: true },
+      ],
+      onUpsert,
+    });
+
+    const row = getGrantRow('Owner Target');
+    const sqliteGroup = within(row).getByRole('group', {
+      name: 'Shared SQLite access for Owner Target',
+    });
+    const saveButton = within(row).getByRole('button', { name: 'Save grant for Owner Target' });
+
     await user.click(within(sqliteGroup).getByRole('button', { name: 'Read / Write' }));
+    await user.click(saveButton);
+
+    expect(await within(row).findByText('Save failed')).not.toBeNull();
+    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
     expect(
       within(sqliteGroup)
         .getByRole('button', { name: 'Read / Write' })
         .getAttribute('aria-pressed'),
     ).toBe('true');
-
-    await user.selectOptions(screen.getByLabelText('Target workspace'), 'ws-zulu');
-
-    expect(
-      within(sqliteGroup).getByRole('button', { name: 'None' }).getAttribute('aria-pressed'),
-    ).toBe('true');
-
-    await user.click(within(sqliteGroup).getByRole('button', { name: 'Read' }));
-    await user.click(screen.getByRole('button', { name: 'Add / Update Grant' }));
-
-    expect(onUpsert).toHaveBeenLastCalledWith({
-      target_workspace_id: 'ws-zulu',
-      access_mode: 'read',
-      sqlite_access_mode: 'read',
-    });
   });
 });

--- a/ragtime/frontend/src/components/shared/AgentAccessModal.test.tsx
+++ b/ragtime/frontend/src/components/shared/AgentAccessModal.test.tsx
@@ -1,0 +1,320 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkspaceAgentGrant } from '@/types';
+import { AgentAccessModal } from './AgentAccessModal';
+
+const SOURCE_WORKSPACE = { id: 'ws-source', name: 'Source Workspace' };
+
+function createGrant(overrides: Partial<WorkspaceAgentGrant> = {}): WorkspaceAgentGrant {
+  return {
+    id: 'grant-1',
+    source_workspace_id: 'ws-source',
+    source_workspace_name: 'Source Workspace',
+    target_workspace_id: 'ws-target',
+    target_workspace_name: 'Target Workspace',
+    access_mode: 'read',
+    sqlite_access_mode: 'none',
+    granted_by_user_id: 'user-1',
+    created_at: '2026-08-05T12:00:00Z',
+    updated_at: '2026-08-05T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderModal({
+  grants = [],
+  availableWorkspaces = [],
+  onUpsert = vi.fn().mockResolvedValue(undefined),
+  onRevoke = vi.fn().mockResolvedValue(undefined),
+}: {
+  grants?: Array<ReturnType<typeof createGrant>>;
+  availableWorkspaces?: Array<{
+    id: string;
+    name: string;
+    canGrantReadWrite?: boolean;
+    canGrantSqlite?: boolean;
+  }>;
+  onUpsert?: ReturnType<typeof vi.fn>;
+  onRevoke?: ReturnType<typeof vi.fn>;
+} = {}) {
+  render(
+    <AgentAccessModal
+      isOpen
+      onClose={vi.fn()}
+      sourceWorkspace={SOURCE_WORKSPACE}
+      availableWorkspaces={availableWorkspaces}
+      grants={grants}
+      onUpsert={onUpsert}
+      onRevoke={onRevoke}
+    />,
+  );
+
+  return { onUpsert, onRevoke };
+}
+
+function getGrantRow(targetName: string): HTMLElement {
+  const targetText = screen
+    .getAllByText(targetName)
+    .find((element) => element.tagName.toLowerCase() === 'span');
+  if (!(targetText instanceof HTMLElement)) {
+    throw new Error(`Missing target label for ${targetName}`);
+  }
+  const row = targetText.closest('.userspace-agent-access-grant-row');
+  if (!(row instanceof HTMLElement)) {
+    throw new Error(`Missing grant row for ${targetName}`);
+  }
+  return row;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('AgentAccessModal', () => {
+  it('renders the SQLite warning, accessible toggle groups, and fixture modes for none/read/read_write', () => {
+    renderModal({
+      grants: [
+        createGrant({
+          id: 'grant-none',
+          target_workspace_id: 'ws-a',
+          target_workspace_name: 'Alpha',
+          sqlite_access_mode: 'none',
+        }),
+        createGrant({
+          id: 'grant-read',
+          target_workspace_id: 'ws-b',
+          target_workspace_name: 'Beta',
+          sqlite_access_mode: 'read',
+        }),
+        createGrant({
+          id: 'grant-read-write',
+          target_workspace_id: 'ws-c',
+          target_workspace_name: 'Gamma',
+          sqlite_access_mode: 'read_write',
+          access_mode: 'read_write',
+        }),
+      ],
+      availableWorkspaces: [
+        { id: 'ws-a', name: 'Alpha', canGrantReadWrite: true, canGrantSqlite: true },
+        { id: 'ws-b', name: 'Beta', canGrantReadWrite: true, canGrantSqlite: true },
+        { id: 'ws-c', name: 'Gamma', canGrantReadWrite: true, canGrantSqlite: true },
+      ],
+    });
+
+    expect(screen.getByRole('note').textContent).toContain(
+      'A SQLite grant covers all data in app.sqlite3, including future data. Only the target workspace owner can change it.',
+    );
+
+    const modal = document.querySelector('.userspace-agent-access-modal');
+    expect(modal).not.toBeNull();
+
+    const alphaRow = getGrantRow('Alpha');
+    expect(alphaRow.querySelector('.userspace-agent-access-control-row')).not.toBeNull();
+    const alphaSqliteGroup = within(alphaRow).getByRole('group', {
+      name: 'Shared SQLite access for Alpha',
+    });
+    expect(
+      within(alphaSqliteGroup).getByRole('button', { name: 'None' }).getAttribute('aria-pressed'),
+    ).toBe('true');
+
+    const betaRow = getGrantRow('Beta');
+    const betaSqliteGroup = within(betaRow).getByRole('group', {
+      name: 'Shared SQLite access for Beta',
+    });
+    expect(
+      within(betaSqliteGroup).getByRole('button', { name: 'Read' }).getAttribute('aria-pressed'),
+    ).toBe('true');
+
+    const gammaRow = getGrantRow('Gamma');
+    const gammaFileGroup = within(gammaRow).getByRole('group', {
+      name: 'File/runtime access for Gamma',
+    });
+    expect(
+      within(gammaFileGroup)
+        .getByRole('button', { name: 'Read / Write' })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+    const gammaSqliteGroup = within(gammaRow).getByRole('group', {
+      name: 'Shared SQLite access for Gamma',
+    });
+    expect(
+      within(gammaSqliteGroup)
+        .getByRole('button', { name: 'Read / Write' })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+  });
+
+  it('lets an owner change SQLite mode while preserving the current file mode', async () => {
+    const user = userEvent.setup();
+    const { onUpsert } = renderModal({
+      grants: [
+        createGrant({
+          target_workspace_id: 'ws-owner',
+          target_workspace_name: 'Owner Target',
+          access_mode: 'read_write',
+          sqlite_access_mode: 'read',
+        }),
+      ],
+      availableWorkspaces: [
+        { id: 'ws-owner', name: 'Owner Target', canGrantReadWrite: true, canGrantSqlite: true },
+      ],
+    });
+
+    const row = getGrantRow('Owner Target');
+    const sqliteGroup = within(row).getByRole('group', {
+      name: 'Shared SQLite access for Owner Target',
+    });
+
+    await user.click(within(sqliteGroup).getByRole('button', { name: 'Read / Write' }));
+
+    expect(onUpsert).toHaveBeenCalledWith({
+      target_workspace_id: 'ws-owner',
+      access_mode: 'read_write',
+      sqlite_access_mode: 'read_write',
+    });
+  });
+
+  it('omits sqlite_access_mode during file-mode edits and keeps the current SQLite state visible', async () => {
+    const user = userEvent.setup();
+    const { onUpsert } = renderModal({
+      grants: [
+        createGrant({
+          target_workspace_id: 'ws-owner',
+          target_workspace_name: 'Owner Target',
+          access_mode: 'read',
+          sqlite_access_mode: 'read_write',
+        }),
+      ],
+      availableWorkspaces: [
+        { id: 'ws-owner', name: 'Owner Target', canGrantReadWrite: true, canGrantSqlite: true },
+      ],
+    });
+
+    const row = getGrantRow('Owner Target');
+    const fileGroup = within(row).getByRole('group', {
+      name: 'File/runtime access for Owner Target',
+    });
+    const sqliteGroup = within(row).getByRole('group', {
+      name: 'Shared SQLite access for Owner Target',
+    });
+
+    await user.click(within(fileGroup).getByRole('button', { name: 'Read / Write' }));
+
+    expect(onUpsert).toHaveBeenCalledWith({
+      target_workspace_id: 'ws-owner',
+      access_mode: 'read_write',
+    });
+    expect(
+      within(sqliteGroup)
+        .getByRole('button', { name: 'Read / Write' })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+  });
+
+  it('shows current SQLite mode to a non-owner, disables SQLite changes, and blocks revoke when SQLite access exists', () => {
+    renderModal({
+      grants: [
+        createGrant({
+          id: 'grant-read',
+          target_workspace_id: 'ws-member',
+          target_workspace_name: 'Member Target',
+          sqlite_access_mode: 'read',
+        }),
+        createGrant({
+          id: 'grant-none',
+          target_workspace_id: 'ws-member-none',
+          target_workspace_name: 'Member Target None',
+          sqlite_access_mode: 'none',
+        }),
+      ],
+      availableWorkspaces: [
+        { id: 'ws-member', name: 'Member Target', canGrantReadWrite: true, canGrantSqlite: false },
+        {
+          id: 'ws-member-none',
+          name: 'Member Target None',
+          canGrantReadWrite: true,
+          canGrantSqlite: false,
+        },
+      ],
+    });
+
+    const row = getGrantRow('Member Target');
+    const sqliteGroup = within(row).getByRole('group', {
+      name: 'Shared SQLite access for Member Target',
+    });
+    const buttons = within(sqliteGroup).getAllByRole('button');
+    expect(buttons.every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
+    expect(
+      within(sqliteGroup).getByRole('button', { name: 'Read' }).getAttribute('aria-pressed'),
+    ).toBe('true');
+    expect(
+      (within(row).getByRole('button', { name: /revoke read only access/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    const noneRow = getGrantRow('Member Target None');
+    expect(
+      (
+        within(noneRow).getByRole('button', {
+          name: /revoke read only access/i,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+  });
+
+  it('omits sqlite_access_mode when a non-owner adds or updates a file-only grant', async () => {
+    const user = userEvent.setup();
+    const { onUpsert } = renderModal({
+      availableWorkspaces: [
+        { id: 'ws-member', name: 'Member Target', canGrantReadWrite: true, canGrantSqlite: false },
+      ],
+    });
+
+    const sqliteGroup = screen.getByRole('group', { name: 'New grant Shared SQLite access' });
+    const sqliteButtons = within(sqliteGroup).getAllByRole('button');
+    expect(sqliteButtons.every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
+
+    await user.click(screen.getByRole('button', { name: 'Add / Update Grant' }));
+
+    expect(onUpsert).toHaveBeenCalledWith({
+      target_workspace_id: 'ws-member',
+      access_mode: 'read',
+    });
+  });
+
+  it('includes sqlite_access_mode for an owned target and resets the local SQLite choice when switching targets', async () => {
+    const user = userEvent.setup();
+    const { onUpsert } = renderModal({
+      availableWorkspaces: [
+        { id: 'ws-alpha', name: 'Alpha Owned', canGrantReadWrite: true, canGrantSqlite: true },
+        { id: 'ws-zulu', name: 'Zulu Owned', canGrantReadWrite: true, canGrantSqlite: true },
+      ],
+    });
+
+    const sqliteGroup = screen.getByRole('group', { name: 'New grant Shared SQLite access' });
+    await user.click(within(sqliteGroup).getByRole('button', { name: 'Read / Write' }));
+    expect(
+      within(sqliteGroup)
+        .getByRole('button', { name: 'Read / Write' })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+
+    await user.selectOptions(screen.getByLabelText('Target workspace'), 'ws-zulu');
+
+    expect(
+      within(sqliteGroup).getByRole('button', { name: 'None' }).getAttribute('aria-pressed'),
+    ).toBe('true');
+
+    await user.click(within(sqliteGroup).getByRole('button', { name: 'Read' }));
+    await user.click(screen.getByRole('button', { name: 'Add / Update Grant' }));
+
+    expect(onUpsert).toHaveBeenLastCalledWith({
+      target_workspace_id: 'ws-zulu',
+      access_mode: 'read',
+      sqlite_access_mode: 'read',
+    });
+  });
+});

--- a/ragtime/frontend/src/components/shared/AgentAccessModal.tsx
+++ b/ragtime/frontend/src/components/shared/AgentAccessModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 import type {
   UpsertWorkspaceAgentGrantRequest,
@@ -26,6 +26,11 @@ interface AgentAccessModalProps {
   revokingTargetId?: string | null;
 }
 
+type AgentAccessDraft = {
+  accessMode: WorkspaceAgentGrantMode;
+  sqliteAccessMode: WorkspaceSqliteGrantMode;
+};
+
 function sortWorkspacesByName(
   workspaces: AgentAccessWorkspaceOption[],
 ): AgentAccessWorkspaceOption[] {
@@ -42,6 +47,38 @@ function sqliteModeLabel(mode: WorkspaceSqliteGrantMode): string {
   return 'None';
 }
 
+function buildGrantDraft(grant: WorkspaceAgentGrant): AgentAccessDraft {
+  return {
+    accessMode: grant.access_mode,
+    sqliteAccessMode: grant.sqlite_access_mode,
+  };
+}
+
+function grantDraftSignature(grant: WorkspaceAgentGrant): string {
+  return `${grant.access_mode}:${grant.sqlite_access_mode}`;
+}
+
+function isDraftDirty(grant: WorkspaceAgentGrant, draft: AgentAccessDraft): boolean {
+  return (
+    grant.access_mode !== draft.accessMode || grant.sqlite_access_mode !== draft.sqliteAccessMode
+  );
+}
+
+function buildUpsertRequest(
+  targetWorkspaceId: string,
+  draft: AgentAccessDraft,
+  canGrantSqlite: boolean,
+): UpsertWorkspaceAgentGrantRequest {
+  const request: UpsertWorkspaceAgentGrantRequest = {
+    target_workspace_id: targetWorkspaceId,
+    access_mode: draft.accessMode,
+  };
+  if (canGrantSqlite) {
+    request.sqlite_access_mode = draft.sqliteAccessMode;
+  }
+  return request;
+}
+
 export function AgentAccessModal({
   isOpen,
   onClose,
@@ -55,8 +92,10 @@ export function AgentAccessModal({
   revokingTargetId = null,
 }: AgentAccessModalProps) {
   const [targetWorkspaceId, setTargetWorkspaceId] = useState('');
-  const [accessMode, setAccessMode] = useState<WorkspaceAgentGrantMode>('read');
-  const [sqliteAccessMode, setSqliteAccessMode] = useState<WorkspaceSqliteGrantMode>('none');
+  const [draftsByTargetId, setDraftsByTargetId] = useState<Record<string, AgentAccessDraft>>({});
+  const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
+  const [createError, setCreateError] = useState<string | null>(null);
+  const persistedGrantSignaturesRef = useRef<Record<string, string>>({});
 
   const workspaceOptions = useMemo(
     () =>
@@ -65,57 +104,132 @@ export function AgentAccessModal({
       ),
     [availableWorkspaces, sourceWorkspace.id],
   );
-  const targetCanGrantReadWrite =
-    workspaceOptions.find((workspace) => workspace.id === targetWorkspaceId)?.canGrantReadWrite ??
-    false;
-  const targetCanGrantSqlite =
-    workspaceOptions.find((workspace) => workspace.id === targetWorkspaceId)?.canGrantSqlite ??
-    false;
+  const workspaceById = useMemo(
+    () => new Map(workspaceOptions.map((workspace) => [workspace.id, workspace])),
+    [workspaceOptions],
+  );
+  const grantedWorkspaceIds = useMemo(
+    () => new Set(grants.map((grant) => grant.target_workspace_id)),
+    [grants],
+  );
+  const isOperationLocked = loading || Boolean(savingTargetId) || Boolean(revokingTargetId);
 
   useEffect(() => {
     if (!isOpen) {
       return;
     }
-    const current = workspaceOptions[0]?.id ?? '';
-    setTargetWorkspaceId((previous) => {
-      if (previous && workspaceOptions.some((workspace) => workspace.id === previous)) {
-        return previous;
-      }
-      return current;
-    });
-    setAccessMode('read');
-    setSqliteAccessMode('none');
-  }, [isOpen, workspaceOptions]);
+    setTargetWorkspaceId('');
+    setCreateError(null);
+  }, [isOpen]);
 
   useEffect(() => {
-    if (!targetCanGrantReadWrite && accessMode === 'read_write') {
-      setAccessMode('read');
+    const previousPersistedSignatures = persistedGrantSignaturesRef.current;
+    const nextPersistedSignatures: Record<string, string> = {};
+
+    for (const grant of grants) {
+      nextPersistedSignatures[grant.target_workspace_id] = grantDraftSignature(grant);
     }
-  }, [accessMode, targetCanGrantReadWrite]);
+
+    setDraftsByTargetId((previous) => {
+      const next: Record<string, AgentAccessDraft> = {};
+      for (const grant of grants) {
+        const targetId = grant.target_workspace_id;
+        next[targetId] =
+          previousPersistedSignatures[targetId] === nextPersistedSignatures[targetId]
+            ? (previous[targetId] ?? buildGrantDraft(grant))
+            : buildGrantDraft(grant);
+      }
+      return next;
+    });
+    persistedGrantSignaturesRef.current = nextPersistedSignatures;
+    setRowErrors((previous) => {
+      const next: Record<string, string> = {};
+      for (const grant of grants) {
+        const error = previous[grant.target_workspace_id];
+        if (error) {
+          next[grant.target_workspace_id] = error;
+        }
+      }
+      return next;
+    });
+  }, [grants]);
 
   const handleClose = () => {
-    if (!loading && !savingTargetId && !revokingTargetId) {
+    if (!isOperationLocked) {
       onClose();
     }
   };
 
   const handleAddGrant = async () => {
-    if (!targetWorkspaceId) {
+    if (!targetWorkspaceId || grantedWorkspaceIds.has(targetWorkspaceId)) {
       return;
     }
-    const request: UpsertWorkspaceAgentGrantRequest = {
-      target_workspace_id: targetWorkspaceId,
-      access_mode: accessMode,
-    };
-    if (targetCanGrantSqlite) {
-      request.sqlite_access_mode = sqliteAccessMode;
+
+    setCreateError(null);
+
+    try {
+      await onUpsert({
+        target_workspace_id: targetWorkspaceId,
+        access_mode: 'read',
+      });
+      setTargetWorkspaceId('');
+    } catch (error) {
+      setCreateError(error instanceof Error ? error.message : 'Unable to add grant');
     }
-    await onUpsert(request);
   };
 
   const handleTargetWorkspaceChange = (workspaceId: string) => {
     setTargetWorkspaceId(workspaceId);
-    setSqliteAccessMode('none');
+    setCreateError(null);
+  };
+
+  const handleDraftChange = (targetWorkspaceId: string, update: Partial<AgentAccessDraft>) => {
+    setDraftsByTargetId((previous) => {
+      const current = previous[targetWorkspaceId];
+      if (!current) {
+        return previous;
+      }
+      return {
+        ...previous,
+        [targetWorkspaceId]: {
+          ...current,
+          ...update,
+        },
+      };
+    });
+    setRowErrors((previous) => {
+      if (!previous[targetWorkspaceId]) {
+        return previous;
+      }
+      const next = { ...previous };
+      delete next[targetWorkspaceId];
+      return next;
+    });
+  };
+
+  const handleSaveGrant = async (
+    grant: WorkspaceAgentGrant,
+    draft: AgentAccessDraft,
+    canGrantSqlite: boolean,
+  ) => {
+    setRowErrors((previous) => {
+      if (!previous[grant.target_workspace_id]) {
+        return previous;
+      }
+      const next = { ...previous };
+      delete next[grant.target_workspace_id];
+      return next;
+    });
+
+    try {
+      await onUpsert(buildUpsertRequest(grant.target_workspace_id, draft, canGrantSqlite));
+    } catch (error) {
+      setRowErrors((previous) => ({
+        ...previous,
+        [grant.target_workspace_id]:
+          error instanceof Error ? error.message : 'Unable to save grant',
+      }));
+    }
   };
 
   if (!isOpen) {
@@ -130,26 +244,19 @@ export function AgentAccessModal({
       >
         <div className="modal-header">
           <h3>Agent Access</h3>
-          <button
-            className="modal-close"
-            onClick={handleClose}
-            disabled={loading || Boolean(savingTargetId) || Boolean(revokingTargetId)}
-          >
+          <button className="modal-close" onClick={handleClose} disabled={isOperationLocked}>
             &times;
           </button>
         </div>
         <div className="modal-body">
           <div className="userspace-agent-access-intro">
             <strong>{sourceWorkspace.name}</strong>
-            <small className="userspace-muted">
+            <small className="userspace-agent-access-note userspace-muted" role="note">
               Allow this workspace&apos;s agent to use file/runtime tools in another workspace you
-              can access.
+              can access. A SQLite grant covers all data in app.sqlite3, including future data. Only
+              the target workspace owner can change it.
             </small>
           </div>
-          <p className="userspace-agent-access-note userspace-muted" role="note">
-            A SQLite grant covers all data in app.sqlite3, including future data. Only the target
-            workspace owner can change it.
-          </p>
 
           {loading ? (
             <p className="userspace-muted">Loading agent grants...</p>
@@ -164,17 +271,22 @@ export function AgentAccessModal({
                   grants.map((grant) => {
                     const targetLabel =
                       grant.target_workspace_name?.trim() || grant.target_workspace_id;
-                    const disabled =
+                    const rowOperationActive =
                       savingTargetId === grant.target_workspace_id ||
                       revokingTargetId === grant.target_workspace_id;
-                    const grantTargetCanReadWrite =
-                      workspaceOptions.find(
-                        (workspace) => workspace.id === grant.target_workspace_id,
-                      )?.canGrantReadWrite ?? grant.access_mode === 'read_write';
-                    const grantTargetCanGrantSqlite =
-                      workspaceOptions.find(
-                        (workspace) => workspace.id === grant.target_workspace_id,
-                      )?.canGrantSqlite ?? false;
+                    const grantWorkspace = workspaceById.get(grant.target_workspace_id);
+                    const canGrantReadWrite =
+                      grantWorkspace?.canGrantReadWrite ?? grant.access_mode === 'read_write';
+                    const canGrantSqlite = grantWorkspace?.canGrantSqlite ?? false;
+                    const draft =
+                      draftsByTargetId[grant.target_workspace_id] ?? buildGrantDraft(grant);
+                    const isDirty = isDraftDirty(grant, draft);
+                    const isInvalid =
+                      (draft.accessMode === 'read_write' &&
+                        !canGrantReadWrite &&
+                        grant.access_mode !== 'read_write') ||
+                      (draft.sqliteAccessMode !== grant.sqlite_access_mode && !canGrantSqlite);
+
                     return (
                       <div
                         key={grant.target_workspace_id}
@@ -184,17 +296,31 @@ export function AgentAccessModal({
                           <div className="userspace-agent-access-info">
                             <span>{targetLabel}</span>
                           </div>
-                          <button
-                            className="chat-action-btn"
-                            onClick={() => void onRevoke(grant.target_workspace_id)}
-                            title={`Revoke ${grantModeLabel(grant.access_mode).toLowerCase()} access`}
-                            disabled={
-                              disabled ||
-                              (!grantTargetCanGrantSqlite && grant.sqlite_access_mode !== 'none')
-                            }
-                          >
-                            <X size={14} />
-                          </button>
+                          <div className="userspace-agent-access-grant-actions">
+                            <button
+                              type="button"
+                              className="btn btn-secondary btn-sm"
+                              aria-label={`Save grant for ${targetLabel}`}
+                              onClick={() => void handleSaveGrant(grant, draft, canGrantSqlite)}
+                              disabled={
+                                isOperationLocked || rowOperationActive || !isDirty || isInvalid
+                              }
+                            >
+                              {savingTargetId === grant.target_workspace_id ? 'Saving...' : 'Save'}
+                            </button>
+                            <button
+                              className="chat-action-btn"
+                              aria-label={`Revoke ${grantModeLabel(grant.access_mode).toLowerCase()} access`}
+                              onClick={() => void onRevoke(grant.target_workspace_id)}
+                              title={`Revoke ${grantModeLabel(grant.access_mode).toLowerCase()} access`}
+                              disabled={
+                                rowOperationActive ||
+                                (!canGrantSqlite && grant.sqlite_access_mode !== 'none')
+                              }
+                            >
+                              <X size={14} />
+                            </button>
+                          </div>
                         </div>
                         <div className="userspace-agent-access-control-row">
                           <span className="userspace-agent-access-control-label">File/runtime</span>
@@ -205,29 +331,29 @@ export function AgentAccessModal({
                           >
                             <button
                               type="button"
-                              className={`userspace-member-role-option ${grant.access_mode === 'read' ? 'active' : ''}`}
-                              aria-pressed={grant.access_mode === 'read'}
+                              className={`userspace-member-role-option ${draft.accessMode === 'read' ? 'active' : ''}`}
+                              aria-pressed={draft.accessMode === 'read'}
                               onClick={() =>
-                                void onUpsert({
-                                  target_workspace_id: grant.target_workspace_id,
-                                  access_mode: 'read',
+                                handleDraftChange(grant.target_workspace_id, {
+                                  accessMode: 'read',
                                 })
                               }
-                              disabled={disabled}
+                              disabled={isOperationLocked || rowOperationActive}
                             >
                               Read
                             </button>
                             <button
                               type="button"
-                              className={`userspace-member-role-option ${grant.access_mode === 'read_write' ? 'active' : ''}`}
-                              aria-pressed={grant.access_mode === 'read_write'}
+                              className={`userspace-member-role-option ${draft.accessMode === 'read_write' ? 'active' : ''}`}
+                              aria-pressed={draft.accessMode === 'read_write'}
                               onClick={() =>
-                                void onUpsert({
-                                  target_workspace_id: grant.target_workspace_id,
-                                  access_mode: 'read_write',
+                                handleDraftChange(grant.target_workspace_id, {
+                                  accessMode: 'read_write',
                                 })
                               }
-                              disabled={disabled || !grantTargetCanReadWrite}
+                              disabled={
+                                isOperationLocked || rowOperationActive || !canGrantReadWrite
+                              }
                             >
                               Read / Write
                             </button>
@@ -246,16 +372,16 @@ export function AgentAccessModal({
                               <button
                                 key={mode}
                                 type="button"
-                                className={`userspace-member-role-option ${grant.sqlite_access_mode === mode ? 'active' : ''}`}
-                                aria-pressed={grant.sqlite_access_mode === mode}
+                                className={`userspace-member-role-option ${draft.sqliteAccessMode === mode ? 'active' : ''}`}
+                                aria-pressed={draft.sqliteAccessMode === mode}
                                 onClick={() =>
-                                  void onUpsert({
-                                    target_workspace_id: grant.target_workspace_id,
-                                    access_mode: grant.access_mode,
-                                    sqlite_access_mode: mode,
+                                  handleDraftChange(grant.target_workspace_id, {
+                                    sqliteAccessMode: mode,
                                   })
                                 }
-                                disabled={disabled || !grantTargetCanGrantSqlite}
+                                disabled={
+                                  isOperationLocked || rowOperationActive || !canGrantSqlite
+                                }
                               >
                                 {sqliteModeLabel(mode)}
                               </button>
@@ -267,6 +393,11 @@ export function AgentAccessModal({
                             workspace_id: {grant.target_workspace_id}
                           </small>
                         </div>
+                        {rowErrors[grant.target_workspace_id] ? (
+                          <div className="userspace-agent-access-row-error">
+                            {rowErrors[grant.target_workspace_id]}
+                          </div>
+                        ) : null}
                       </div>
                     );
                   })
@@ -281,107 +412,49 @@ export function AgentAccessModal({
                   id="userspace-agent-target-select"
                   value={targetWorkspaceId}
                   onChange={(event) => handleTargetWorkspaceChange(event.target.value)}
-                  disabled={
-                    workspaceOptions.length === 0 ||
-                    Boolean(savingTargetId) ||
-                    Boolean(revokingTargetId)
-                  }
+                  disabled={workspaceOptions.length === 0 || isOperationLocked}
                 >
                   {workspaceOptions.length === 0 ? (
                     <option value="">No other accessible workspaces</option>
                   ) : (
-                    workspaceOptions.map((workspace) => (
-                      <option key={workspace.id} value={workspace.id}>
-                        {workspace.name}
-                      </option>
-                    ))
+                    <>
+                      <option value="">Select a workspace...</option>
+                      {workspaceOptions.map((workspace) => (
+                        <option
+                          key={workspace.id}
+                          value={workspace.id}
+                          disabled={grantedWorkspaceIds.has(workspace.id)}
+                        >
+                          {workspace.name}
+                          {grantedWorkspaceIds.has(workspace.id) ? ' (already granted)' : ''}
+                        </option>
+                      ))}
+                    </>
                   )}
                 </select>
-
-                <div
-                  className="userspace-member-role-toggle userspace-agent-access-create-toggle"
-                  role="group"
-                  aria-label="New grant file/runtime access"
-                >
-                  <button
-                    type="button"
-                    className={`userspace-member-role-option ${accessMode === 'read' ? 'active' : ''}`}
-                    aria-pressed={accessMode === 'read'}
-                    onClick={() => setAccessMode('read')}
-                    disabled={
-                      workspaceOptions.length === 0 ||
-                      Boolean(savingTargetId) ||
-                      Boolean(revokingTargetId)
-                    }
-                  >
-                    Read
-                  </button>
-                  <button
-                    type="button"
-                    className={`userspace-member-role-option ${accessMode === 'read_write' ? 'active' : ''}`}
-                    aria-pressed={accessMode === 'read_write'}
-                    onClick={() => setAccessMode('read_write')}
-                    disabled={
-                      workspaceOptions.length === 0 ||
-                      !targetCanGrantReadWrite ||
-                      Boolean(savingTargetId) ||
-                      Boolean(revokingTargetId)
-                    }
-                  >
-                    Read / Write
-                  </button>
-                </div>
-                <div
-                  className="userspace-member-role-toggle userspace-agent-access-create-toggle"
-                  role="group"
-                  aria-label="New grant Shared SQLite access"
-                >
-                  {(['none', 'read', 'read_write'] as const).map((mode) => (
-                    <button
-                      key={mode}
-                      type="button"
-                      className={`userspace-member-role-option ${sqliteAccessMode === mode ? 'active' : ''}`}
-                      aria-pressed={sqliteAccessMode === mode}
-                      onClick={() => setSqliteAccessMode(mode)}
-                      disabled={
-                        workspaceOptions.length === 0 ||
-                        !targetCanGrantSqlite ||
-                        Boolean(savingTargetId) ||
-                        Boolean(revokingTargetId)
-                      }
-                    >
-                      {sqliteModeLabel(mode)}
-                    </button>
-                  ))}
-                </div>
-                <small className="userspace-muted">
-                  Read allows listing, reading, and screenshots. Read / Write also allows file edits
-                  and terminal commands.
-                </small>
+                {createError ? (
+                  <div className="userspace-agent-access-row-error">{createError}</div>
+                ) : null}
               </div>
             </>
           )}
         </div>
         <div className="modal-footer">
-          <button
-            className="btn btn-secondary"
-            onClick={handleClose}
-            disabled={loading || Boolean(savingTargetId) || Boolean(revokingTargetId)}
-          >
+          <button className="btn btn-secondary" onClick={handleClose} disabled={isOperationLocked}>
             Close
           </button>
           <button
+            type="button"
             className="btn btn-primary"
             onClick={() => void handleAddGrant()}
             disabled={
-              loading ||
+              isOperationLocked ||
               !targetWorkspaceId ||
               workspaceOptions.length === 0 ||
-              Boolean(savingTargetId) ||
-              Boolean(revokingTargetId)
+              grantedWorkspaceIds.has(targetWorkspaceId)
             }
           >
-            {savingTargetId === targetWorkspaceId ? 'Saving...' : 'Add / Update Grant'}
+            {savingTargetId === targetWorkspaceId ? 'Adding...' : 'Add grant'}
           </button>
         </div>
       </div>

--- a/ragtime/frontend/src/components/shared/AgentAccessModal.tsx
+++ b/ragtime/frontend/src/components/shared/AgentAccessModal.tsx
@@ -5,10 +5,12 @@ import type {
   UserSpaceWorkspace,
   WorkspaceAgentGrant,
   WorkspaceAgentGrantMode,
+  WorkspaceSqliteGrantMode,
 } from '@/types';
 
 type AgentAccessWorkspaceOption = Pick<UserSpaceWorkspace, 'id' | 'name'> & {
   canGrantReadWrite?: boolean;
+  canGrantSqlite?: boolean;
 };
 
 interface AgentAccessModalProps {
@@ -34,6 +36,12 @@ function grantModeLabel(mode: WorkspaceAgentGrantMode): string {
   return mode === 'read_write' ? 'Read / Write' : 'Read Only';
 }
 
+function sqliteModeLabel(mode: WorkspaceSqliteGrantMode): string {
+  if (mode === 'read_write') return 'Read / Write';
+  if (mode === 'read') return 'Read';
+  return 'None';
+}
+
 export function AgentAccessModal({
   isOpen,
   onClose,
@@ -48,6 +56,7 @@ export function AgentAccessModal({
 }: AgentAccessModalProps) {
   const [targetWorkspaceId, setTargetWorkspaceId] = useState('');
   const [accessMode, setAccessMode] = useState<WorkspaceAgentGrantMode>('read');
+  const [sqliteAccessMode, setSqliteAccessMode] = useState<WorkspaceSqliteGrantMode>('none');
 
   const workspaceOptions = useMemo(
     () =>
@@ -58,6 +67,9 @@ export function AgentAccessModal({
   );
   const targetCanGrantReadWrite =
     workspaceOptions.find((workspace) => workspace.id === targetWorkspaceId)?.canGrantReadWrite ??
+    false;
+  const targetCanGrantSqlite =
+    workspaceOptions.find((workspace) => workspace.id === targetWorkspaceId)?.canGrantSqlite ??
     false;
 
   useEffect(() => {
@@ -72,6 +84,7 @@ export function AgentAccessModal({
       return current;
     });
     setAccessMode('read');
+    setSqliteAccessMode('none');
   }, [isOpen, workspaceOptions]);
 
   useEffect(() => {
@@ -90,10 +103,19 @@ export function AgentAccessModal({
     if (!targetWorkspaceId) {
       return;
     }
-    await onUpsert({
+    const request: UpsertWorkspaceAgentGrantRequest = {
       target_workspace_id: targetWorkspaceId,
       access_mode: accessMode,
-    });
+    };
+    if (targetCanGrantSqlite) {
+      request.sqlite_access_mode = sqliteAccessMode;
+    }
+    await onUpsert(request);
+  };
+
+  const handleTargetWorkspaceChange = (workspaceId: string) => {
+    setTargetWorkspaceId(workspaceId);
+    setSqliteAccessMode('none');
   };
 
   if (!isOpen) {
@@ -124,6 +146,10 @@ export function AgentAccessModal({
               can access.
             </small>
           </div>
+          <p className="userspace-agent-access-note userspace-muted" role="note">
+            A SQLite grant covers all data in app.sqlite3, including future data. Only the target
+            workspace owner can change it.
+          </p>
 
           {loading ? (
             <p className="userspace-muted">Loading agent grants...</p>
@@ -145,6 +171,10 @@ export function AgentAccessModal({
                       workspaceOptions.find(
                         (workspace) => workspace.id === grant.target_workspace_id,
                       )?.canGrantReadWrite ?? grant.access_mode === 'read_write';
+                    const grantTargetCanGrantSqlite =
+                      workspaceOptions.find(
+                        (workspace) => workspace.id === grant.target_workspace_id,
+                      )?.canGrantSqlite ?? false;
                     return (
                       <div
                         key={grant.target_workspace_id}
@@ -154,14 +184,29 @@ export function AgentAccessModal({
                           <div className="userspace-agent-access-info">
                             <span>{targetLabel}</span>
                           </div>
+                          <button
+                            className="chat-action-btn"
+                            onClick={() => void onRevoke(grant.target_workspace_id)}
+                            title={`Revoke ${grantModeLabel(grant.access_mode).toLowerCase()} access`}
+                            disabled={
+                              disabled ||
+                              (!grantTargetCanGrantSqlite && grant.sqlite_access_mode !== 'none')
+                            }
+                          >
+                            <X size={14} />
+                          </button>
+                        </div>
+                        <div className="userspace-agent-access-control-row">
+                          <span className="userspace-agent-access-control-label">File/runtime</span>
                           <div
-                            className="userspace-member-role-toggle"
+                            className="userspace-member-role-toggle userspace-agent-access-toggle"
                             role="group"
-                            aria-label={`Access mode for ${targetLabel}`}
+                            aria-label={`File/runtime access for ${targetLabel}`}
                           >
                             <button
                               type="button"
                               className={`userspace-member-role-option ${grant.access_mode === 'read' ? 'active' : ''}`}
+                              aria-pressed={grant.access_mode === 'read'}
                               onClick={() =>
                                 void onUpsert({
                                   target_workspace_id: grant.target_workspace_id,
@@ -175,6 +220,7 @@ export function AgentAccessModal({
                             <button
                               type="button"
                               className={`userspace-member-role-option ${grant.access_mode === 'read_write' ? 'active' : ''}`}
+                              aria-pressed={grant.access_mode === 'read_write'}
                               onClick={() =>
                                 void onUpsert({
                                   target_workspace_id: grant.target_workspace_id,
@@ -186,14 +232,35 @@ export function AgentAccessModal({
                               Read / Write
                             </button>
                           </div>
-                          <button
-                            className="chat-action-btn"
-                            onClick={() => void onRevoke(grant.target_workspace_id)}
-                            title={`Revoke ${grantModeLabel(grant.access_mode).toLowerCase()} access`}
-                            disabled={disabled}
+                        </div>
+                        <div className="userspace-agent-access-control-row">
+                          <span className="userspace-agent-access-control-label">
+                            Shared SQLite
+                          </span>
+                          <div
+                            className="userspace-member-role-toggle userspace-agent-access-toggle"
+                            role="group"
+                            aria-label={`Shared SQLite access for ${targetLabel}`}
                           >
-                            <X size={14} />
-                          </button>
+                            {(['none', 'read', 'read_write'] as const).map((mode) => (
+                              <button
+                                key={mode}
+                                type="button"
+                                className={`userspace-member-role-option ${grant.sqlite_access_mode === mode ? 'active' : ''}`}
+                                aria-pressed={grant.sqlite_access_mode === mode}
+                                onClick={() =>
+                                  void onUpsert({
+                                    target_workspace_id: grant.target_workspace_id,
+                                    access_mode: grant.access_mode,
+                                    sqlite_access_mode: mode,
+                                  })
+                                }
+                                disabled={disabled || !grantTargetCanGrantSqlite}
+                              >
+                                {sqliteModeLabel(mode)}
+                              </button>
+                            ))}
+                          </div>
                         </div>
                         <div className="userspace-agent-access-workspace-id">
                           <small className="userspace-muted">
@@ -213,7 +280,7 @@ export function AgentAccessModal({
                 <select
                   id="userspace-agent-target-select"
                   value={targetWorkspaceId}
-                  onChange={(event) => setTargetWorkspaceId(event.target.value)}
+                  onChange={(event) => handleTargetWorkspaceChange(event.target.value)}
                   disabled={
                     workspaceOptions.length === 0 ||
                     Boolean(savingTargetId) ||
@@ -234,11 +301,12 @@ export function AgentAccessModal({
                 <div
                   className="userspace-member-role-toggle userspace-agent-access-create-toggle"
                   role="group"
-                  aria-label="New grant access mode"
+                  aria-label="New grant file/runtime access"
                 >
                   <button
                     type="button"
                     className={`userspace-member-role-option ${accessMode === 'read' ? 'active' : ''}`}
+                    aria-pressed={accessMode === 'read'}
                     onClick={() => setAccessMode('read')}
                     disabled={
                       workspaceOptions.length === 0 ||
@@ -251,6 +319,7 @@ export function AgentAccessModal({
                   <button
                     type="button"
                     className={`userspace-member-role-option ${accessMode === 'read_write' ? 'active' : ''}`}
+                    aria-pressed={accessMode === 'read_write'}
                     onClick={() => setAccessMode('read_write')}
                     disabled={
                       workspaceOptions.length === 0 ||
@@ -261,6 +330,29 @@ export function AgentAccessModal({
                   >
                     Read / Write
                   </button>
+                </div>
+                <div
+                  className="userspace-member-role-toggle userspace-agent-access-create-toggle"
+                  role="group"
+                  aria-label="New grant Shared SQLite access"
+                >
+                  {(['none', 'read', 'read_write'] as const).map((mode) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      className={`userspace-member-role-option ${sqliteAccessMode === mode ? 'active' : ''}`}
+                      aria-pressed={sqliteAccessMode === mode}
+                      onClick={() => setSqliteAccessMode(mode)}
+                      disabled={
+                        workspaceOptions.length === 0 ||
+                        !targetCanGrantSqlite ||
+                        Boolean(savingTargetId) ||
+                        Boolean(revokingTargetId)
+                      }
+                    >
+                      {sqliteModeLabel(mode)}
+                    </button>
+                  ))}
                 </div>
                 <small className="userspace-muted">
                   Read allows listing, reading, and screenshots. Read / Write also allows file edits

--- a/ragtime/frontend/src/components/shared/WorkspaceSqliteInspectorModal.test.tsx
+++ b/ragtime/frontend/src/components/shared/WorkspaceSqliteInspectorModal.test.tsx
@@ -1,0 +1,293 @@
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  apiMock,
+  eventSourceInstances,
+  toastMock,
+}: {
+  apiMock: Record<string, ReturnType<typeof vi.fn>>;
+  eventSourceInstances: Array<{
+    listeners: Map<string, (event: MessageEvent) => void>;
+    close: ReturnType<typeof vi.fn>;
+  }>;
+  toastMock: [
+    never[],
+    {
+      error: ReturnType<typeof vi.fn>;
+      success: ReturnType<typeof vi.fn>;
+      info: ReturnType<typeof vi.fn>;
+      dismiss: ReturnType<typeof vi.fn>;
+    },
+  ];
+} = vi.hoisted(() => ({
+  apiMock: {
+    listUserSpaceSqliteDatabases: vi.fn(),
+    listUserSpaceSqliteTables: vi.fn(),
+    listUserSpaceSqliteRows: vi.fn(),
+    getUserSpaceSqliteTableSchema: vi.fn(),
+    initializeUserSpaceSqliteDatabase: vi.fn(),
+    importUserSpaceSqliteDatabase: vi.fn(),
+    deleteUserSpaceSqliteDatabase: vi.fn(),
+    exportUserSpaceSqliteDatabase: vi.fn(),
+    exportUserSpaceSqliteTable: vi.fn(),
+    importUserSpaceSqliteTable: vi.fn(),
+    createUserSpaceSqliteTable: vi.fn(),
+    dropUserSpaceSqliteTable: vi.fn(),
+    insertUserSpaceSqliteRow: vi.fn(),
+    updateUserSpaceSqliteRow: vi.fn(),
+    deleteUserSpaceSqliteRow: vi.fn(),
+    alterUserSpaceSqliteTable: vi.fn(),
+    queryUserSpaceSqliteDatabase: vi.fn(),
+  },
+  eventSourceInstances: [],
+  toastMock: [[], { error: vi.fn(), success: vi.fn(), info: vi.fn(), dismiss: vi.fn() }],
+}));
+
+vi.mock('@/api/client', () => ({
+  api: apiMock,
+}));
+
+vi.mock('./Toast', () => ({
+  useToast: () => toastMock,
+  ToastContainer: () => null,
+}));
+
+import { WorkspaceSqliteInspectorModal } from './WorkspaceSqliteInspectorModal';
+
+type InspectorDatabase = {
+  name: string;
+  relative_path: string;
+  size_bytes: number;
+  table_count: number;
+  last_modified_ms: number | null;
+  owner_workspace_id: string;
+  owner_workspace_name: string;
+  ownership: 'owned' | 'linked';
+  access_mode: 'read' | 'read_write';
+  persistence_mode: 'include' | 'exclude';
+  initialized: boolean;
+};
+
+const owned: InspectorDatabase = {
+  name: 'app.sqlite3',
+  relative_path: '.ragtime/db/app.sqlite3',
+  size_bytes: 1024,
+  table_count: 2,
+  last_modified_ms: 1_786_032_000_000,
+  owner_workspace_id: 'source-ws',
+  owner_workspace_name: 'Source Workspace',
+  ownership: 'owned',
+  access_mode: 'read_write',
+  persistence_mode: 'include',
+  initialized: true,
+};
+
+const linkedRead: InspectorDatabase = {
+  ...owned,
+  owner_workspace_id: 'target-read',
+  owner_workspace_name: 'Reporting',
+  ownership: 'linked',
+  access_mode: 'read',
+};
+
+const linkedWriteMissing: InspectorDatabase = {
+  ...owned,
+  size_bytes: 0,
+  table_count: 0,
+  last_modified_ms: null,
+  owner_workspace_id: 'target-write',
+  owner_workspace_name: 'Operations',
+  ownership: 'linked',
+  access_mode: 'read_write',
+  persistence_mode: 'exclude',
+  initialized: false,
+};
+
+const listResponse = {
+  workspace_id: 'source-ws',
+  databases: [owned, linkedRead, linkedWriteMissing],
+  total_bytes: 1024,
+  default_database_name: 'app.sqlite3',
+  persistence_mode: 'include' as const,
+};
+
+const tableListResponse = {
+  workspace_id: 'source-ws',
+  database: linkedRead,
+  tables: [{ name: 'events', type: 'table', row_count: 1 }],
+  persistence_mode: 'include' as const,
+  mode_promoted: false,
+};
+
+const rowPageResponse = {
+  database: linkedRead,
+  table: { name: 'events', type: 'table', row_count: 1 },
+  columns: [{ name: 'id', type: 'INTEGER', primary_key: true, not_null: true }],
+  rows: [{ id: 1 }],
+  total: 1,
+  offset: 0,
+  limit: 50,
+  elapsed_ms: 3,
+};
+
+const schemaResponse = {
+  database: linkedRead,
+  table: { name: 'events', type: 'table', row_count: 1 },
+  schema: {
+    columns: [{ name: 'id', type: 'INTEGER', primary_key: true, not_null: true }],
+    indexes: [],
+    foreign_keys: [],
+    create_sql: 'CREATE TABLE events (id INTEGER PRIMARY KEY);',
+  },
+  mode_promoted: false,
+};
+
+class MockEventSource {
+  listeners = new Map<string, (event: MessageEvent) => void>();
+  close = vi.fn();
+
+  constructor(_url: string) {
+    eventSourceInstances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    this.listeners.set(type, listener);
+  }
+}
+
+function renderModal() {
+  return render(
+    <WorkspaceSqliteInspectorModal
+      isOpen
+      workspaceId="source-ws"
+      workspaceName="Source Workspace"
+      canEdit
+      onClose={vi.fn()}
+      onPersistencePromoted={vi.fn()}
+    />,
+  );
+}
+
+describe('WorkspaceSqliteInspectorModal', () => {
+  beforeEach(() => {
+    vi.stubGlobal('EventSource', MockEventSource as unknown as typeof EventSource);
+    eventSourceInstances.length = 0;
+    Object.values(apiMock).forEach((mockFn) => mockFn.mockReset());
+    apiMock.listUserSpaceSqliteDatabases.mockResolvedValue(listResponse);
+    apiMock.listUserSpaceSqliteTables.mockResolvedValue(tableListResponse);
+    apiMock.listUserSpaceSqliteRows.mockResolvedValue(rowPageResponse);
+    apiMock.getUserSpaceSqliteTableSchema.mockResolvedValue(schemaResponse);
+    apiMock.queryUserSpaceSqliteDatabase.mockResolvedValue({
+      sql: 'SELECT 1;',
+      columns: ['value'],
+      rows: [{ value: 1 }],
+      row_count: 1,
+      truncated: false,
+      elapsed_ms: 1,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders grouped workspace and linked database sections with ownership text and missing-state copy', async () => {
+    renderModal();
+
+    const workspaceHeading = await screen.findByRole('heading', { name: 'Workspace databases' });
+    const linkedHeading = screen.getByRole('heading', { name: 'Linked databases' });
+
+    const workspaceSection = workspaceHeading.closest('section');
+    const linkedSection = linkedHeading.closest('section');
+
+    expect(workspaceSection).not.toBeNull();
+    expect(linkedSection).not.toBeNull();
+    expect(within(workspaceSection as HTMLElement).getByText('Owned')).toBeTruthy();
+    expect(within(linkedSection as HTMLElement).getByText('Read only')).toBeTruthy();
+    expect(within(linkedSection as HTMLElement).getByText('Read / Write')).toBeTruthy();
+    expect(within(linkedSection as HTMLElement).getByText('Linked from Reporting')).toBeTruthy();
+    expect(within(linkedSection as HTMLElement).getByText('Linked from Operations')).toBeTruthy();
+    expect(within(linkedSection as HTMLElement).getByText('Not initialized')).toBeTruthy();
+  });
+
+  it('routes linked reads through the owner workspace, keeps read-only access visible, and reconciles SSE by owner-aware key', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    const linkedSection = (
+      await screen.findByRole('heading', { name: 'Linked databases' })
+    ).closest('section');
+    expect(linkedSection).not.toBeNull();
+
+    await user.click(
+      within(linkedSection as HTMLElement).getAllByRole('button', { name: /app\.sqlite3/i })[0],
+    );
+
+    await waitFor(() => {
+      expect(apiMock.listUserSpaceSqliteTables).toHaveBeenCalledWith(
+        'source-ws',
+        'app.sqlite3',
+        'target-read',
+      );
+    });
+
+    expect(screen.getByText(/Linked from Reporting/i)).toBeTruthy();
+    expect(screen.getByText(/Read only/i)).toBeTruthy();
+    expect(screen.queryByText(/Changes affect the Reporting workspace\./i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /New table/i })).toBeNull();
+    expect(screen.queryByTitle('Import CSV')).toBeNull();
+    expect(screen.queryByTitle('Drop table')).toBeNull();
+    expect(screen.getByRole('button', { name: /Console/i })).toBeTruthy();
+    expect(screen.getByTitle('Export table')).toBeTruthy();
+
+    const databasesListener = eventSourceInstances[0]?.listeners.get('databases');
+    expect(databasesListener).toBeTypeOf('function');
+    databasesListener?.(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          ...listResponse,
+          databases: [
+            { ...owned, table_count: 9 },
+            { ...linkedRead, owner_workspace_name: 'Reporting Updated', table_count: 4 },
+            linkedWriteMissing,
+          ],
+        }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Linked from Reporting Updated/i)).toBeTruthy();
+    });
+    expect(screen.queryByText(/Linked from Source Workspace/i)).toBeNull();
+  });
+
+  it('opens missing linked read-write databases without table loading and exposes initialize and import actions', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    const linkedSection = (
+      await screen.findByRole('heading', { name: 'Linked databases' })
+    ).closest('section');
+    expect(linkedSection).not.toBeNull();
+
+    await user.click(
+      within(linkedSection as HTMLElement).getAllByRole('button', { name: /app\.sqlite3/i })[1],
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Linked from Operations/i)).toBeTruthy();
+    });
+
+    expect(apiMock.listUserSpaceSqliteTables).not.toHaveBeenCalledWith(
+      'source-ws',
+      'app.sqlite3',
+      'target-write',
+    );
+    expect(screen.getAllByText(/Not initialized/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /Initialize app\.sqlite3/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Import database/i })).toBeTruthy();
+  });
+});

--- a/ragtime/frontend/src/components/shared/WorkspaceSqliteInspectorModal.test.tsx
+++ b/ragtime/frontend/src/components/shared/WorkspaceSqliteInspectorModal.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -70,6 +70,11 @@ type InspectorDatabase = {
   initialized: boolean;
 };
 
+type LegacyInspectorDatabase = Pick<
+  InspectorDatabase,
+  'name' | 'relative_path' | 'size_bytes' | 'table_count' | 'last_modified_ms'
+>;
+
 const owned: InspectorDatabase = {
   name: 'app.sqlite3',
   relative_path: '.ragtime/db/app.sqlite3',
@@ -103,6 +108,14 @@ const linkedWriteMissing: InspectorDatabase = {
   access_mode: 'read_write',
   persistence_mode: 'exclude',
   initialized: false,
+};
+
+const legacyOwned: LegacyInspectorDatabase = {
+  name: 'app.sqlite3',
+  relative_path: '.ragtime/db/app.sqlite3',
+  size_bytes: 0,
+  table_count: 0,
+  last_modified_ms: 1_786_032_000_000,
 };
 
 const listResponse = {
@@ -194,37 +207,69 @@ describe('WorkspaceSqliteInspectorModal', () => {
     vi.unstubAllGlobals();
   });
 
-  it('renders grouped workspace and linked database sections with ownership text and missing-state copy', async () => {
+  it('renders one unified database grid with owned and linked cards', async () => {
+    apiMock.listUserSpaceSqliteDatabases.mockResolvedValue({
+      ...listResponse,
+      databases: [legacyOwned, linkedRead, linkedWriteMissing],
+    });
     renderModal();
 
-    const workspaceHeading = await screen.findByRole('heading', { name: 'Workspace databases' });
-    const linkedHeading = screen.getByRole('heading', { name: 'Linked databases' });
+    await screen.findAllByRole('button', { name: /^app\.sqlite3/i });
 
-    const workspaceSection = workspaceHeading.closest('section');
-    const linkedSection = linkedHeading.closest('section');
+    expect(screen.queryByRole('heading', { name: 'Workspace databases' })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Linked databases' })).toBeNull();
+    expect(screen.getByText('0 tables')).toBeTruthy();
+    expect(screen.getByText('0 B')).toBeTruthy();
+    expect(screen.queryByText('Owned')).toBeNull();
+    expect(screen.queryByText('Read only')).toBeNull();
+    expect(screen.queryByText('Read / Write')).toBeNull();
+    expect(screen.getByText('Linked from Reporting')).toBeTruthy();
+    expect(screen.getByText('Linked from Operations')).toBeTruthy();
+    expect(screen.getByText('Not initialized')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: /^app\.sqlite3/i })).toHaveLength(3);
 
-    expect(workspaceSection).not.toBeNull();
-    expect(linkedSection).not.toBeNull();
-    expect(within(workspaceSection as HTMLElement).getByText('Owned')).toBeTruthy();
-    expect(within(linkedSection as HTMLElement).getByText('Read only')).toBeTruthy();
-    expect(within(linkedSection as HTMLElement).getByText('Read / Write')).toBeTruthy();
-    expect(within(linkedSection as HTMLElement).getByText('Linked from Reporting')).toBeTruthy();
-    expect(within(linkedSection as HTMLElement).getByText('Linked from Operations')).toBeTruthy();
-    expect(within(linkedSection as HTMLElement).getByText('Not initialized')).toBeTruthy();
+    const cards = screen.getAllByRole('button', { name: /^app\.sqlite3/i });
+    const ownedCard = cards[0]?.closest('.userspace-sqlite-card');
+    expect(ownedCard).toBeTruthy();
+    expect(ownedCard?.querySelector('.userspace-sqlite-card-badge')).toBeNull();
+
+    const reportingCard = screen
+      .getByText('Linked from Reporting')
+      .closest('.userspace-sqlite-card');
+    expect(reportingCard).toBeTruthy();
+    expect(reportingCard?.querySelector('.lucide-database')).toBeTruthy();
+    expect(reportingCard?.querySelector('.lucide-link-2')).toBeNull();
+    const modifiedSpans = screen.getAllByText(/^Modified /i);
+    expect(modifiedSpans.length).toBeGreaterThan(0);
+    modifiedSpans.forEach((modifiedSpan) => {
+      expect(modifiedSpan.classList.contains('userspace-sqlite-card-modified')).toBe(true);
+    });
+    const reportingSource = screen.getByText('Linked from Reporting');
+    const reportingMeta = reportingSource.closest('.userspace-sqlite-card-meta');
+    expect(reportingMeta).toBeTruthy();
+    const reportingModified = reportingMeta?.querySelector('.userspace-sqlite-card-modified');
+    expect(reportingModified).toBeTruthy();
+    const reportingBadge = reportingCard?.querySelector('.userspace-sqlite-card-badge');
+    expect(reportingBadge?.textContent).toBe('Reporting');
+    expect(reportingBadge?.getAttribute('title')).toBe('Reporting');
+    expect(reportingSource.classList.contains('userspace-sqlite-card-source')).toBe(true);
+    expect(reportingModified?.nextElementSibling).toBe(reportingSource);
+    expect(reportingMeta?.lastElementChild).toBe(reportingSource);
+
+    const operationsCard = screen
+      .getByText('Linked from Operations')
+      .closest('.userspace-sqlite-card');
+    expect(operationsCard).toBeTruthy();
+    const operationsBadge = operationsCard?.querySelector('.userspace-sqlite-card-badge');
+    expect(operationsBadge?.textContent).toBe('Operations');
+    expect(operationsBadge?.getAttribute('title')).toBe('Operations');
   });
 
   it('routes linked reads through the owner workspace, keeps read-only access visible, and reconciles SSE by owner-aware key', async () => {
     const user = userEvent.setup();
     renderModal();
 
-    const linkedSection = (
-      await screen.findByRole('heading', { name: 'Linked databases' })
-    ).closest('section');
-    expect(linkedSection).not.toBeNull();
-
-    await user.click(
-      within(linkedSection as HTMLElement).getAllByRole('button', { name: /app\.sqlite3/i })[0],
-    );
+    await user.click((await screen.findAllByRole('button', { name: /^app\.sqlite3/i }))[1]);
 
     await waitFor(() => {
       expect(apiMock.listUserSpaceSqliteTables).toHaveBeenCalledWith(
@@ -264,18 +309,39 @@ describe('WorkspaceSqliteInspectorModal', () => {
     expect(screen.queryByText(/Linked from Source Workspace/i)).toBeNull();
   });
 
+  it('normalizes legacy owned database summaries for table loading and editing controls', async () => {
+    const user = userEvent.setup();
+    apiMock.listUserSpaceSqliteDatabases.mockResolvedValue({
+      ...listResponse,
+      databases: [legacyOwned, linkedRead],
+    });
+    apiMock.listUserSpaceSqliteTables.mockResolvedValue({
+      ...tableListResponse,
+      database: legacyOwned,
+    });
+
+    renderModal();
+
+    await user.click((await screen.findAllByRole('button', { name: /^app\.sqlite3/i }))[0]);
+
+    await waitFor(() => {
+      expect(apiMock.listUserSpaceSqliteTables).toHaveBeenCalledWith(
+        'source-ws',
+        'app.sqlite3',
+        'source-ws',
+      );
+    });
+
+    expect(screen.getByRole('button', { name: /New table/i })).toBeTruthy();
+    expect(screen.getByTitle('Import CSV')).toBeTruthy();
+    expect(screen.getByTitle('Drop table')).toBeTruthy();
+  });
+
   it('opens missing linked read-write databases without table loading and exposes initialize and import actions', async () => {
     const user = userEvent.setup();
     renderModal();
 
-    const linkedSection = (
-      await screen.findByRole('heading', { name: 'Linked databases' })
-    ).closest('section');
-    expect(linkedSection).not.toBeNull();
-
-    await user.click(
-      within(linkedSection as HTMLElement).getAllByRole('button', { name: /app\.sqlite3/i })[1],
-    );
+    await user.click((await screen.findAllByRole('button', { name: /^app\.sqlite3/i }))[2]);
 
     await waitFor(() => {
       expect(screen.getByText(/Linked from Operations/i)).toBeTruthy();

--- a/ragtime/frontend/src/components/shared/WorkspaceSqliteInspectorModal.tsx
+++ b/ragtime/frontend/src/components/shared/WorkspaceSqliteInspectorModal.tsx
@@ -6,6 +6,7 @@ import {
   Download,
   FileText,
   Filter,
+  Link2,
   Loader2,
   PlusCircle,
   RefreshCw,
@@ -46,7 +47,27 @@ interface WorkspaceSqliteInspectorModalProps {
   workspaceName?: string;
   canEdit: boolean;
   onClose: () => void;
-  onPersistencePromoted?: () => void;
+  onPersistencePromoted?: (workspaceId: string) => void;
+}
+
+type InspectorDatabaseSummary = SqliteInspectorDatabaseSummary;
+
+function asInspectorDatabase(database: SqliteInspectorDatabaseSummary): InspectorDatabaseSummary {
+  return database;
+}
+
+function databaseKey(
+  database: Pick<InspectorDatabaseSummary, 'owner_workspace_id' | 'name'>,
+): string {
+  return `${database.owner_workspace_id}:${database.name}`;
+}
+
+function getDatabaseAccessLabel(accessMode: SqliteInspectorDatabaseSummary['access_mode']): string {
+  return accessMode === 'read_write' ? 'Read / Write' : 'Read only';
+}
+
+function isDatabaseWritable(database: InspectorDatabaseSummary | null): boolean {
+  return database?.access_mode === 'read_write';
 }
 
 function formatBytes(bytes: number): string {
@@ -244,15 +265,13 @@ export function WorkspaceSqliteInspectorModal({
   const [pendingDatabaseImportName, setPendingDatabaseImportName] = useState<string | null>(null);
   const [pendingTableImportName, setPendingTableImportName] = useState<string | null>(null);
   const [step, setStep] = useState<WizardStep>('databases');
-  const [databases, setDatabases] = useState<SqliteInspectorDatabaseSummary[]>([]);
+  const [databases, setDatabases] = useState<InspectorDatabaseSummary[]>([]);
   const [defaultDatabaseName, setDefaultDatabaseName] = useState<string>('app.sqlite3');
   const [persistenceMode, setPersistenceMode] = useState<'include' | 'exclude'>('include');
   const [totalBytes, setTotalBytes] = useState<number>(0);
   const [loadingDatabases, setLoadingDatabases] = useState(false);
 
-  const [selectedDatabase, setSelectedDatabase] = useState<SqliteInspectorDatabaseSummary | null>(
-    null,
-  );
+  const [selectedDatabase, setSelectedDatabase] = useState<InspectorDatabaseSummary | null>(null);
   const [tables, setTables] = useState<SqliteInspectorTableSummary[]>([]);
   const [loadingTables, setLoadingTables] = useState(false);
 
@@ -309,7 +328,7 @@ export function WorkspaceSqliteInspectorModal({
     setLoadingDatabases(true);
     try {
       const result = await api.listUserSpaceSqliteDatabases(workspaceId);
-      setDatabases(result.databases);
+      setDatabases(result.databases.map(asInspectorDatabase));
       setDefaultDatabaseName(result.default_database_name);
       setPersistenceMode(result.persistence_mode);
       setTotalBytes(result.total_bytes);
@@ -321,12 +340,16 @@ export function WorkspaceSqliteInspectorModal({
   }, [toastError, workspaceId]);
 
   const loadTables = useCallback(
-    async (database: SqliteInspectorDatabaseSummary) => {
+    async (database: InspectorDatabaseSummary) => {
       if (!workspaceId) return;
       setLoadingTables(true);
       try {
-        const result = await api.listUserSpaceSqliteTables(workspaceId, database.name);
-        setSelectedDatabase(result.database);
+        const result = await api.listUserSpaceSqliteTables(
+          workspaceId,
+          database.name,
+          database.owner_workspace_id,
+        );
+        setSelectedDatabase(asInspectorDatabase(result.database));
         setTables(result.tables);
         setPersistenceMode(result.persistence_mode);
       } catch (err) {
@@ -339,14 +362,22 @@ export function WorkspaceSqliteInspectorModal({
   );
 
   const loadRows = useCallback(
-    async (databaseName: string, tableName: string, offset: number, limit: number) => {
+    async (
+      database: InspectorDatabaseSummary,
+      tableName: string,
+      offset: number,
+      limit: number,
+    ) => {
       if (!workspaceId) return;
       setLoadingRows(true);
       try {
-        const result = await api.listUserSpaceSqliteRows(workspaceId, databaseName, tableName, {
-          offset,
-          limit,
-        });
+        const result = await api.listUserSpaceSqliteRows(
+          workspaceId,
+          database.name,
+          tableName,
+          { offset, limit },
+          database.owner_workspace_id,
+        );
         setRowPage(result);
         setRowOffset(result.offset);
         setRowLimit(result.limit);
@@ -360,14 +391,15 @@ export function WorkspaceSqliteInspectorModal({
   );
 
   const loadSchema = useCallback(
-    async (databaseName: string, tableName: string) => {
+    async (database: InspectorDatabaseSummary, tableName: string) => {
       if (!workspaceId) return;
       setLoadingSchema(true);
       try {
         const result = await api.getUserSpaceSqliteTableSchema(
           workspaceId,
-          databaseName,
+          database.name,
           tableName,
+          database.owner_workspace_id,
         );
         setTableSchema(result.schema);
       } catch (err) {
@@ -392,13 +424,14 @@ export function WorkspaceSqliteInspectorModal({
           persistence_mode: 'include' | 'exclude';
           total_bytes: number;
         };
-        setDatabases(result.databases);
+        const nextDatabases = result.databases.map(asInspectorDatabase);
+        setDatabases(nextDatabases);
         setDefaultDatabaseName(result.default_database_name);
         setPersistenceMode(result.persistence_mode);
         setTotalBytes(result.total_bytes);
         setSelectedDatabase((current) => {
           if (!current) return current;
-          return result.databases.find((db) => db.name === current.name) ?? current;
+          return nextDatabases.find((db) => databaseKey(db) === databaseKey(current)) ?? current;
         });
       } catch {
         // Ignore malformed event payloads; the normal request path still reports errors.
@@ -416,42 +449,81 @@ export function WorkspaceSqliteInspectorModal({
   }, [isOpen, loadDatabases, reset]);
 
   const handlePromotionFlag = useCallback(
-    (promoted: boolean) => {
+    (
+      promoted: boolean,
+      promotedWorkspaceId: string,
+      nextDatabase?: InspectorDatabaseSummary | null,
+    ) => {
       if (!promoted) return;
-      setPersistenceMode('include');
-      onPersistencePromoted?.();
+      if (nextDatabase) {
+        setSelectedDatabase({ ...nextDatabase, persistence_mode: 'include' });
+      } else if (selectedDatabase && selectedDatabase.owner_workspace_id === promotedWorkspaceId) {
+        setSelectedDatabase({ ...selectedDatabase, persistence_mode: 'include' });
+      }
+      setDatabases((current) =>
+        current.map((database) =>
+          database.owner_workspace_id === promotedWorkspaceId
+            ? { ...database, persistence_mode: 'include' }
+            : database,
+        ),
+      );
+      if (promotedWorkspaceId === workspaceId) {
+        setPersistenceMode('include');
+      }
+      onPersistencePromoted?.(promotedWorkspaceId);
       toastSuccess(
         'Two-lane persistence enabled: SQLite changes will be included in workspace snapshots.',
       );
     },
-    [onPersistencePromoted, toastSuccess],
+    [onPersistencePromoted, selectedDatabase, toastSuccess, workspaceId],
   );
 
-  const handleInitializeDatabase = useCallback(async () => {
-    if (!workspaceId || !canEdit) return;
-    try {
-      const result = await api.initializeUserSpaceSqliteDatabase(workspaceId, {});
-      // Pre-fetch the destination data before transitioning so the new step
-      // renders fully populated.
-      await Promise.all([loadDatabases(), loadTables(result.database)]);
-      handlePromotionFlag(result.mode_promoted);
-      toastSuccess(`Initialized ${result.database.name}`);
-      setStep('database');
-    } catch (err) {
-      toastError(err instanceof Error ? err.message : 'Failed to initialize database');
-    }
-  }, [
-    canEdit,
-    handlePromotionFlag,
-    loadDatabases,
-    loadTables,
-    toastSuccess,
-    toastError,
-    workspaceId,
-  ]);
+  const handleInitializeDatabase = useCallback(
+    async (database?: InspectorDatabaseSummary | null) => {
+      if (!workspaceId) return;
+      const targetDatabase = database ?? selectedDatabase;
+      const ownerWorkspaceId = targetDatabase?.owner_workspace_id;
+      const canWrite = targetDatabase ? isDatabaseWritable(targetDatabase) : canEdit;
+      if (!canWrite) return;
+      try {
+        const result = await api.initializeUserSpaceSqliteDatabase(
+          workspaceId,
+          {},
+          ownerWorkspaceId,
+        );
+        const nextDatabase = asInspectorDatabase(result.database);
+        // Pre-fetch the destination data before transitioning so the new step
+        // renders fully populated.
+        await Promise.all([loadDatabases(), loadTables(nextDatabase)]);
+        handlePromotionFlag(result.mode_promoted, nextDatabase.owner_workspace_id, nextDatabase);
+        toastSuccess(`Initialized ${result.database.name}`);
+        setStep('database');
+      } catch (err) {
+        toastError(err instanceof Error ? err.message : 'Failed to initialize database');
+      }
+    },
+    [
+      canEdit,
+      handlePromotionFlag,
+      loadDatabases,
+      loadTables,
+      selectedDatabase,
+      toastSuccess,
+      toastError,
+      workspaceId,
+    ],
+  );
 
   const handleOpenDatabase = useCallback(
-    async (database: SqliteInspectorDatabaseSummary) => {
+    async (database: InspectorDatabaseSummary) => {
+      setSelectedDatabase(database);
+      if (!database.initialized) {
+        setTables([]);
+        setTableSchema(null);
+        setRowPage(null);
+        setStep('database');
+        return;
+      }
       await loadTables(database);
       setStep('database');
     },
@@ -463,8 +535,8 @@ export function WorkspaceSqliteInspectorModal({
       if (!selectedDatabase) return;
       // Fetch rows + schema before navigating so the table view never flashes empty.
       await Promise.all([
-        loadRows(selectedDatabase.name, table.name, 0, DEFAULT_ROW_PAGE_SIZE),
-        loadSchema(selectedDatabase.name, table.name),
+        loadRows(selectedDatabase, table.name, 0, DEFAULT_ROW_PAGE_SIZE),
+        loadSchema(selectedDatabase, table.name),
       ]);
       setSelectedTableName(table.name);
       setTableSubTab('rows');
@@ -477,24 +549,43 @@ export function WorkspaceSqliteInspectorModal({
   );
 
   const handleDeleteDatabase = useCallback(
-    async (database: SqliteInspectorDatabaseSummary) => {
-      if (!workspaceId || !canEdit) return;
+    async (database: InspectorDatabaseSummary) => {
+      if (!workspaceId || !isDatabaseWritable(database)) return;
       try {
-        await api.deleteUserSpaceSqliteDatabase(workspaceId, database.name);
+        await api.deleteUserSpaceSqliteDatabase(
+          workspaceId,
+          database.name,
+          database.owner_workspace_id,
+        );
         toastSuccess(`Deleted ${database.name}`);
+        if (selectedDatabase && databaseKey(selectedDatabase) === databaseKey(database)) {
+          setSelectedDatabase({
+            ...database,
+            initialized: false,
+            table_count: 0,
+            size_bytes: 0,
+            last_modified_ms: null,
+          });
+          setTables([]);
+          setStep('databases');
+        }
         await loadDatabases();
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to delete database');
       }
     },
-    [canEdit, loadDatabases, toastSuccess, toastError, workspaceId],
+    [loadDatabases, selectedDatabase, toastSuccess, toastError, workspaceId],
   );
 
   const handleExportDatabase = useCallback(
-    async (database: SqliteInspectorDatabaseSummary) => {
+    async (database: InspectorDatabaseSummary) => {
       if (!workspaceId) return;
       try {
-        await api.exportUserSpaceSqliteDatabase(workspaceId, database.name);
+        await api.exportUserSpaceSqliteDatabase(
+          workspaceId,
+          database.name,
+          database.owner_workspace_id,
+        );
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to export database');
       }
@@ -502,30 +593,34 @@ export function WorkspaceSqliteInspectorModal({
     [toastError, workspaceId],
   );
 
-  const handleRequestImportDatabase = useCallback(
-    (databaseName: string) => {
-      if (!canEdit) return;
-      setPendingDatabaseImportName(databaseName);
-      databaseImportInputRef.current?.click();
-    },
-    [canEdit],
-  );
+  const handleRequestImportDatabase = useCallback((database: InspectorDatabaseSummary) => {
+    if (!isDatabaseWritable(database)) return;
+    setSelectedDatabase(database);
+    setPendingDatabaseImportName(databaseKey(database));
+    databaseImportInputRef.current?.click();
+  }, []);
 
   const handleDatabaseImportFile = useCallback(
     async (file: File | null) => {
-      if (!workspaceId || !canEdit || !pendingDatabaseImportName || !file) return;
+      if (!workspaceId || !pendingDatabaseImportName || !file) return;
+      const targetDatabase = databases.find(
+        (database) => databaseKey(database) === pendingDatabaseImportName,
+      );
+      if (!targetDatabase || !isDatabaseWritable(targetDatabase)) return;
       const formData = new FormData();
       formData.append('database_file', file);
       try {
         const result = await api.importUserSpaceSqliteDatabase(
           workspaceId,
-          pendingDatabaseImportName,
+          targetDatabase.name,
           formData,
+          targetDatabase.owner_workspace_id,
         );
-        handlePromotionFlag(result.mode_promoted);
+        const nextDatabase = asInspectorDatabase(result.database);
+        handlePromotionFlag(result.mode_promoted, nextDatabase.owner_workspace_id, nextDatabase);
         toastSuccess(`Imported ${result.database.name}`);
         await loadDatabases();
-        await loadTables(result.database);
+        await loadTables(nextDatabase);
         setStep('database');
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to import database');
@@ -535,7 +630,7 @@ export function WorkspaceSqliteInspectorModal({
       }
     },
     [
-      canEdit,
+      databases,
       handlePromotionFlag,
       loadDatabases,
       loadTables,
@@ -547,7 +642,7 @@ export function WorkspaceSqliteInspectorModal({
   );
 
   const handleCreateTable = useCallback(async () => {
-    if (!workspaceId || !canEdit || !selectedDatabase) return;
+    if (!workspaceId || !selectedDatabase || !isDatabaseWritable(selectedDatabase)) return;
     setCreatingTable(true);
     try {
       const cleanColumns: SqliteInspectorColumnSpec[] = newTableColumns
@@ -559,11 +654,20 @@ export function WorkspaceSqliteInspectorModal({
           default_value: c.default_value?.trim() || undefined,
         }))
         .filter((c) => c.name);
-      const result = await api.createUserSpaceSqliteTable(workspaceId, selectedDatabase.name, {
-        name: newTableName.trim(),
-        columns: cleanColumns,
-      });
-      handlePromotionFlag(result.mode_promoted);
+      const result = await api.createUserSpaceSqliteTable(
+        workspaceId,
+        selectedDatabase.name,
+        {
+          name: newTableName.trim(),
+          columns: cleanColumns,
+        },
+        selectedDatabase.owner_workspace_id,
+      );
+      handlePromotionFlag(
+        result.mode_promoted,
+        selectedDatabase.owner_workspace_id,
+        selectedDatabase,
+      );
       toastSuccess(`Created table ${result.table.name}`);
       setShowCreateTableForm(false);
       setNewTableName('');
@@ -575,7 +679,6 @@ export function WorkspaceSqliteInspectorModal({
       setCreatingTable(false);
     }
   }, [
-    canEdit,
     handlePromotionFlag,
     loadTables,
     newTableColumns,
@@ -588,36 +691,38 @@ export function WorkspaceSqliteInspectorModal({
 
   const handleDropTable = useCallback(
     async (table: SqliteInspectorTableSummary) => {
-      if (!workspaceId || !canEdit || !selectedDatabase) return;
+      if (!workspaceId || !selectedDatabase || !isDatabaseWritable(selectedDatabase)) return;
       try {
         const result = await api.dropUserSpaceSqliteTable(
           workspaceId,
           selectedDatabase.name,
           table.name,
+          selectedDatabase.owner_workspace_id,
         );
-        handlePromotionFlag(result.mode_promoted);
+        handlePromotionFlag(
+          result.mode_promoted,
+          selectedDatabase.owner_workspace_id,
+          selectedDatabase,
+        );
         toastSuccess(`Dropped table ${table.name}`);
         await loadTables(selectedDatabase);
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to drop table');
       }
     },
-    [
-      canEdit,
-      handlePromotionFlag,
-      loadTables,
-      selectedDatabase,
-      toastSuccess,
-      toastError,
-      workspaceId,
-    ],
+    [handlePromotionFlag, loadTables, selectedDatabase, toastSuccess, toastError, workspaceId],
   );
 
   const handleExportTable = useCallback(
     async (table: SqliteInspectorTableSummary) => {
       if (!workspaceId || !selectedDatabase) return;
       try {
-        await api.exportUserSpaceSqliteTable(workspaceId, selectedDatabase.name, table.name);
+        await api.exportUserSpaceSqliteTable(
+          workspaceId,
+          selectedDatabase.name,
+          table.name,
+          selectedDatabase.owner_workspace_id,
+        );
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to export table');
       }
@@ -627,16 +732,23 @@ export function WorkspaceSqliteInspectorModal({
 
   const handleRequestImportTable = useCallback(
     (tableName: string) => {
-      if (!canEdit) return;
+      if (!selectedDatabase || !isDatabaseWritable(selectedDatabase)) return;
       setPendingTableImportName(tableName);
       tableImportInputRef.current?.click();
     },
-    [canEdit],
+    [selectedDatabase],
   );
 
   const handleTableImportFile = useCallback(
     async (file: File | null) => {
-      if (!workspaceId || !canEdit || !selectedDatabase || !pendingTableImportName || !file) return;
+      if (
+        !workspaceId ||
+        !selectedDatabase ||
+        !pendingTableImportName ||
+        !file ||
+        !isDatabaseWritable(selectedDatabase)
+      )
+        return;
       const formData = new FormData();
       formData.append('csv_file', file);
       try {
@@ -645,13 +757,18 @@ export function WorkspaceSqliteInspectorModal({
           selectedDatabase.name,
           pendingTableImportName,
           formData,
+          selectedDatabase.owner_workspace_id,
         );
-        handlePromotionFlag(result.mode_promoted);
+        handlePromotionFlag(
+          result.mode_promoted,
+          selectedDatabase.owner_workspace_id,
+          selectedDatabase,
+        );
         toastSuccess(`Imported rows into ${result.table.name}`);
         await loadTables(selectedDatabase);
         if (selectedTableName === pendingTableImportName) {
-          await loadRows(selectedDatabase.name, pendingTableImportName, rowOffset, rowLimit);
-          await loadSchema(selectedDatabase.name, pendingTableImportName);
+          await loadRows(selectedDatabase, pendingTableImportName, rowOffset, rowLimit);
+          await loadSchema(selectedDatabase, pendingTableImportName);
         }
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to import table');
@@ -661,7 +778,6 @@ export function WorkspaceSqliteInspectorModal({
       }
     },
     [
-      canEdit,
       handlePromotionFlag,
       loadRows,
       loadSchema,
@@ -678,7 +794,14 @@ export function WorkspaceSqliteInspectorModal({
   );
 
   const handleSaveNewRow = useCallback(async () => {
-    if (!workspaceId || !canEdit || !selectedDatabase || !selectedTableName || !tableSchema) return;
+    if (
+      !workspaceId ||
+      !selectedDatabase ||
+      !selectedTableName ||
+      !tableSchema ||
+      !isDatabaseWritable(selectedDatabase)
+    )
+      return;
     setSavingRow(true);
     try {
       const values: Record<string, unknown> = {};
@@ -695,12 +818,17 @@ export function WorkspaceSqliteInspectorModal({
         selectedDatabase.name,
         selectedTableName,
         { values },
+        selectedDatabase.owner_workspace_id,
       );
-      handlePromotionFlag(result.mode_promoted);
+      handlePromotionFlag(
+        result.mode_promoted,
+        selectedDatabase.owner_workspace_id,
+        selectedDatabase,
+      );
       toastSuccess('Row inserted');
       setShowAddRowForm(false);
       setNewRowValues({});
-      await loadRows(selectedDatabase.name, selectedTableName, rowOffset, rowLimit);
+      await loadRows(selectedDatabase, selectedTableName, rowOffset, rowLimit);
       await loadTables(selectedDatabase);
     } catch (err) {
       toastError(err instanceof Error ? err.message : 'Failed to insert row');
@@ -708,7 +836,6 @@ export function WorkspaceSqliteInspectorModal({
       setSavingRow(false);
     }
   }, [
-    canEdit,
     handlePromotionFlag,
     loadRows,
     loadTables,
@@ -744,7 +871,13 @@ export function WorkspaceSqliteInspectorModal({
 
   const handleUpdateCell = useCallback(
     async (originalRow: Record<string, unknown>, colName: string, newValue: unknown) => {
-      if (!workspaceId || !canEdit || !selectedDatabase || !selectedTableName || !tableSchema)
+      if (
+        !workspaceId ||
+        !selectedDatabase ||
+        !selectedTableName ||
+        !tableSchema ||
+        !isDatabaseWritable(selectedDatabase)
+      )
         return;
       try {
         const rowKey = buildRowKey(originalRow, tableSchema.columns);
@@ -756,17 +889,21 @@ export function WorkspaceSqliteInspectorModal({
             row_key: rowKey,
             values: { [colName]: newValue },
           },
+          selectedDatabase.owner_workspace_id,
         );
-        handlePromotionFlag(result.mode_promoted);
+        handlePromotionFlag(
+          result.mode_promoted,
+          selectedDatabase.owner_workspace_id,
+          selectedDatabase,
+        );
         toastSuccess('Cell updated');
-        await loadRows(selectedDatabase.name, selectedTableName, rowOffset, rowLimit);
+        await loadRows(selectedDatabase, selectedTableName, rowOffset, rowLimit);
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to update cell');
       }
     },
     [
       buildRowKey,
-      canEdit,
       handlePromotionFlag,
       loadRows,
       rowLimit,
@@ -782,7 +919,13 @@ export function WorkspaceSqliteInspectorModal({
 
   const handleDeleteRow = useCallback(
     async (row: Record<string, unknown>) => {
-      if (!workspaceId || !canEdit || !selectedDatabase || !selectedTableName || !tableSchema)
+      if (
+        !workspaceId ||
+        !selectedDatabase ||
+        !selectedTableName ||
+        !tableSchema ||
+        !isDatabaseWritable(selectedDatabase)
+      )
         return;
       try {
         const rowKey = buildRowKey(row, tableSchema.columns);
@@ -791,10 +934,15 @@ export function WorkspaceSqliteInspectorModal({
           selectedDatabase.name,
           selectedTableName,
           { row_key: rowKey },
+          selectedDatabase.owner_workspace_id,
         );
-        handlePromotionFlag(result.mode_promoted);
+        handlePromotionFlag(
+          result.mode_promoted,
+          selectedDatabase.owner_workspace_id,
+          selectedDatabase,
+        );
         toastSuccess('Row deleted');
-        await loadRows(selectedDatabase.name, selectedTableName, rowOffset, rowLimit);
+        await loadRows(selectedDatabase, selectedTableName, rowOffset, rowLimit);
         await loadTables(selectedDatabase);
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to delete row');
@@ -802,7 +950,6 @@ export function WorkspaceSqliteInspectorModal({
     },
     [
       buildRowKey,
-      canEdit,
       handlePromotionFlag,
       loadRows,
       loadTables,
@@ -819,7 +966,13 @@ export function WorkspaceSqliteInspectorModal({
 
   const handleBulkDeleteRows = useCallback(
     async (rows: Record<string, unknown>[]) => {
-      if (!workspaceId || !canEdit || !selectedDatabase || !selectedTableName || !tableSchema)
+      if (
+        !workspaceId ||
+        !selectedDatabase ||
+        !selectedTableName ||
+        !tableSchema ||
+        !isDatabaseWritable(selectedDatabase)
+      )
         return;
       try {
         for (const row of rows) {
@@ -829,10 +982,11 @@ export function WorkspaceSqliteInspectorModal({
             selectedDatabase.name,
             selectedTableName,
             { row_key: rowKey },
+            selectedDatabase.owner_workspace_id,
           );
         }
         toastSuccess(`Deleted ${rows.length} row${rows.length === 1 ? '' : 's'}`);
-        await loadRows(selectedDatabase.name, selectedTableName, rowOffset, rowLimit);
+        await loadRows(selectedDatabase, selectedTableName, rowOffset, rowLimit);
         await loadTables(selectedDatabase);
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to delete rows');
@@ -840,7 +994,6 @@ export function WorkspaceSqliteInspectorModal({
     },
     [
       buildRowKey,
-      canEdit,
       loadRows,
       loadTables,
       rowLimit,
@@ -856,7 +1009,13 @@ export function WorkspaceSqliteInspectorModal({
 
   const handleDropColumn = useCallback(
     async (columnName: string) => {
-      if (!workspaceId || !canEdit || !selectedDatabase || !selectedTableName) return;
+      if (
+        !workspaceId ||
+        !selectedDatabase ||
+        !selectedTableName ||
+        !isDatabaseWritable(selectedDatabase)
+      )
+        return;
       try {
         const alterations: SqliteInspectorAlterationStep[] = [
           { op: 'drop_column', column_name: columnName },
@@ -866,17 +1025,21 @@ export function WorkspaceSqliteInspectorModal({
           selectedDatabase.name,
           selectedTableName,
           { alterations },
+          selectedDatabase.owner_workspace_id,
         );
-        handlePromotionFlag(result.mode_promoted);
+        handlePromotionFlag(
+          result.mode_promoted,
+          selectedDatabase.owner_workspace_id,
+          selectedDatabase,
+        );
         setTableSchema(result.schema);
         toastSuccess(`Dropped column ${columnName}`);
-        await loadRows(selectedDatabase.name, selectedTableName, rowOffset, rowLimit);
+        await loadRows(selectedDatabase, selectedTableName, rowOffset, rowLimit);
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to drop column');
       }
     },
     [
-      canEdit,
       handlePromotionFlag,
       loadRows,
       rowLimit,
@@ -891,7 +1054,13 @@ export function WorkspaceSqliteInspectorModal({
 
   const handleAddColumn = useCallback(
     async (spec: SqliteInspectorColumnSpec) => {
-      if (!workspaceId || !canEdit || !selectedDatabase || !selectedTableName) return;
+      if (
+        !workspaceId ||
+        !selectedDatabase ||
+        !selectedTableName ||
+        !isDatabaseWritable(selectedDatabase)
+      )
+        return;
       try {
         const alterations: SqliteInspectorAlterationStep[] = [{ op: 'add_column', column: spec }];
         const result = await api.alterUserSpaceSqliteTable(
@@ -899,17 +1068,21 @@ export function WorkspaceSqliteInspectorModal({
           selectedDatabase.name,
           selectedTableName,
           { alterations },
+          selectedDatabase.owner_workspace_id,
         );
-        handlePromotionFlag(result.mode_promoted);
+        handlePromotionFlag(
+          result.mode_promoted,
+          selectedDatabase.owner_workspace_id,
+          selectedDatabase,
+        );
         setTableSchema(result.schema);
         toastSuccess(`Added column ${spec.name}`);
-        await loadRows(selectedDatabase.name, selectedTableName, rowOffset, rowLimit);
+        await loadRows(selectedDatabase, selectedTableName, rowOffset, rowLimit);
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to add column');
       }
     },
     [
-      canEdit,
       handlePromotionFlag,
       loadRows,
       rowLimit,
@@ -926,10 +1099,10 @@ export function WorkspaceSqliteInspectorModal({
     async (columnName: string, newColumnName: string) => {
       if (
         !workspaceId ||
-        !canEdit ||
         !selectedDatabase ||
         !selectedTableName ||
-        columnName === newColumnName
+        columnName === newColumnName ||
+        !isDatabaseWritable(selectedDatabase)
       )
         return;
       try {
@@ -941,17 +1114,21 @@ export function WorkspaceSqliteInspectorModal({
           selectedDatabase.name,
           selectedTableName,
           { alterations },
+          selectedDatabase.owner_workspace_id,
         );
-        handlePromotionFlag(result.mode_promoted);
+        handlePromotionFlag(
+          result.mode_promoted,
+          selectedDatabase.owner_workspace_id,
+          selectedDatabase,
+        );
         setTableSchema(result.schema);
         toastSuccess(`Renamed column ${columnName}`);
-        await loadRows(selectedDatabase.name, selectedTableName, rowOffset, rowLimit);
+        await loadRows(selectedDatabase, selectedTableName, rowOffset, rowLimit);
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to rename column');
       }
     },
     [
-      canEdit,
       handlePromotionFlag,
       loadRows,
       rowLimit,
@@ -968,10 +1145,10 @@ export function WorkspaceSqliteInspectorModal({
     async (column: SqliteInspectorColumnInfo, newType: SqliteInspectorColumnType) => {
       if (
         !workspaceId ||
-        !canEdit ||
         !selectedDatabase ||
         !selectedTableName ||
-        column.type === newType
+        column.type === newType ||
+        !isDatabaseWritable(selectedDatabase)
       )
         return;
       try {
@@ -993,17 +1170,21 @@ export function WorkspaceSqliteInspectorModal({
           selectedDatabase.name,
           selectedTableName,
           { alterations },
+          selectedDatabase.owner_workspace_id,
         );
-        handlePromotionFlag(result.mode_promoted);
+        handlePromotionFlag(
+          result.mode_promoted,
+          selectedDatabase.owner_workspace_id,
+          selectedDatabase,
+        );
         setTableSchema(result.schema);
         toastSuccess(`Changed ${column.name} to ${newType}`);
-        await loadRows(selectedDatabase.name, selectedTableName, rowOffset, rowLimit);
+        await loadRows(selectedDatabase, selectedTableName, rowOffset, rowLimit);
       } catch (err) {
         toastError(err instanceof Error ? err.message : 'Failed to change column type');
       }
     },
     [
-      canEdit,
       handlePromotionFlag,
       loadRows,
       rowLimit,
@@ -1020,10 +1201,15 @@ export function WorkspaceSqliteInspectorModal({
     if (!workspaceId || !selectedDatabase || !sqlText.trim()) return;
     setSqlRunning(true);
     try {
-      const result = await api.queryUserSpaceSqliteDatabase(workspaceId, selectedDatabase.name, {
-        sql: sqlText,
-        max_rows: 200,
-      });
+      const result = await api.queryUserSpaceSqliteDatabase(
+        workspaceId,
+        selectedDatabase.name,
+        {
+          sql: sqlText,
+          max_rows: 200,
+        },
+        selectedDatabase.owner_workspace_id,
+      );
       setSqlResult(result);
     } catch (err) {
       toastError(err instanceof Error ? err.message : 'Failed to run query');
@@ -1038,7 +1224,10 @@ export function WorkspaceSqliteInspectorModal({
     ];
     if (step !== 'databases' && selectedDatabase) {
       parts.push({
-        label: dbDisplayName(selectedDatabase.name),
+        label:
+          selectedDatabase.ownership === 'linked'
+            ? `${selectedDatabase.owner_workspace_name} · ${dbDisplayName(selectedDatabase.name)}`
+            : dbDisplayName(selectedDatabase.name),
         onClick: () => setStep('database'),
       });
     }
@@ -1047,6 +1236,12 @@ export function WorkspaceSqliteInspectorModal({
     }
     return parts;
   }, [selectedDatabase, selectedTableName, step]);
+
+  const selectedDatabaseCanWrite = isDatabaseWritable(selectedDatabase);
+  const effectivePersistenceMode = selectedDatabase?.persistence_mode ?? persistenceMode;
+  const linkedBannerText = selectedDatabase
+    ? `Linked from ${selectedDatabase.owner_workspace_name} · ${getDatabaseAccessLabel(selectedDatabase.access_mode)}${selectedDatabase.access_mode === 'read_write' ? ` · Changes affect the ${selectedDatabase.owner_workspace_name} workspace.` : ''}`
+    : null;
 
   if (!isOpen) {
     return null;
@@ -1127,12 +1322,13 @@ export function WorkspaceSqliteInspectorModal({
         </div>
 
         <div className="modal-body userspace-sqlite-body">
-          {persistenceMode === 'exclude' && (
+          {effectivePersistenceMode === 'exclude' && (
             <div className="userspace-sqlite-banner">
               <Sparkles size={14} />
               <span>
-                This workspace currently excludes SQLite from snapshots. The first edit will switch
-                it to two-lane persistence (include).
+                {selectedDatabase?.ownership === 'linked'
+                  ? `${selectedDatabase.owner_workspace_name} currently excludes SQLite from snapshots. The first edit will switch that workspace to two-lane persistence (include).`
+                  : 'This workspace currently excludes SQLite from snapshots. The first edit will switch it to two-lane persistence (include).'}
               </span>
             </div>
           )}
@@ -1145,7 +1341,21 @@ export function WorkspaceSqliteInspectorModal({
               loading={loadingDatabases}
               canEdit={canEdit}
               onInitialize={handleInitializeDatabase}
-              onImportDefault={() => handleRequestImportDatabase(defaultDatabaseName)}
+              onImportDefault={() =>
+                handleRequestImportDatabase({
+                  name: defaultDatabaseName,
+                  relative_path: `.ragtime/db/${defaultDatabaseName}`,
+                  size_bytes: 0,
+                  table_count: 0,
+                  last_modified_ms: null,
+                  owner_workspace_id: workspaceId ?? '',
+                  owner_workspace_name: workspaceName ?? 'This workspace',
+                  ownership: 'owned',
+                  access_mode: canEdit ? 'read_write' : 'read',
+                  persistence_mode: persistenceMode,
+                  initialized: false,
+                })
+              }
               onOpen={handleOpenDatabase}
               onExport={handleExportDatabase}
               onImport={handleRequestImportDatabase}
@@ -1158,7 +1368,8 @@ export function WorkspaceSqliteInspectorModal({
               database={selectedDatabase}
               tables={tables}
               loading={loadingTables}
-              canEdit={canEdit}
+              canEdit={selectedDatabaseCanWrite}
+              linkedBannerText={selectedDatabase.ownership === 'linked' ? linkedBannerText : null}
               showCreateForm={showCreateTableForm}
               onShowCreateForm={() => setShowCreateTableForm(true)}
               onCancelCreateForm={() => setShowCreateTableForm(false)}
@@ -1173,6 +1384,9 @@ export function WorkspaceSqliteInspectorModal({
               onExportTable={handleExportTable}
               onImportTable={handleRequestImportTable}
               onDropTable={handleDropTable}
+              onInitializeDatabase={() => void handleInitializeDatabase(selectedDatabase)}
+              onImportDatabase={() => handleRequestImportDatabase(selectedDatabase)}
+              onExportDatabase={() => void handleExportDatabase(selectedDatabase)}
               sqlText={sqlText}
               onSqlTextChange={setSqlText}
               sqlResult={sqlResult}
@@ -1184,6 +1398,7 @@ export function WorkspaceSqliteInspectorModal({
           {step === 'table' && selectedDatabase && selectedTableName && (
             <TableStep
               databaseName={selectedDatabase.name}
+              linkedBannerText={selectedDatabase.ownership === 'linked' ? linkedBannerText : null}
               tableName={selectedTableName}
               subTab={tableSubTab}
               onSubTabChange={setTableSubTab}
@@ -1193,11 +1408,11 @@ export function WorkspaceSqliteInspectorModal({
               rowLimit={rowLimit}
               onChangeOffset={(next) => {
                 setRowOffset(next);
-                void loadRows(selectedDatabase.name, selectedTableName, next, rowLimit);
+                void loadRows(selectedDatabase, selectedTableName, next, rowLimit);
               }}
               schema={tableSchema}
               loadingSchema={loadingSchema}
-              canEdit={canEdit}
+              canEdit={selectedDatabaseCanWrite}
               showAddRowForm={showAddRowForm}
               onShowAddRowForm={() => {
                 setNewRowValues({});
@@ -1212,13 +1427,13 @@ export function WorkspaceSqliteInspectorModal({
               onDeleteRow={handleDeleteRow}
               onBulkDeleteRows={handleBulkDeleteRows}
               onRefreshRows={() =>
-                loadRows(selectedDatabase.name, selectedTableName, rowOffset, rowLimit)
+                loadRows(selectedDatabase, selectedTableName, rowOffset, rowLimit)
               }
               onAddColumn={handleAddColumn}
               onRenameColumn={handleRenameColumn}
               onChangeColumnType={handleChangeColumnType}
               onDropColumn={handleDropColumn}
-              onRefreshSchema={() => loadSchema(selectedDatabase.name, selectedTableName)}
+              onRefreshSchema={() => loadSchema(selectedDatabase, selectedTableName)}
               sqlText={sqlText}
               onSqlTextChange={setSqlText}
               sqlResult={sqlResult}
@@ -1238,17 +1453,17 @@ export function WorkspaceSqliteInspectorModal({
 // ---------------------------------------------------------------------------
 
 interface DatabasesStepProps {
-  databases: SqliteInspectorDatabaseSummary[];
+  databases: InspectorDatabaseSummary[];
   defaultDatabaseName: string;
   totalBytes: number;
   loading: boolean;
   canEdit: boolean;
-  onInitialize: () => void;
+  onInitialize: (database?: InspectorDatabaseSummary | null) => void;
   onImportDefault: () => void;
-  onOpen: (db: SqliteInspectorDatabaseSummary) => void;
-  onExport: (db: SqliteInspectorDatabaseSummary) => void;
-  onImport: (databaseName: string) => void;
-  onDelete: (db: SqliteInspectorDatabaseSummary) => void;
+  onOpen: (db: InspectorDatabaseSummary) => void;
+  onExport: (db: InspectorDatabaseSummary) => void;
+  onImport: (database: InspectorDatabaseSummary) => void;
+  onDelete: (db: InspectorDatabaseSummary) => void;
 }
 
 function DatabasesStep({
@@ -1264,19 +1479,119 @@ function DatabasesStep({
   onImport,
   onDelete,
 }: DatabasesStepProps) {
-  const hasDefault = databases.some((d) => d.name === defaultDatabaseName);
+  const ownedDatabases = databases.filter((database) => database.ownership === 'owned');
+  const linkedDatabases = databases.filter((database) => database.ownership === 'linked');
+  const hasDefault = ownedDatabases.some((d) => d.name === defaultDatabaseName);
+
+  const renderDatabaseCard = (db: InspectorDatabaseSummary) => {
+    const canMutate = db.access_mode === 'read_write';
+    const isLinked = db.ownership === 'linked';
+
+    return (
+      <div
+        key={databaseKey(db)}
+        className={`userspace-sqlite-card${isLinked ? ' userspace-sqlite-card--linked' : ''}`}
+      >
+        <button type="button" className="userspace-sqlite-card-main" onClick={() => onOpen(db)}>
+          <div className="userspace-sqlite-card-title">
+            {isLinked ? <Link2 size={16} /> : <Database size={16} />}
+            <span>{db.name}</span>
+            <span
+              className={`userspace-sqlite-card-badge ${
+                db.ownership === 'owned'
+                  ? ''
+                  : db.access_mode === 'read_write'
+                    ? 'userspace-sqlite-access-badge--write'
+                    : 'userspace-sqlite-access-badge--read'
+              }`.trim()}
+            >
+              {db.ownership === 'owned' ? 'Owned' : getDatabaseAccessLabel(db.access_mode)}
+            </span>
+          </div>
+          {isLinked && (
+            <div className="userspace-sqlite-card-owner">Linked from {db.owner_workspace_name}</div>
+          )}
+          <div className="userspace-sqlite-card-meta">
+            {db.initialized ? (
+              <>
+                <span>
+                  {db.table_count} table{db.table_count === 1 ? '' : 's'}
+                </span>
+                <span>{formatBytes(db.size_bytes)}</span>
+                {db.last_modified_ms != null ? (
+                  <span>Modified {formatTimestamp(db.last_modified_ms)}</span>
+                ) : null}
+              </>
+            ) : (
+              <span>Not initialized</span>
+            )}
+          </div>
+        </button>
+        <div className="userspace-sqlite-card-actions">
+          {db.initialized ? (
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm btn-icon"
+              onClick={() => onExport(db)}
+              title="Export database"
+            >
+              <Download size={14} />
+            </button>
+          ) : null}
+          {canMutate ? (
+            db.initialized ? (
+              <>
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm btn-icon"
+                  onClick={() => onImport(db)}
+                  title="Import database"
+                >
+                  <Upload size={14} />
+                </button>
+                <DeleteConfirmButton
+                  onDelete={() => onDelete(db)}
+                  className="btn btn-danger btn-sm"
+                  title="Delete database"
+                  buttonText="Delete"
+                />
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm"
+                  onClick={() => onInitialize(db)}
+                >
+                  <PlusCircle size={14} /> Initialize {db.name}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm"
+                  onClick={() => onImport(db)}
+                >
+                  <Upload size={14} /> Import database
+                </button>
+              </>
+            )
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div className="userspace-sqlite-step">
       <div className="userspace-sqlite-step-header">
         <div>
-          <h4>Databases</h4>
+          <h4>Accessible SQLite databases</h4>
           <p className="field-help">
             Files under <code>.ragtime/db/</code>. Total size: {formatBytes(totalBytes)}.
           </p>
         </div>
         <div className="userspace-sqlite-step-actions">
           {!hasDefault && canEdit && (
-            <button type="button" className="btn btn-primary btn-sm" onClick={onInitialize}>
+            <button type="button" className="btn btn-primary btn-sm" onClick={() => onInitialize()}>
               <PlusCircle size={14} /> Initialize {defaultDatabaseName}
             </button>
           )}
@@ -1297,62 +1612,37 @@ function DatabasesStep({
           <Database size={24} />
           <p>No databases yet.</p>
           {canEdit && (
-            <button type="button" className="btn btn-primary btn-sm" onClick={onInitialize}>
+            <button type="button" className="btn btn-primary btn-sm" onClick={() => onInitialize()}>
               <PlusCircle size={14} /> Initialize {defaultDatabaseName}
             </button>
           )}
         </div>
       ) : (
-        <div className="userspace-sqlite-card-grid">
-          {databases.map((db) => (
-            <div key={db.name} className="userspace-sqlite-card">
-              <button
-                type="button"
-                className="userspace-sqlite-card-main"
-                onClick={() => onOpen(db)}
-              >
-                <div className="userspace-sqlite-card-title">
-                  <Database size={16} />
-                  <span>{db.name}</span>
-                </div>
-                <div className="userspace-sqlite-card-meta">
-                  <span>
-                    {db.table_count} table{db.table_count === 1 ? '' : 's'}
-                  </span>
-                  <span>{formatBytes(db.size_bytes)}</span>
-                  <span>Modified {formatTimestamp(db.last_modified_ms)}</span>
-                </div>
-              </button>
-              <div className="userspace-sqlite-card-actions">
-                <button
-                  type="button"
-                  className="btn btn-secondary btn-sm btn-icon"
-                  onClick={() => onExport(db)}
-                  title="Export database"
-                >
-                  <Download size={14} />
-                </button>
-                {canEdit && (
-                  <>
-                    <button
-                      type="button"
-                      className="btn btn-secondary btn-sm btn-icon"
-                      onClick={() => onImport(db.name)}
-                      title="Import database"
-                    >
-                      <Upload size={14} />
-                    </button>
-                    <DeleteConfirmButton
-                      onDelete={() => onDelete(db)}
-                      className="btn btn-danger btn-sm"
-                      title="Delete database"
-                      buttonText="Delete"
-                    />
-                  </>
-                )}
-              </div>
+        <div className="userspace-sqlite-group-stack">
+          <section className="userspace-sqlite-group">
+            <div className="userspace-sqlite-group-header">
+              <h5>Workspace databases</h5>
             </div>
-          ))}
+            {ownedDatabases.length > 0 ? (
+              <div className="userspace-sqlite-card-grid">
+                {ownedDatabases.map(renderDatabaseCard)}
+              </div>
+            ) : (
+              <div className="userspace-sqlite-empty-row">No workspace databases.</div>
+            )}
+          </section>
+          <section className="userspace-sqlite-group">
+            <div className="userspace-sqlite-group-header">
+              <h5>Linked databases</h5>
+            </div>
+            {linkedDatabases.length > 0 ? (
+              <div className="userspace-sqlite-card-grid">
+                {linkedDatabases.map(renderDatabaseCard)}
+              </div>
+            ) : (
+              <div className="userspace-sqlite-empty-row">No linked databases.</div>
+            )}
+          </section>
         </div>
       )}
     </div>
@@ -1360,10 +1650,11 @@ function DatabasesStep({
 }
 
 interface DatabaseStepProps {
-  database: SqliteInspectorDatabaseSummary;
+  database: InspectorDatabaseSummary;
   tables: SqliteInspectorTableSummary[];
   loading: boolean;
   canEdit: boolean;
+  linkedBannerText: string | null;
   showCreateForm: boolean;
   onShowCreateForm: () => void;
   onCancelCreateForm: () => void;
@@ -1378,6 +1669,9 @@ interface DatabaseStepProps {
   onExportTable: (table: SqliteInspectorTableSummary) => void;
   onImportTable: (tableName: string) => void;
   onDropTable: (table: SqliteInspectorTableSummary) => void;
+  onInitializeDatabase: () => void;
+  onImportDatabase: () => void;
+  onExportDatabase: () => void;
   sqlText: string;
   onSqlTextChange: (sql: string) => void;
   sqlResult: SqliteInspectorSqlQueryResponse | null;
@@ -1390,6 +1684,7 @@ function DatabaseStep({
   tables,
   loading,
   canEdit,
+  linkedBannerText,
   showCreateForm,
   onShowCreateForm,
   onCancelCreateForm,
@@ -1404,6 +1699,9 @@ function DatabaseStep({
   onExportTable,
   onImportTable,
   onDropTable,
+  onInitializeDatabase,
+  onImportDatabase,
+  onExportDatabase,
   sqlText,
   onSqlTextChange,
   sqlResult,
@@ -1427,15 +1725,31 @@ function DatabaseStep({
       <div className="userspace-sqlite-step-header userspace-sqlite-step-header-inline">
         <div>
           <div className="userspace-sqlite-meta">
-            <span>
-              {database.table_count} table{database.table_count === 1 ? '' : 's'}
-            </span>
-            <span>{formatBytes(database.size_bytes)}</span>
+            {database.initialized ? (
+              <>
+                <span>
+                  {database.table_count} table{database.table_count === 1 ? '' : 's'}
+                </span>
+                <span>{formatBytes(database.size_bytes)}</span>
+              </>
+            ) : (
+              <span>Not initialized</span>
+            )}
             <code className="userspace-sqlite-meta-path">{database.relative_path}</code>
           </div>
         </div>
         <div className="userspace-sqlite-step-actions">
-          {subTab === 'tables' && (
+          {database.initialized && (
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm btn-icon"
+              onClick={onExportDatabase}
+              title="Export database"
+            >
+              <Download size={14} />
+            </button>
+          )}
+          {database.initialized && subTab === 'tables' && (
             <>
               <button
                 type="button"
@@ -1472,7 +1786,32 @@ function DatabaseStep({
         </div>
       </div>
 
-      {showCreateForm && (
+      {linkedBannerText ? (
+        <div className="userspace-sqlite-linked-banner">{linkedBannerText}</div>
+      ) : null}
+
+      {!database.initialized ? (
+        <div className="userspace-sqlite-empty">
+          <Database size={24} />
+          <p>Not initialized</p>
+          {canEdit ? (
+            <div className="userspace-sqlite-step-actions">
+              <button
+                type="button"
+                className="btn btn-primary btn-sm"
+                onClick={onInitializeDatabase}
+              >
+                <PlusCircle size={14} /> Initialize {database.name}
+              </button>
+              <button type="button" className="btn btn-secondary btn-sm" onClick={onImportDatabase}>
+                <Upload size={14} /> Import database
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {database.initialized && showCreateForm && (
         <div className="userspace-sqlite-form">
           <div className="form-row">
             <label className="field-label">Table name</label>
@@ -1573,87 +1912,89 @@ function DatabaseStep({
         </div>
       )}
 
-      {subTab === 'console' ? (
-        <SqlConsolePane
-          sqlText={sqlText}
-          onSqlTextChange={onSqlTextChange}
-          result={sqlResult}
-          running={sqlRunning}
-          onRun={onRunSql}
-        />
-      ) : (
-        <>
-          {loading && !tables.length ? (
-            <div className="userspace-sqlite-empty">
-              <Loader2 size={16} className="spinning" /> Loading…
-            </div>
-          ) : tables.length === 0 ? (
-            <div className="userspace-sqlite-empty">
-              <TableIcon size={24} />
-              <p>This database has no tables yet.</p>
-            </div>
-          ) : (
-            <div className="userspace-sqlite-card-grid">
-              {tables.map((table) => (
-                <div key={table.name} className="userspace-sqlite-card">
-                  <button
-                    type="button"
-                    className="userspace-sqlite-card-main"
-                    onClick={() => onOpenTable(table)}
-                  >
-                    <div className="userspace-sqlite-card-title">
-                      <TableIcon size={16} />
-                      <span>{table.name}</span>
-                      {table.type === 'view' && (
-                        <span className="userspace-sqlite-card-badge">view</span>
-                      )}
-                    </div>
-                    <div className="userspace-sqlite-card-meta">
-                      <span>
-                        {table.row_count} row{table.row_count === 1 ? '' : 's'}
-                      </span>
-                    </div>
-                  </button>
-                  <div className="userspace-sqlite-card-actions">
+      {database.initialized &&
+        (subTab === 'console' ? (
+          <SqlConsolePane
+            sqlText={sqlText}
+            onSqlTextChange={onSqlTextChange}
+            result={sqlResult}
+            running={sqlRunning}
+            onRun={onRunSql}
+          />
+        ) : (
+          <>
+            {loading && !tables.length ? (
+              <div className="userspace-sqlite-empty">
+                <Loader2 size={16} className="spinning" /> Loading…
+              </div>
+            ) : tables.length === 0 ? (
+              <div className="userspace-sqlite-empty">
+                <TableIcon size={24} />
+                <p>This database has no tables yet.</p>
+              </div>
+            ) : (
+              <div className="userspace-sqlite-card-grid">
+                {tables.map((table) => (
+                  <div key={table.name} className="userspace-sqlite-card">
                     <button
                       type="button"
-                      className="btn btn-secondary btn-sm btn-icon"
-                      onClick={() => onExportTable(table)}
-                      title="Export table"
+                      className="userspace-sqlite-card-main"
+                      onClick={() => onOpenTable(table)}
                     >
-                      <Download size={14} />
+                      <div className="userspace-sqlite-card-title">
+                        <TableIcon size={16} />
+                        <span>{table.name}</span>
+                        {table.type === 'view' && (
+                          <span className="userspace-sqlite-card-badge">view</span>
+                        )}
+                      </div>
+                      <div className="userspace-sqlite-card-meta">
+                        <span>
+                          {table.row_count} row{table.row_count === 1 ? '' : 's'}
+                        </span>
+                      </div>
                     </button>
-                    {canEdit && table.type === 'table' && (
-                      <>
-                        <button
-                          type="button"
-                          className="btn btn-secondary btn-sm btn-icon"
-                          onClick={() => onImportTable(table.name)}
-                          title="Import CSV"
-                        >
-                          <Upload size={14} />
-                        </button>
-                        <DeleteConfirmButton
-                          onDelete={() => onDropTable(table)}
-                          className="btn btn-danger btn-sm"
-                          title="Drop table"
-                          buttonText="Drop"
-                        />
-                      </>
-                    )}
+                    <div className="userspace-sqlite-card-actions">
+                      <button
+                        type="button"
+                        className="btn btn-secondary btn-sm btn-icon"
+                        onClick={() => onExportTable(table)}
+                        title="Export table"
+                      >
+                        <Download size={14} />
+                      </button>
+                      {canEdit && table.type === 'table' && (
+                        <>
+                          <button
+                            type="button"
+                            className="btn btn-secondary btn-sm btn-icon"
+                            onClick={() => onImportTable(table.name)}
+                            title="Import CSV"
+                          >
+                            <Upload size={14} />
+                          </button>
+                          <DeleteConfirmButton
+                            onDelete={() => onDropTable(table)}
+                            className="btn btn-danger btn-sm"
+                            title="Drop table"
+                            buttonText="Drop"
+                          />
+                        </>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </>
-      )}
+                ))}
+              </div>
+            )}
+          </>
+        ))}
     </div>
   );
 }
 
 interface TableStepProps {
   databaseName: string;
+  linkedBannerText: string | null;
   tableName: string;
   subTab: TableSubTab;
   onSubTabChange: (tab: TableSubTab) => void;
@@ -1694,6 +2035,7 @@ interface TableStepProps {
 function TableStep(props: TableStepProps) {
   const {
     databaseName,
+    linkedBannerText,
     tableName,
     subTab,
     onSubTabChange,
@@ -1764,6 +2106,10 @@ function TableStep(props: TableStepProps) {
           </button>
         </div>
       </div>
+
+      {linkedBannerText ? (
+        <div className="userspace-sqlite-linked-banner">{linkedBannerText}</div>
+      ) : null}
 
       {subTab === 'rows' ? (
         <RowsPane

--- a/ragtime/frontend/src/components/shared/WorkspaceSqliteInspectorModal.tsx
+++ b/ragtime/frontend/src/components/shared/WorkspaceSqliteInspectorModal.tsx
@@ -6,7 +6,6 @@ import {
   Download,
   FileText,
   Filter,
-  Link2,
   Loader2,
   PlusCircle,
   RefreshCw,
@@ -52,8 +51,41 @@ interface WorkspaceSqliteInspectorModalProps {
 
 type InspectorDatabaseSummary = SqliteInspectorDatabaseSummary;
 
-function asInspectorDatabase(database: SqliteInspectorDatabaseSummary): InspectorDatabaseSummary {
-  return database;
+type LegacyInspectorDatabaseSummary = Pick<
+  SqliteInspectorDatabaseSummary,
+  'name' | 'relative_path' | 'size_bytes' | 'table_count' | 'last_modified_ms'
+> &
+  Partial<
+    Pick<
+      SqliteInspectorDatabaseSummary,
+      | 'owner_workspace_id'
+      | 'owner_workspace_name'
+      | 'ownership'
+      | 'access_mode'
+      | 'persistence_mode'
+      | 'initialized'
+    >
+  >;
+
+function normalizeInspectorDatabase(
+  database: SqliteInspectorDatabaseSummary | LegacyInspectorDatabaseSummary,
+  options: {
+    workspaceId: string | null;
+    workspaceName?: string;
+    canEdit: boolean;
+    persistenceMode: 'include' | 'exclude';
+  },
+): InspectorDatabaseSummary {
+  return {
+    ...database,
+    owner_workspace_id: database.owner_workspace_id ?? options.workspaceId ?? '',
+    owner_workspace_name:
+      database.owner_workspace_name ?? options.workspaceName ?? 'This workspace',
+    ownership: database.ownership ?? 'owned',
+    access_mode: database.access_mode ?? (options.canEdit ? 'read_write' : 'read'),
+    persistence_mode: database.persistence_mode ?? options.persistenceMode,
+    initialized: database.initialized ?? true,
+  };
 }
 
 function databaseKey(
@@ -300,6 +332,28 @@ export function WorkspaceSqliteInspectorModal({
   const [newRowValues, setNewRowValues] = useState<Record<string, string>>({});
   const [savingRow, setSavingRow] = useState(false);
 
+  const normalizeDatabase = useCallback(
+    (
+      database: SqliteInspectorDatabaseSummary | LegacyInspectorDatabaseSummary,
+      nextPersistenceMode: 'include' | 'exclude',
+    ) =>
+      normalizeInspectorDatabase(database, {
+        workspaceId,
+        workspaceName,
+        canEdit,
+        persistenceMode: nextPersistenceMode,
+      }),
+    [canEdit, workspaceId, workspaceName],
+  );
+
+  const normalizeDatabases = useCallback(
+    (
+      nextDatabases: Array<SqliteInspectorDatabaseSummary | LegacyInspectorDatabaseSummary>,
+      nextPersistenceMode: 'include' | 'exclude',
+    ) => nextDatabases.map((database) => normalizeDatabase(database, nextPersistenceMode)),
+    [normalizeDatabase],
+  );
+
   const reset = useCallback(() => {
     setStep('databases');
     setDatabases([]);
@@ -328,7 +382,7 @@ export function WorkspaceSqliteInspectorModal({
     setLoadingDatabases(true);
     try {
       const result = await api.listUserSpaceSqliteDatabases(workspaceId);
-      setDatabases(result.databases.map(asInspectorDatabase));
+      setDatabases(normalizeDatabases(result.databases, result.persistence_mode));
       setDefaultDatabaseName(result.default_database_name);
       setPersistenceMode(result.persistence_mode);
       setTotalBytes(result.total_bytes);
@@ -337,7 +391,7 @@ export function WorkspaceSqliteInspectorModal({
     } finally {
       setLoadingDatabases(false);
     }
-  }, [toastError, workspaceId]);
+  }, [normalizeDatabases, toastError, workspaceId]);
 
   const loadTables = useCallback(
     async (database: InspectorDatabaseSummary) => {
@@ -349,7 +403,7 @@ export function WorkspaceSqliteInspectorModal({
           database.name,
           database.owner_workspace_id,
         );
-        setSelectedDatabase(asInspectorDatabase(result.database));
+        setSelectedDatabase(normalizeDatabase(result.database, result.persistence_mode));
         setTables(result.tables);
         setPersistenceMode(result.persistence_mode);
       } catch (err) {
@@ -358,7 +412,7 @@ export function WorkspaceSqliteInspectorModal({
         setLoadingTables(false);
       }
     },
-    [toastError, workspaceId],
+    [normalizeDatabase, toastError, workspaceId],
   );
 
   const loadRows = useCallback(
@@ -419,12 +473,12 @@ export function WorkspaceSqliteInspectorModal({
     events.addEventListener('databases', (event) => {
       try {
         const result = JSON.parse((event as MessageEvent).data) as {
-          databases: SqliteInspectorDatabaseSummary[];
+          databases: Array<SqliteInspectorDatabaseSummary | LegacyInspectorDatabaseSummary>;
           default_database_name: string;
           persistence_mode: 'include' | 'exclude';
           total_bytes: number;
         };
-        const nextDatabases = result.databases.map(asInspectorDatabase);
+        const nextDatabases = normalizeDatabases(result.databases, result.persistence_mode);
         setDatabases(nextDatabases);
         setDefaultDatabaseName(result.default_database_name);
         setPersistenceMode(result.persistence_mode);
@@ -438,7 +492,7 @@ export function WorkspaceSqliteInspectorModal({
       }
     });
     return () => events.close();
-  }, [isOpen, workspaceId]);
+  }, [isOpen, normalizeDatabases, workspaceId]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -491,7 +545,7 @@ export function WorkspaceSqliteInspectorModal({
           {},
           ownerWorkspaceId,
         );
-        const nextDatabase = asInspectorDatabase(result.database);
+        const nextDatabase = normalizeDatabase(result.database, result.persistence_mode);
         // Pre-fetch the destination data before transitioning so the new step
         // renders fully populated.
         await Promise.all([loadDatabases(), loadTables(nextDatabase)]);
@@ -511,6 +565,7 @@ export function WorkspaceSqliteInspectorModal({
       toastSuccess,
       toastError,
       workspaceId,
+      normalizeDatabase,
     ],
   );
 
@@ -616,7 +671,7 @@ export function WorkspaceSqliteInspectorModal({
           formData,
           targetDatabase.owner_workspace_id,
         );
-        const nextDatabase = asInspectorDatabase(result.database);
+        const nextDatabase = normalizeDatabase(result.database, persistenceMode);
         handlePromotionFlag(result.mode_promoted, nextDatabase.owner_workspace_id, nextDatabase);
         toastSuccess(`Imported ${result.database.name}`);
         await loadDatabases();
@@ -638,6 +693,8 @@ export function WorkspaceSqliteInspectorModal({
       toastError,
       toastSuccess,
       workspaceId,
+      normalizeDatabase,
+      persistenceMode,
     ],
   );
 
@@ -1342,19 +1399,19 @@ export function WorkspaceSqliteInspectorModal({
               canEdit={canEdit}
               onInitialize={handleInitializeDatabase}
               onImportDefault={() =>
-                handleRequestImportDatabase({
-                  name: defaultDatabaseName,
-                  relative_path: `.ragtime/db/${defaultDatabaseName}`,
-                  size_bytes: 0,
-                  table_count: 0,
-                  last_modified_ms: null,
-                  owner_workspace_id: workspaceId ?? '',
-                  owner_workspace_name: workspaceName ?? 'This workspace',
-                  ownership: 'owned',
-                  access_mode: canEdit ? 'read_write' : 'read',
-                  persistence_mode: persistenceMode,
-                  initialized: false,
-                })
+                handleRequestImportDatabase(
+                  normalizeDatabase(
+                    {
+                      name: defaultDatabaseName,
+                      relative_path: `.ragtime/db/${defaultDatabaseName}`,
+                      size_bytes: 0,
+                      table_count: 0,
+                      last_modified_ms: null,
+                      initialized: false,
+                    },
+                    persistenceMode,
+                  ),
+                )
               }
               onOpen={handleOpenDatabase}
               onExport={handleExportDatabase}
@@ -1479,9 +1536,9 @@ function DatabasesStep({
   onImport,
   onDelete,
 }: DatabasesStepProps) {
-  const ownedDatabases = databases.filter((database) => database.ownership === 'owned');
-  const linkedDatabases = databases.filter((database) => database.ownership === 'linked');
-  const hasDefault = ownedDatabases.some((d) => d.name === defaultDatabaseName);
+  const hasDefault = databases.some(
+    (database) => database.ownership === 'owned' && database.name === defaultDatabaseName,
+  );
 
   const renderDatabaseCard = (db: InspectorDatabaseSummary) => {
     const canMutate = db.access_mode === 'read_write';
@@ -1494,23 +1551,21 @@ function DatabasesStep({
       >
         <button type="button" className="userspace-sqlite-card-main" onClick={() => onOpen(db)}>
           <div className="userspace-sqlite-card-title">
-            {isLinked ? <Link2 size={16} /> : <Database size={16} />}
+            <Database size={16} />
             <span>{db.name}</span>
-            <span
-              className={`userspace-sqlite-card-badge ${
-                db.ownership === 'owned'
-                  ? ''
-                  : db.access_mode === 'read_write'
+            {isLinked ? (
+              <span
+                className={`userspace-sqlite-card-badge ${
+                  db.access_mode === 'read_write'
                     ? 'userspace-sqlite-access-badge--write'
                     : 'userspace-sqlite-access-badge--read'
-              }`.trim()}
-            >
-              {db.ownership === 'owned' ? 'Owned' : getDatabaseAccessLabel(db.access_mode)}
-            </span>
+                }`.trim()}
+                title={db.owner_workspace_name}
+              >
+                {db.owner_workspace_name}
+              </span>
+            ) : null}
           </div>
-          {isLinked && (
-            <div className="userspace-sqlite-card-owner">Linked from {db.owner_workspace_name}</div>
-          )}
           <div className="userspace-sqlite-card-meta">
             {db.initialized ? (
               <>
@@ -1519,11 +1574,25 @@ function DatabasesStep({
                 </span>
                 <span>{formatBytes(db.size_bytes)}</span>
                 {db.last_modified_ms != null ? (
-                  <span>Modified {formatTimestamp(db.last_modified_ms)}</span>
+                  <span className="userspace-sqlite-card-modified">
+                    Modified {formatTimestamp(db.last_modified_ms)}
+                  </span>
+                ) : null}
+                {isLinked ? (
+                  <span className="userspace-sqlite-card-source">
+                    Linked from {db.owner_workspace_name}
+                  </span>
                 ) : null}
               </>
             ) : (
-              <span>Not initialized</span>
+              <>
+                <span>Not initialized</span>
+                {isLinked ? (
+                  <span className="userspace-sqlite-card-source">
+                    Linked from {db.owner_workspace_name}
+                  </span>
+                ) : null}
+              </>
             )}
           </div>
         </button>
@@ -1618,32 +1687,7 @@ function DatabasesStep({
           )}
         </div>
       ) : (
-        <div className="userspace-sqlite-group-stack">
-          <section className="userspace-sqlite-group">
-            <div className="userspace-sqlite-group-header">
-              <h5>Workspace databases</h5>
-            </div>
-            {ownedDatabases.length > 0 ? (
-              <div className="userspace-sqlite-card-grid">
-                {ownedDatabases.map(renderDatabaseCard)}
-              </div>
-            ) : (
-              <div className="userspace-sqlite-empty-row">No workspace databases.</div>
-            )}
-          </section>
-          <section className="userspace-sqlite-group">
-            <div className="userspace-sqlite-group-header">
-              <h5>Linked databases</h5>
-            </div>
-            {linkedDatabases.length > 0 ? (
-              <div className="userspace-sqlite-card-grid">
-                {linkedDatabases.map(renderDatabaseCard)}
-              </div>
-            ) : (
-              <div className="userspace-sqlite-empty-row">No linked databases.</div>
-            )}
-          </section>
-        </div>
+        <div className="userspace-sqlite-card-grid">{databases.map(renderDatabaseCard)}</div>
       )}
     </div>
   );

--- a/ragtime/frontend/src/styles/components.css
+++ b/ragtime/frontend/src/styles/components.css
@@ -4140,6 +4140,10 @@ textarea:focus {
   margin-bottom: var(--space-md);
 }
 
+.userspace-agent-access-note {
+  margin: 0 0 var(--space-md);
+}
+
 .userspace-agent-access-info {
   flex: 1;
   min-width: 0;
@@ -4156,8 +4160,28 @@ textarea:focus {
 
 .userspace-agent-access-grant-top {
   display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.userspace-agent-access-control-row {
+  display: flex;
   align-items: center;
   gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.userspace-agent-access-control-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  min-width: 92px;
+}
+
+.userspace-agent-access-toggle {
+  width: fit-content;
+  max-width: 100%;
+  flex-wrap: wrap;
 }
 
 .userspace-agent-access-workspace-id {

--- a/ragtime/frontend/src/styles/components.css
+++ b/ragtime/frontend/src/styles/components.css
@@ -4163,6 +4163,15 @@ textarea:focus {
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.userspace-agent-access-grant-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .userspace-agent-access-control-row {
@@ -4202,8 +4211,21 @@ textarea:focus {
   gap: var(--space-xs);
 }
 
-.userspace-agent-access-create-toggle {
-  width: fit-content;
+.userspace-agent-access-row-error {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-error);
+}
+
+@media (max-width: 640px) {
+  .userspace-agent-access-modal .modal-footer {
+    flex-wrap: wrap;
+  }
+
+  .userspace-agent-access-modal .modal-footer .btn {
+    flex: 1 1 0;
+    min-width: 0;
+  }
 }
 
 .userspace-member-row select {

--- a/ragtime/frontend/src/styles/components.css
+++ b/ragtime/frontend/src/styles/components.css
@@ -9117,6 +9117,27 @@ fieldset legend.legend-with-status .legend-divider {
   align-items: center;
   gap: var(--space-sm);
 }
+.userspace-sqlite-group-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+.userspace-sqlite-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+.userspace-sqlite-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+.userspace-sqlite-group-header h5 {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
 .userspace-sqlite-step-header-inline {
   align-items: center;
 }
@@ -9141,6 +9162,9 @@ fieldset legend.legend-with-status .legend-divider {
   transition:
     border-color var(--transition-fast),
     background var(--transition-fast);
+}
+.userspace-sqlite-card--linked {
+  border-style: dashed;
 }
 .userspace-sqlite-card:hover {
   border-color: var(--color-accent, var(--color-border));
@@ -9169,6 +9193,8 @@ fieldset legend.legend-with-status .legend-divider {
   align-items: center;
   gap: 4px;
   flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 .userspace-sqlite-card-title {
   display: flex;
@@ -9184,6 +9210,23 @@ fieldset legend.legend-with-status .legend-divider {
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
+.userspace-sqlite-card-owner {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+.userspace-sqlite-access-badge--read,
+.userspace-sqlite-access-badge--write {
+  border: 1px solid var(--color-border);
+}
+.userspace-sqlite-access-badge--read {
+  background: var(--color-info-light);
+  color: var(--color-info);
+}
+.userspace-sqlite-access-badge--write {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  border-color: var(--color-primary-border);
+}
 .userspace-sqlite-card-meta {
   display: flex;
   align-items: center;
@@ -9191,6 +9234,14 @@ fieldset legend.legend-with-status .legend-divider {
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   flex-wrap: wrap;
+}
+.userspace-sqlite-linked-banner {
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
 }
 /* Inline metadata row used inside step headers (not cards) */
 .userspace-sqlite-meta {

--- a/ragtime/frontend/src/styles/components.css
+++ b/ragtime/frontend/src/styles/components.css
@@ -9117,27 +9117,6 @@ fieldset legend.legend-with-status .legend-divider {
   align-items: center;
   gap: var(--space-sm);
 }
-.userspace-sqlite-group-stack {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
-}
-.userspace-sqlite-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-}
-.userspace-sqlite-group-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-sm);
-}
-.userspace-sqlite-group-header h5 {
-  margin: 0;
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-}
 .userspace-sqlite-step-header-inline {
   align-items: center;
 }
@@ -9153,7 +9132,7 @@ fieldset legend.legend-with-status .legend-divider {
 .userspace-sqlite-card {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
+  align-items: start;
   gap: var(--space-sm);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
@@ -9201,18 +9180,29 @@ fieldset legend.legend-with-status .legend-divider {
   align-items: center;
   gap: var(--space-xs);
   font-weight: 600;
+  min-width: 0;
+}
+.userspace-sqlite-card-title .lucide {
+  flex-shrink: 0;
+}
+.userspace-sqlite-card-title > span {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.userspace-sqlite-card-title > span:first-of-type {
+  flex: 1 1 auto;
 }
 .userspace-sqlite-card-badge {
+  max-width: 50%;
+  flex: 0 1 auto;
   font-size: 10px;
   padding: 1px 6px;
   border-radius: var(--radius-sm);
   background: var(--color-surface-hover);
   text-transform: uppercase;
   color: var(--color-text-muted);
-}
-.userspace-sqlite-card-owner {
-  font-size: var(--text-xs);
-  color: var(--color-text-secondary);
 }
 .userspace-sqlite-access-badge--read,
 .userspace-sqlite-access-badge--write {
@@ -9234,6 +9224,10 @@ fieldset legend.legend-with-status .legend-divider {
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   flex-wrap: wrap;
+}
+.userspace-sqlite-card-modified,
+.userspace-sqlite-card-source {
+  flex-basis: 100%;
 }
 .userspace-sqlite-linked-banner {
   padding: var(--space-sm) var(--space-md);

--- a/ragtime/frontend/src/styles/components.css
+++ b/ragtime/frontend/src/styles/components.css
@@ -9227,7 +9227,11 @@ fieldset legend.legend-with-status .legend-divider {
 }
 .userspace-sqlite-card-modified,
 .userspace-sqlite-card-source {
-  flex-basis: 100%;
+  flex: 1 1 100%;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .userspace-sqlite-linked-banner {
   padding: var(--space-sm) var(--space-md);

--- a/ragtime/frontend/src/styles/responsive.css
+++ b/ragtime/frontend/src/styles/responsive.css
@@ -255,6 +255,32 @@
     min-width: auto;
   }
 
+  .userspace-sqlite-breadcrumb-row,
+  .userspace-sqlite-step-header,
+  .userspace-sqlite-step-header-inline,
+  .userspace-sqlite-step-actions,
+  .userspace-sqlite-group-header,
+  .userspace-sqlite-card,
+  .userspace-sqlite-card-actions {
+    flex-wrap: wrap;
+  }
+
+  .userspace-sqlite-card {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .userspace-sqlite-card-actions {
+    justify-content: flex-start;
+  }
+
+  .userspace-sqlite-linked-banner {
+    line-height: var(--leading-relaxed);
+  }
+
+  .userspace-sqlite-column-row {
+    grid-template-columns: 1fr;
+  }
+
   /* Index items */
   .index-item {
     flex-direction: column;

--- a/ragtime/frontend/src/styles/responsive.css
+++ b/ragtime/frontend/src/styles/responsive.css
@@ -259,7 +259,6 @@
   .userspace-sqlite-step-header,
   .userspace-sqlite-step-header-inline,
   .userspace-sqlite-step-actions,
-  .userspace-sqlite-group-header,
   .userspace-sqlite-card,
   .userspace-sqlite-card-actions {
     flex-wrap: wrap;

--- a/ragtime/frontend/src/types/api.ts
+++ b/ragtime/frontend/src/types/api.ts
@@ -4861,8 +4861,17 @@ export interface SqliteInspectorDatabaseSummary {
   relative_path: string;
   size_bytes: number;
   table_count: number;
-  last_modified_ms: number;
+  last_modified_ms: number | null;
+  owner_workspace_id: string;
+  owner_workspace_name: string;
+  ownership: SqliteInspectorDatabaseOwnership;
+  access_mode: SqliteInspectorDatabaseAccessMode;
+  persistence_mode: 'include' | 'exclude';
+  initialized: boolean;
 }
+
+export type SqliteInspectorDatabaseOwnership = 'owned' | 'linked';
+export type SqliteInspectorDatabaseAccessMode = 'read' | 'read_write';
 
 export interface SqliteInspectorDatabaseListResponse {
   workspace_id: string;

--- a/ragtime/frontend/src/types/api.ts
+++ b/ragtime/frontend/src/types/api.ts
@@ -3309,6 +3309,7 @@ export interface UpdateUserSpaceWorkspaceMembersRequest {
 }
 
 export type WorkspaceAgentGrantMode = 'read' | 'read_write';
+export type WorkspaceSqliteGrantMode = 'none' | 'read' | 'read_write';
 
 export interface WorkspaceAgentGrant {
   id: string;
@@ -3317,6 +3318,7 @@ export interface WorkspaceAgentGrant {
   target_workspace_id: string;
   target_workspace_name?: string | null;
   access_mode: WorkspaceAgentGrantMode;
+  sqlite_access_mode: WorkspaceSqliteGrantMode;
   granted_by_user_id: string;
   granted_by_username?: string | null;
   expires_at?: string | null;
@@ -3327,6 +3329,7 @@ export interface WorkspaceAgentGrant {
 export interface UpsertWorkspaceAgentGrantRequest {
   target_workspace_id: string;
   access_mode: WorkspaceAgentGrantMode;
+  sqlite_access_mode?: WorkspaceSqliteGrantMode;
 }
 
 export interface RevokeWorkspaceAgentGrantResponse {

--- a/ragtime/rag/components.py
+++ b/ragtime/rag/components.py
@@ -14891,6 +14891,7 @@ class RAGComponents:
         allowed_tool_config_ids: list[str] | None = None
         prompt_additions = ""
         include_sqlite_persistence = False
+        shared_sqlite_databases: list[dict[str, str]] = []
         userspace_env_var_turn_hint = ""
         userspace_runtime_status_turn_hint = ""
         userspace_diagnostics_turn_hint = ""
@@ -15150,6 +15151,43 @@ class RAGComponents:
                 accessible_workspace_modes=accessible_workspace_modes,
             )
 
+            try:
+                runtime_session_response = await userspace_runtime_service.get_runtime_session(
+                    workspace_id,
+                    request_user_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to resolve runtime session for shared SQLite prompt context %s/%s: %s",
+                    workspace_id,
+                    request_user_id,
+                    _format_exception_message(exc),
+                )
+            else:
+                leased_by_user_id = request_user_id
+                runtime_session = getattr(runtime_session_response, "session", None)
+                if runtime_session is not None:
+                    leased_by_user_id = str(getattr(runtime_session, "leased_by_user_id", "") or "").strip()
+                    if not leased_by_user_id:
+                        logger.warning(
+                            "Omitting shared SQLite prompt targets for workspace %s because the active runtime session has no leased user identity.",
+                            workspace_id,
+                        )
+                        leased_by_user_id = ""
+                if leased_by_user_id:
+                    try:
+                        shared_sqlite_databases = await userspace_service.list_accessible_cross_workspace_sqlite_targets(
+                            workspace_id,
+                            leased_by_user_id,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to resolve shared SQLite prompt targets for workspace %s and prompt identity %s: %s",
+                            workspace_id,
+                            leased_by_user_id,
+                            _format_exception_message(exc),
+                        )
+
             subagent_private_prompt = (workspace_context or {}).get(SUBAGENT_PRIVATE_PROMPT_CONTEXT_KEY)
             if isinstance(subagent_private_prompt, str) and subagent_private_prompt.strip():
                 prompt_additions += "\n\n" + subagent_private_prompt.strip()
@@ -15237,6 +15275,7 @@ class RAGComponents:
                     has_live_data_tools=bool(allowed_tool_config_ids),
                     workspace_continuity=continuity_ctx,
                     available_tool_names=available_userspace_tool_names,
+                    shared_sqlite_databases=shared_sqlite_databases,
                 )
                 + prompt_additions
             )

--- a/ragtime/rag/prompts.py
+++ b/ragtime/rag/prompts.py
@@ -257,9 +257,11 @@ _USERSPACE_TURN_REMINDER_BASE = """[USER SPACE TURN CHECKLIST
 """
 
 _SQLITE_TURN_REMINDER_LINE = (
-    "- SQLite local persistence is ON: ensure this delivery includes both live data "
-    "wiring (Lane A) and any needed SQLite migrations under .ragtime/db/migrations/ (Lane B). "
-    "Migration creation and upkeep are your responsibility in this mode.\n"
+    "- SQLite local persistence is ON: when selected tools are part of the requested "
+    "feature, keep live data wiring aligned with the current execution surface; when "
+    "local schema needs change, add any needed SQLite migrations under "
+    ".ragtime/db/migrations/. Migration creation and upkeep are your responsibility "
+    "in this mode.\n"
 )
 
 
@@ -764,7 +766,9 @@ _USERSPACE_DATA_WIRING_BLOCK = """
 
 - Use real tool outputs as the source of truth for rendered data.
 - In tool-enabled workspaces, do not replace live dashboard data connections with SQLite snapshots or seeded local tables.
-- Persistent User Space dashboards must be live-wired via `context.components[componentId].execute()`.
+- Persistent User Space dashboards must be live-wired via the approved execution surface for the current entrypoint.
+- Browser example: use `context.components[componentId].execute()` in preview code when the current entrypoint is using the browser execution surface.
+- Server-backed entrypoints may fetch the same live data through app-owned server code and pass the results into the UI.
 - When the workspace has selected tools, hardcoded/mock/sample data in any entrypoint file (including Python server entrypoints like `app.py`) is flagged as a live data contract violation. Use live tool connections to fetch data instead of embedding it in source.
 - For TypeScript dashboard mode, only `dashboard/main.ts` (the entry module) requires `live_data_connections`, `live_data_checks`, and verified `execute()` call sites.
 - Helper components under `dashboard/` (e.g., `dashboard/components/*`, `dashboard/charts/*`) do NOT need live_data_connections. They receive data as parameters from the entry module.
@@ -776,7 +780,7 @@ _USERSPACE_DATA_WIRING_BLOCK = """
 - Do not persist `dashboard/main.ts` without connection metadata when workspace has tools. If the file is persisted with contract violations, fix the violations via `patch_userspace_file` rather than regenerating the entire file.
 - Data connections are internal components, abstracted from end users.
 - These components map to admin-configured tools from Settings.
-- Persist the connection request (query/command payload + component reference), then read/fetch through `context.components` at render/runtime.
+- Persist the connection request (query/command payload + component reference), then read/fetch through the active execution surface at render/runtime.
 {userspace_shared_live_data_guardrails}
 - When creating chart/datatable payloads for reusable artifacts, include `data_connection` as a component reference:
     - `component_kind`: `tool_config`
@@ -789,7 +793,7 @@ _USERSPACE_DATA_WIRING_BLOCK = """
 
 ### Resilient data loading
 
-- Always wrap every `context.components[componentId].execute()` call in a try/catch block.
+- Always wrap every live-data execution call in a try/catch block.
 - When a data source is offline, timed-out, or returns an error, the dashboard must still render a visible layout with a user-friendly status message (e.g., "Data unavailable - source offline") instead of silently failing or rendering a blank page.
 - Render static layout elements (headers, navigation, empty table/chart placeholders) first, then load data asynchronously inside individual try/catch blocks so one failed source doesn't block the entire dashboard.
 - A single offline component must never prevent the rest of the dashboard from rendering.
@@ -864,42 +868,13 @@ Default to hiding unless the user benefits from seeing technical details.
 # USER SPACE MODE PROMPTS
 # =============================================================================
 
-_USERSPACE_SQLITE_PERSISTENCE_BLOCK = """
-
-#### Two-lane persistence contract
-
-This workspace has SQLite local persistence enabled. You must satisfy **both** lanes in every delivery:
-
-**Lane A -- Live data (primary, required when workspace has tools)**
-- Dashboard datasets requested by the user MUST be fetched at runtime via `context.components[componentId].execute()`.
-- Live tool responses are the source of truth for rendered data. Never substitute SQLite tables or local snapshots for live datasets.
-- All `live_data_connections`, `live_data_checks`, and AST `execute()` binding rules still apply.
-
-**Lane B -- SQLite local persistence (required for local app state)**
-- Use SQLite at `.ragtime/db/app.sqlite3` for local domain/app state (for example: user preferences, UI state, cache, drafts, operational data, computed aggregations for offline use).
-- You are responsible for persistence lifecycle management in include mode: design schema changes, add migrations, apply them in runtime/bootstrap, and keep migration history forward-only.
-- Every schema change requires a new numbered migration file in `.ragtime/db/migrations/` in lexical order (`0001_init.sql`, `0002_add_table.sql`, ...).
-- The workspace includes a runner at `.ragtime/scripts/sqlite_migrate.py`; keep it or replace it with an equivalent migration apply step.
-- Runtime bootstrap should run `.ragtime/scripts/sqlite_migrate.py --db .ragtime/db/app.sqlite3 --migrations .ragtime/db/migrations` so migrations apply on start/restart.
-- The default runner tracks applied migrations in `_ragtime_migrations` with SHA-256 checksums.
-- Never edit a previously applied migration file; always create a new migration.
-- If the project is JavaScript/TypeScript and an ORM is appropriate, Prisma is an optional query/modeling layer with a SQLite datasource; keep workspace persistence migrations in `.ragtime/db/migrations/` as the source of truth.
-- When scaffolding backend code, wire database configuration to `.ragtime/db/app.sqlite3` so local preview/runtime stays deterministic.
-
-**Delivery checklist (both lanes in one pass):**
-1. Create/extend the SQLite migration chain for any local state schema needs.
-2. Wire live data via `context.components[componentId].execute()` for dashboard datasets.
-3. Ensure local SQLite reads supplement but never replace live data connections.
-4. Validate all changed files, then snapshot.
-"""
-
 # Reusable hint appended to validation/tool feedback when sqlite_persistence_mode=include.
 # Keeps the two-lane expectation visible in error/violation payloads without duplicating prose.
 SQLITE_INCLUDE_MODE_HINT = (
     "This workspace has SQLite local persistence enabled (include mode). "
-    "Live data wiring remains required for dashboard datasets; additionally, "
-    "persist local app state in .ragtime/db/app.sqlite3 with numbered SQL "
-    "migration files in .ragtime/db/migrations/. You own creating and maintaining those migrations."
+    "When selected tools are part of the requested feature, live data wiring remains required for dashboard datasets. "
+    "When local schema needs change, persist local app state in .ragtime/db/app.sqlite3 with numbered SQL migration files in .ragtime/db/migrations/. "
+    "You own creating and maintaining those migrations."
 )
 
 
@@ -926,7 +901,6 @@ You are operating in User Space mode for a persistent workspace artifact workflo
 - As complexity grows, split concerns into stable `dashboard/*` subpaths such as components, data, charts, and styles.
 - For multi-page or multi-route apps, keep clear page names, shared layout components, and clean module boundaries.
 {sqlite_persistence_block}
-{shared_sqlite_fragment}
 
 #### Optional platform primitives
 
@@ -998,8 +972,11 @@ def build_userspace_mode_prompt_addition(
         data_wiring_block = ""
 
     return _build_userspace_mode_prompt_template(available_tool_names).format(
-        sqlite_persistence_block=(_USERSPACE_SQLITE_PERSISTENCE_BLOCK if include_sqlite_persistence else ""),
-        shared_sqlite_fragment=build_shared_sqlite_prompt_fragment(shared_sqlite_databases or []),
+        sqlite_persistence_block=build_userspace_data_and_persistence_boundaries_fragment(
+            include_sqlite_persistence=include_sqlite_persistence,
+            has_live_data_tools=has_live_data_tools,
+            shared_sqlite_databases=shared_sqlite_databases or [],
+        ),
         data_wiring_block=data_wiring_block,
         workspace_continuity=workspace_continuity,
     )
@@ -1205,21 +1182,21 @@ _USERSPACE_RUNTIME_BRIDGE_BLOCK = """
 This workspace runs a real server entrypoint, so fetch live tool data from your
 SERVER code via the runtime bridge instead of wiring context.components[...] in
 browser modules:
-- Env vars available to the server process: RAGTIME_BRIDGE_URL, RAGTIME_BRIDGE_TOKEN.
-- Contract: POST {RAGTIME_BRIDGE_URL}/execute-component with header
+- Env vars available to the server process: `RAGTIME_BRIDGE_URL`, `RAGTIME_BRIDGE_TOKEN`.
+- Contract: POST `{RAGTIME_BRIDGE_URL}/execute-component` with header
   `Authorization: Bearer $RAGTIME_BRIDGE_TOKEN` and JSON body
   `{"component_id": "<selected component id>", "request": {"query": "SELECT ... LIMIT 100"}}`.
 - For HTTP API-backed components, the same JSON body can instead be
   `{"component_id": "<selected component id>", "request": {"method": "GET", "path": "/customers"}}` (plus optional `query`, approved
   `headers`, `json_body`, `form_body`, or `response_selector`). Do not include credentials in app code.
 - Responses are `{rows, columns, row_count, error}` — same shape as the browser bridge.
-- Write access has two lanes; do not mix them:
-  - SERVER lane (this bridge, bearer token): follows Workspace Tools access policy.
+- Write access has two execution surfaces; do not mix them:
+  - SERVER execution surface (this bridge, bearer token): follows Workspace Tools access policy.
     Tools default read-only unless the workspace owner has Read+Write access and explicitly enables write
     access for the workspace.
-  - BROWSER lane (`context.components[...].execute()` in preview/shared pages):
+  - BROWSER execution surface (`context.components[...].execute()` in preview/shared pages):
     ALWAYS read-only, regardless of the workspace write toggle. Its request payload
-    comes from the browser, so the platform rejects writes on this lane by design.
+    comes from the browser, so the platform rejects writes on this execution surface by design.
 - Never attempt INSERT/UPDATE/DELETE or other mutations from browser code. Route
   every mutation through your own server route, and have the server call this bridge.
 - The runtime token is the backend service identity; backend mutation routes must enforce their own authz/authn and must never expose that token to browser code.
@@ -1264,7 +1241,9 @@ def build_shared_sqlite_prompt_fragment(accessible_databases: list[dict[str, str
         )
 
     return (
-        "\n\n### Shared SQLite cross-workspace reference\n"
+        "\n##### Shared SQLite target workspaces\n"
+        "- Shared SQLite is not a third persistence lane and never substitutes for selected live-tool data.\n"
+        "- `/sqlite/query` and `/sqlite/mutate` are only for cross-workspace access. Browser code must call an app-owned server route, and must never call bridge endpoints directly or receive `RAGTIME_BRIDGE_TOKEN`.\n"
         "- Use Shared SQLite from server code only. Call `POST {RAGTIME_BRIDGE_URL}/sqlite/query` or `POST {RAGTIME_BRIDGE_URL}/sqlite/mutate` with `Authorization: Bearer $RAGTIME_BRIDGE_TOKEN`. Never send the bridge token, raw credentials, or server bridge calls to browser code.\n"
         "- A server-backed entrypoint is required for this access. Static or missing entrypoints cannot execute these server bridge calls until you add backend/server code.\n"
         '- Query contract: `POST {RAGTIME_BRIDGE_URL}/sqlite/query` with `target_workspace_id`, fixed `database_name: "app.sqlite3"`, parameterized SQL, positional-list or named-dict `parameters`, and `max_rows` up to 500. Responses include `columns`, `rows`, `row_count`, and `truncated`.\n'
@@ -1277,6 +1256,56 @@ def build_shared_sqlite_prompt_fragment(accessible_databases: list[dict[str, str
         "- Failure handling: Handle HTTP 409 as busy, 504 as timeout, and 503 as audit unavailable. A 503 audit failure occurs before writes and is safe to retry. Do not blindly retry other mutation failures.\n"
         "- Accessible targets:\n" + "\n".join(target_lines) + "\n"
     )
+
+
+def build_userspace_data_and_persistence_boundaries_fragment(
+    *,
+    include_sqlite_persistence: bool,
+    has_live_data_tools: bool,
+    shared_sqlite_databases: list[dict[str, str]],
+) -> str:
+    """Build the combined data/persistence guidance block when any relevant boundary applies."""
+
+    shared_fragment = build_shared_sqlite_prompt_fragment(shared_sqlite_databases)
+    if not include_sqlite_persistence and not shared_fragment:
+        return ""
+
+    sections = [
+        "\n\n#### Data and persistence boundaries\n",
+        "- These sections define responsibilities, not mandatory work in every turn.\n",
+    ]
+
+    if include_sqlite_persistence and has_live_data_tools:
+        sections.extend(
+            [
+                "\n##### Lane A - Live tool data\n",
+                "- Use the approved execution surface for the current entrypoint when fetching live datasets.\n",
+                "- Live tool responses are the source of truth for rendered data. Never substitute SQLite tables or local snapshots for live datasets.\n",
+                "- All `live_data_connections`, `live_data_checks`, and AST `execute()` binding rules still apply.\n",
+            ]
+        )
+
+    if include_sqlite_persistence:
+        sections.extend(
+            [
+                "\n##### Lane B - Primary workspace SQLite\n",
+                "- Primary workspace SQLite is accessed directly from server code at `.ragtime/db/app.sqlite3`; its workspace owns migrations and DDL.\n",
+                "- Use it for local domain/app state (for example: user preferences, UI state, cache, drafts, operational data, computed aggregations for offline use).\n",
+                "- You are responsible for persistence lifecycle management in include mode: design schema changes, add migrations, apply them in runtime/bootstrap, and keep migration history forward-only.\n",
+                "- Every schema change requires a new numbered migration file in `.ragtime/db/migrations/` in lexical order (`0001_init.sql`, `0002_add_table.sql`, ...).\n",
+                "- The workspace includes a runner at `.ragtime/scripts/sqlite_migrate.py`; keep it or replace it with an equivalent migration apply step.\n",
+                "- Runtime bootstrap should run `.ragtime/scripts/sqlite_migrate.py --db .ragtime/db/app.sqlite3 --migrations .ragtime/db/migrations` so migrations apply on start/restart.\n",
+                "- The default runner tracks applied migrations in `_ragtime_migrations` with SHA-256 checksums.\n",
+                "- Never edit a previously applied migration file; always create a new migration.\n",
+                "- If the project is JavaScript/TypeScript and an ORM is appropriate, Prisma is an optional query/modeling layer with a SQLite datasource; keep workspace persistence migrations in `.ragtime/db/migrations/` as the source of truth.\n",
+                "- When scaffolding backend code, wire database configuration to `.ragtime/db/app.sqlite3` so local preview/runtime stays deterministic.\n",
+            ]
+        )
+
+    if shared_fragment:
+        sections.append(shared_fragment)
+
+    return "".join(sections)
 
 
 # Nudge for missing/default entrypoint – lightweight suggestion style.

--- a/ragtime/rag/prompts.py
+++ b/ragtime/rag/prompts.py
@@ -1226,6 +1226,17 @@ browser modules:
 - The runtime token is the backend service identity; backend mutation routes must enforce their own authz/authn and must never expose that token to browser code.
 - The browser bridge (`context.components[...]`) still works and remains correct
   for static-page reads; prefer the server bridge for backend routes and data APIs.
+
+### Shared SQLite cross-workspace reference
+- Use Shared SQLite from server code only. Call `POST {RAGTIME_BRIDGE_URL}/sqlite/query` or `POST {RAGTIME_BRIDGE_URL}/sqlite/mutate` with `Authorization: Bearer $RAGTIME_BRIDGE_TOKEN`. Never send the bridge token, raw credentials, or server bridge calls to browser code.
+- Query contract: `POST {RAGTIME_BRIDGE_URL}/sqlite/query` with `target_workspace_id`, fixed `database_name: "app.sqlite3"`, parameterized SQL, positional-list or named-dict `parameters`, and `max_rows` up to 500. Responses include `columns`, `rows`, `row_count`, and `truncated`.
+- Example query: `{"target_workspace_id": "ws_target", "database_name": "app.sqlite3", "sql": "SELECT * FROM orders WHERE customer_id = :customer_id LIMIT 100", "parameters": {"customer_id": "<customer_id>"}, "max_rows": 100}`.
+- Mutation contract: `POST {RAGTIME_BRIDGE_URL}/sqlite/mutate` with a target and 1..500 structured `insert`, `upsert`, `update`, or `delete` operations. Use `table`, `values`, nonempty `where` for update/delete, and `conflict_columns` for upsert. The bridge does not accept raw writable SQL.
+- Example mutate payload: `{"target_workspace_id": "ws_target", "database_name": "app.sqlite3", "operations": [{"kind": "update", "table": "orders", "values": {"status": "<status>"}, "where": {"id": "<order_id>"}}]}`.
+- Access rules: The target owner must grant Shared SQLite access. Read grants allow queries; Read / Write grants allow structured mutations.
+- Membership rules: The runtime's leased user must keep source membership plus target viewer membership for query or target editor membership for mutation.
+- Schema rules: The target workspace owns `.ragtime/db/migrations/*.sql` and all DDL. Consumers cannot run DDL, PRAGMA, ATTACH, or extension loading.
+- Failure handling: Handle HTTP 409 as busy, 504 as timeout, and 503 as audit unavailable. A 503 audit failure occurs before writes and is safe to retry. Do not blindly retry other mutation failures.
 """.strip()
 
 # Nudge for missing/default entrypoint – lightweight suggestion style.

--- a/ragtime/rag/prompts.py
+++ b/ragtime/rag/prompts.py
@@ -17,6 +17,7 @@ The system prompt is composed of these sections in order:
 
 from __future__ import annotations
 
+import json
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Iterable, List, Mapping, Optional, Sequence
@@ -925,6 +926,7 @@ You are operating in User Space mode for a persistent workspace artifact workflo
 - As complexity grows, split concerns into stable `dashboard/*` subpaths such as components, data, charts, and styles.
 - For multi-page or multi-route apps, keep clear page names, shared layout components, and clean module boundaries.
 {sqlite_persistence_block}
+{shared_sqlite_fragment}
 
 #### Optional platform primitives
 
@@ -976,6 +978,7 @@ def build_userspace_mode_prompt_addition(
     has_live_data_tools: bool = True,
     workspace_continuity: str = "",
     available_tool_names: set[str] | None = None,
+    shared_sqlite_databases: list[dict[str, str]] | None = None,
 ) -> str:
     """Build userspace prompt additions with optional SQLite guidance and workspace continuity.
 
@@ -996,14 +999,10 @@ def build_userspace_mode_prompt_addition(
 
     return _build_userspace_mode_prompt_template(available_tool_names).format(
         sqlite_persistence_block=(_USERSPACE_SQLITE_PERSISTENCE_BLOCK if include_sqlite_persistence else ""),
+        shared_sqlite_fragment=build_shared_sqlite_prompt_fragment(shared_sqlite_databases or []),
         data_wiring_block=data_wiring_block,
         workspace_continuity=workspace_continuity,
     )
-
-
-USERSPACE_MODE_PROMPT_ADDITION = build_userspace_mode_prompt_addition(
-    include_sqlite_persistence=True,
-)
 
 
 _CHAT_DIAGNOSTICS_PROMPT_HEADER = """
@@ -1226,18 +1225,59 @@ browser modules:
 - The runtime token is the backend service identity; backend mutation routes must enforce their own authz/authn and must never expose that token to browser code.
 - The browser bridge (`context.components[...]`) still works and remains correct
   for static-page reads; prefer the server bridge for backend routes and data APIs.
-
-### Shared SQLite cross-workspace reference
-- Use Shared SQLite from server code only. Call `POST {RAGTIME_BRIDGE_URL}/sqlite/query` or `POST {RAGTIME_BRIDGE_URL}/sqlite/mutate` with `Authorization: Bearer $RAGTIME_BRIDGE_TOKEN`. Never send the bridge token, raw credentials, or server bridge calls to browser code.
-- Query contract: `POST {RAGTIME_BRIDGE_URL}/sqlite/query` with `target_workspace_id`, fixed `database_name: "app.sqlite3"`, parameterized SQL, positional-list or named-dict `parameters`, and `max_rows` up to 500. Responses include `columns`, `rows`, `row_count`, and `truncated`.
-- Example query: `{"target_workspace_id": "ws_target", "database_name": "app.sqlite3", "sql": "SELECT * FROM orders WHERE customer_id = :customer_id LIMIT 100", "parameters": {"customer_id": "<customer_id>"}, "max_rows": 100}`.
-- Mutation contract: `POST {RAGTIME_BRIDGE_URL}/sqlite/mutate` with a target and 1..500 structured `insert`, `upsert`, `update`, or `delete` operations. Use `table`, `values`, nonempty `where` for update/delete, and `conflict_columns` for upsert. The bridge does not accept raw writable SQL.
-- Example mutate payload: `{"target_workspace_id": "ws_target", "database_name": "app.sqlite3", "operations": [{"kind": "update", "table": "orders", "values": {"status": "<status>"}, "where": {"id": "<order_id>"}}]}`.
-- Access rules: The target owner must grant Shared SQLite access. Read grants allow queries; Read / Write grants allow structured mutations.
-- Membership rules: The runtime's leased user must keep source membership plus target viewer membership for query or target editor membership for mutation.
-- Schema rules: The target workspace owns `.ragtime/db/migrations/*.sql` and all DDL. Consumers cannot run DDL, PRAGMA, ATTACH, or extension loading.
-- Failure handling: Handle HTTP 409 as busy, 504 as timeout, and 503 as audit unavailable. A 503 audit failure occurs before writes and is safe to retry. Do not blindly retry other mutation failures.
 """.strip()
+
+_SHARED_SQLITE_WORKSPACE_NAME_MAX_CHARS = 120
+
+
+def _sanitize_shared_sqlite_workspace_name(value: str) -> str:
+    normalized = re.sub(r"\s+", " ", str(value or "")).strip()
+    if len(normalized) > _SHARED_SQLITE_WORKSPACE_NAME_MAX_CHARS:
+        normalized = normalized[: _SHARED_SQLITE_WORKSPACE_NAME_MAX_CHARS - 1].rstrip() + "…"
+    return json.dumps(normalized or "Unnamed workspace")
+
+
+def build_shared_sqlite_prompt_fragment(accessible_databases: list[dict[str, str]]) -> str:
+    """Build the Shared SQLite guidance fragment for accessible cross-workspace targets."""
+
+    if not accessible_databases:
+        return ""
+
+    sorted_targets = sorted(
+        accessible_databases,
+        key=lambda item: (
+            str(item.get("workspace_id", "") or ""),
+            str(item.get("workspace_name", "") or ""),
+            str(item.get("access_mode", "") or ""),
+        ),
+    )
+    target_lines: list[str] = []
+    for target in sorted_targets:
+        access_mode = "Read / Write" if target.get("access_mode") == "read_write" else "Read"
+        target_lines.extend(
+            [
+                f"- Workspace: {_sanitize_shared_sqlite_workspace_name(target.get('workspace_name', ''))}",
+                f"- target_workspace_id: `{target.get('workspace_id', '')}`",
+                "- database_name: `app.sqlite3`",
+                f"- effective_permission: {access_mode}",
+            ]
+        )
+
+    return (
+        "\n\n### Shared SQLite cross-workspace reference\n"
+        "- Use Shared SQLite from server code only. Call `POST {RAGTIME_BRIDGE_URL}/sqlite/query` or `POST {RAGTIME_BRIDGE_URL}/sqlite/mutate` with `Authorization: Bearer $RAGTIME_BRIDGE_TOKEN`. Never send the bridge token, raw credentials, or server bridge calls to browser code.\n"
+        "- A server-backed entrypoint is required for this access. Static or missing entrypoints cannot execute these server bridge calls until you add backend/server code.\n"
+        '- Query contract: `POST {RAGTIME_BRIDGE_URL}/sqlite/query` with `target_workspace_id`, fixed `database_name: "app.sqlite3"`, parameterized SQL, positional-list or named-dict `parameters`, and `max_rows` up to 500. Responses include `columns`, `rows`, `row_count`, and `truncated`.\n'
+        '- Example query: `{"target_workspace_id": "ws_target", "database_name": "app.sqlite3", "sql": "SELECT * FROM orders WHERE customer_id = :customer_id LIMIT 100", "parameters": {"customer_id": "<customer_id>"}, "max_rows": 100}`.\n'
+        "- Mutation contract: `POST {RAGTIME_BRIDGE_URL}/sqlite/mutate` with a target and 1..500 structured `insert`, `upsert`, `update`, or `delete` operations. Use `table`, `values`, nonempty `where` for update/delete, and `conflict_columns` for upsert. The bridge does not accept raw writable SQL.\n"
+        '- Example mutate payload: `{"target_workspace_id": "ws_target", "database_name": "app.sqlite3", "operations": [{"kind": "update", "table": "orders", "values": {"status": "<status>"}, "where": {"id": "<order_id>"}}]}`.\n'
+        "- Access rules: The target owner must grant Shared SQLite access. Read grants allow queries; Read / Write grants allow structured mutations.\n"
+        "- Membership rules: The runtime's leased user must keep source membership plus target viewer membership for query or target editor membership for mutation.\n"
+        "- Schema rules: The target workspace owns `.ragtime/db/migrations/*.sql` and all DDL. Consumers cannot run DDL, PRAGMA, ATTACH, or extension loading.\n"
+        "- Failure handling: Handle HTTP 409 as busy, 504 as timeout, and 503 as audit unavailable. A 503 audit failure occurs before writes and is safe to retry. Do not blindly retry other mutation failures.\n"
+        "- Accessible targets:\n" + "\n".join(target_lines) + "\n"
+    )
+
 
 # Nudge for missing/default entrypoint – lightweight suggestion style.
 _USERSPACE_ENTRYPOINT_MISSING_NUDGE = """
@@ -1297,6 +1337,11 @@ def build_userspace_entrypoint_nudge(
     if status.framework != "static":
         prompt += "\n\n" + _USERSPACE_RUNTIME_BRIDGE_BLOCK
     return prompt
+
+
+USERSPACE_MODE_PROMPT_ADDITION = build_userspace_mode_prompt_addition(
+    include_sqlite_persistence=True,
+)
 
 
 def build_index_system_prompt(index_metadata: List[dict]) -> str:

--- a/ragtime/userspace/cross_workspace_sqlite.py
+++ b/ragtime/userspace/cross_workspace_sqlite.py
@@ -1,0 +1,737 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import sqlite3
+import time
+import weakref
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Literal, cast
+
+from fastapi import HTTPException
+
+from ragtime.core.workspace_ops import normalize_runtime_file_path
+from ragtime.userspace import sqlite_inspector
+
+LOGGER = logging.getLogger(__name__)
+
+_SQLITE_PATH = f"{sqlite_inspector.MANAGED_DB_DIRNAME}/{sqlite_inspector.DEFAULT_DATABASE_NAME}"
+_SQLITE_URI_SUFFIX = "?mode=ro"
+_QUERY_MAX_SQL_BYTES = 32 * 1024
+_QUERY_MAX_RESPONSE_BYTES = 1024 * 1024
+_MUTATION_MAX_PAYLOAD_BYTES = 1024 * 1024
+_MAX_BIND_PARAMETERS = 500
+_DEFAULT_QUERY_TIMEOUT_SECONDS = 2.0
+_DEFAULT_BUSY_TIMEOUT_MS = 5000
+_RETRY_DELAYS_SECONDS = (0.1, 0.25)
+_AUTHORIZE_DENY = getattr(sqlite3, "SQLITE_DENY", 1)
+_AUTHORIZE_OK = getattr(sqlite3, "SQLITE_OK", 0)
+_ALLOWED_LEADING_TOKENS = {"SELECT", "WITH", "EXPLAIN"}
+_DENIED_FUNCTIONS = {"load_extension", "writefile", "readfile", "fts3_tokenizer"}
+MutationKind = Literal["insert", "upsert", "update", "delete"]
+_MUTATION_KINDS: frozenset[MutationKind] = frozenset(("insert", "upsert", "update", "delete"))
+_SUPPORTED_VALUE_TYPES = (type(None), bool, int, float, str, bytes)
+_SQLITE_BUSY_CODES = {
+    getattr(sqlite3, "SQLITE_BUSY", 5),
+    getattr(sqlite3, "SQLITE_LOCKED", 6),
+}
+_SQLITE_INTERRUPT = getattr(sqlite3, "SQLITE_INTERRUPT", 9)
+_SQLITE_CANTOPEN = getattr(sqlite3, "SQLITE_CANTOPEN", 14)
+_SQLITE_INT64_MIN = -(2**63)
+_SQLITE_INT64_MAX = 2**63 - 1
+_MUTATION_LOCKS: weakref.WeakValueDictionary[Path, "_PathLockBox"] = weakref.WeakValueDictionary()
+
+_DENIED_ACTION_CODES = {
+    code
+    for code in (
+        getattr(sqlite3, "SQLITE_INSERT", None),
+        getattr(sqlite3, "SQLITE_UPDATE", None),
+        getattr(sqlite3, "SQLITE_DELETE", None),
+        getattr(sqlite3, "SQLITE_CREATE_INDEX", None),
+        getattr(sqlite3, "SQLITE_CREATE_TABLE", None),
+        getattr(sqlite3, "SQLITE_CREATE_TEMP_INDEX", None),
+        getattr(sqlite3, "SQLITE_CREATE_TEMP_TABLE", None),
+        getattr(sqlite3, "SQLITE_CREATE_TEMP_TRIGGER", None),
+        getattr(sqlite3, "SQLITE_CREATE_TEMP_VIEW", None),
+        getattr(sqlite3, "SQLITE_CREATE_TRIGGER", None),
+        getattr(sqlite3, "SQLITE_CREATE_VIEW", None),
+        getattr(sqlite3, "SQLITE_CREATE_VTABLE", None),
+        getattr(sqlite3, "SQLITE_DROP_INDEX", None),
+        getattr(sqlite3, "SQLITE_DROP_TABLE", None),
+        getattr(sqlite3, "SQLITE_DROP_TEMP_INDEX", None),
+        getattr(sqlite3, "SQLITE_DROP_TEMP_TABLE", None),
+        getattr(sqlite3, "SQLITE_DROP_TEMP_TRIGGER", None),
+        getattr(sqlite3, "SQLITE_DROP_TEMP_VIEW", None),
+        getattr(sqlite3, "SQLITE_DROP_TRIGGER", None),
+        getattr(sqlite3, "SQLITE_DROP_VIEW", None),
+        getattr(sqlite3, "SQLITE_DROP_VTABLE", None),
+        getattr(sqlite3, "SQLITE_ALTER_TABLE", None),
+        getattr(sqlite3, "SQLITE_TRANSACTION", None),
+        getattr(sqlite3, "SQLITE_SAVEPOINT", None),
+        getattr(sqlite3, "SQLITE_ATTACH", None),
+        getattr(sqlite3, "SQLITE_DETACH", None),
+        getattr(sqlite3, "SQLITE_PRAGMA", None),
+        getattr(sqlite3, "SQLITE_REINDEX", None),
+        getattr(sqlite3, "SQLITE_ANALYZE", None),
+    )
+    if code is not None
+}
+
+_SAFE_MESSAGES = {
+    "invalid_sql": "SQL input is invalid.",
+    "invalid_parameters": "Parameters are invalid.",
+    "sql_too_large": "SQL input exceeds the maximum size.",
+    "payload_too_large": "Mutation payload exceeds the maximum size.",
+    "response_too_large": "Query response exceeds the maximum size.",
+    "row_limit_invalid": "Row limit must be between 1 and 500.",
+    "database_not_found": "Managed SQLite database is unavailable.",
+    "sqlite_busy": "Managed SQLite database is busy.",
+    "query_timeout": "SQLite operation timed out.",
+    "sql_not_allowed": "SQL statement is not allowed.",
+    "query_failed": "SQLite query failed.",
+    "mutation_failed": "SQLite mutation failed.",
+    "audit_unavailable": "Mutation audit could not be recorded.",
+}
+
+
+@dataclass
+class CrossWorkspaceSqlitePolicy:
+    query_timeout_seconds: float = _DEFAULT_QUERY_TIMEOUT_SECONDS
+    busy_timeout_ms: int = _DEFAULT_BUSY_TIMEOUT_MS
+
+
+@dataclass(frozen=True)
+class QueryResult:
+    columns: list[str]
+    rows: list[dict[str, Any]]
+    row_count: int
+    truncated: bool = False
+
+
+@dataclass(frozen=True)
+class MutationOperation:
+    kind: MutationKind
+    table: str
+    values: Mapping[str, Any] | None = None
+    where: Mapping[str, Any] | None = None
+    conflict_columns: Sequence[str] | None = None
+
+
+@dataclass(frozen=True)
+class MutationOperationResult:
+    kind: MutationKind
+    rowcount: int
+    lastrowid: int | None = None
+
+
+@dataclass(frozen=True)
+class MutationResult:
+    operations: list[MutationOperationResult]
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class AuditIdentityContext:
+    actor_id: str
+    actor_type: str = "user"
+    request_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AuditIntent:
+    fingerprint: str
+    operation_count: int
+    identity_context: AuditIdentityContext
+
+
+@dataclass(frozen=True)
+class AuditOutcome:
+    fingerprint: str
+    operation_count: int
+    identity_context: AuditIdentityContext
+    status: str
+    error_code: str | None = None
+
+
+@dataclass
+class _PreparedMutationOperation:
+    kind: MutationKind
+    table: str
+    values: dict[str, Any] = field(default_factory=dict)
+    where: dict[str, Any] = field(default_factory=dict)
+    conflict_columns: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _PathLockBox:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+class CrossWorkspaceSqliteError(Exception):
+    def __init__(self, code: str):
+        self.code = code
+        self.safe_message = _SAFE_MESSAGES[code]
+        super().__init__(self.safe_message)
+
+
+class CrossWorkspaceSqliteBroker:
+    def __init__(self, policy: CrossWorkspaceSqlitePolicy):
+        self.policy = policy
+
+    async def query(
+        self,
+        workspace_files_dir: Path,
+        sql: str,
+        *,
+        parameters: Sequence[Any] | Mapping[str, Any] | None = None,
+        max_rows: int = 200,
+    ) -> QueryResult:
+        if isinstance(max_rows, bool) or not isinstance(max_rows, int) or max_rows < 1 or max_rows > 500:
+            raise CrossWorkspaceSqliteError("row_limit_invalid")
+        statement = _validate_query_sql(sql)
+        bindings = _normalize_bind_parameters(parameters)
+        db_path = _resolve_managed_db_path(workspace_files_dir)
+        return await asyncio.to_thread(
+            _execute_query,
+            db_path,
+            statement,
+            bindings,
+            max_rows,
+            self.policy,
+        )
+
+    async def mutate(
+        self,
+        workspace_files_dir: Path,
+        operations: Sequence[MutationOperation],
+        *,
+        audit_context: AuditIdentityContext,
+        audit_intent_callback: Callable[[AuditIntent], Any],
+        audit_outcome_callback: Callable[[AuditOutcome], Any] | None = None,
+    ) -> MutationResult:
+        prepared = _prepare_mutation_operations(operations)
+        _validate_mutation_payload_size(prepared)
+        fingerprint = self.fingerprint_operations(prepared)
+        intent = AuditIntent(
+            fingerprint=fingerprint,
+            operation_count=len(prepared),
+            identity_context=audit_context,
+        )
+        if not await _call_audit_intent(audit_intent_callback, intent):
+            raise CrossWorkspaceSqliteError("audit_unavailable")
+
+        db_path = _resolve_managed_db_path(workspace_files_dir)
+        lock_box = _mutation_lock_for(db_path)
+        error: CrossWorkspaceSqliteError | None = None
+        results: list[MutationOperationResult] | None = None
+        async with lock_box.lock:
+            try:
+                results = await asyncio.to_thread(_execute_mutation_transaction, db_path, prepared, self.policy)
+            except CrossWorkspaceSqliteError as exc:
+                error = exc
+            except Exception as exc:
+                error = CrossWorkspaceSqliteError("mutation_failed")
+                error.__cause__ = exc
+
+        if error is not None:
+            await _call_audit_outcome(
+                audit_outcome_callback,
+                AuditOutcome(
+                    fingerprint=fingerprint,
+                    operation_count=len(prepared),
+                    identity_context=audit_context,
+                    status=_outcome_status_for_error(error.code),
+                    error_code=error.code,
+                ),
+            )
+            raise error
+
+        await _call_audit_outcome(
+            audit_outcome_callback,
+            AuditOutcome(
+                fingerprint=fingerprint,
+                operation_count=len(prepared),
+                identity_context=audit_context,
+                status="committed",
+                error_code=None,
+            ),
+        )
+        return MutationResult(operations=results or [], fingerprint=fingerprint)
+
+    async def checkpoint(self, workspace_files_dir: Path) -> None:
+        db_path = _resolve_managed_db_path(workspace_files_dir)
+        lock_box = _mutation_lock_for(db_path)
+        async with lock_box.lock:
+            await asyncio.to_thread(_execute_wal_checkpoint, db_path, self.policy)
+
+    def fingerprint_operations(self, operations: Sequence[MutationOperation | _PreparedMutationOperation]) -> str:
+        canonical = {
+            "version": 1,
+            "operations": [
+                {
+                    "index": index,
+                    "kind": operation.kind,
+                    "table": operation.table,
+                    "value_columns": sorted((operation.values or {}).keys()),
+                    "predicate_columns": sorted((operation.where or {}).keys()),
+                    "conflict_columns": sorted(operation.conflict_columns or []),
+                }
+                for index, operation in enumerate(operations)
+            ],
+        }
+        payload = json.dumps(canonical, separators=(",", ":"), sort_keys=True, ensure_ascii=False).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+
+def _mutation_lock_for(db_path: Path) -> _PathLockBox:
+    canonical = db_path.resolve()
+    lock_box = _MUTATION_LOCKS.get(canonical)
+    if lock_box is None:
+        lock_box = _PathLockBox()
+        _MUTATION_LOCKS[canonical] = lock_box
+    return lock_box
+
+
+def _resolve_managed_db_path(workspace_files_dir: Path) -> Path:
+    clean_path = normalize_runtime_file_path(_SQLITE_PATH, enforce_sqlite_managed=True)
+    workspace_root = workspace_files_dir.resolve()
+    db_path = (workspace_root / clean_path).resolve()
+    try:
+        db_path.relative_to(workspace_root)
+    except ValueError as exc:
+        raise CrossWorkspaceSqliteError("database_not_found") from exc
+    return db_path
+
+
+def _validate_query_sql(sql: str) -> str:
+    if not isinstance(sql, str):
+        raise CrossWorkspaceSqliteError("invalid_sql")
+    encoded = (sql or "").encode("utf-8")
+    if len(encoded) > _QUERY_MAX_SQL_BYTES:
+        raise CrossWorkspaceSqliteError("sql_too_large")
+    cleaned = (sql or "").strip()
+    if not cleaned:
+        raise CrossWorkspaceSqliteError("invalid_sql")
+    statement = cleaned[:-1].strip() if cleaned.endswith(";") else cleaned
+    if not statement or ";" in statement:
+        raise CrossWorkspaceSqliteError("invalid_sql")
+    leading_token = statement.split(None, 1)[0].upper() if statement.split(None, 1) else ""
+    if leading_token not in _ALLOWED_LEADING_TOKENS:
+        raise CrossWorkspaceSqliteError("sql_not_allowed")
+    return statement
+
+
+def _normalize_bind_parameters(parameters: Sequence[Any] | Mapping[str, Any] | None) -> Sequence[Any] | Mapping[str, Any]:
+    if parameters is None:
+        return ()
+    if isinstance(parameters, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, value in parameters.items():
+            if not isinstance(key, str):
+                raise CrossWorkspaceSqliteError("invalid_parameters")
+            normalized[key] = _validate_bind_value(value)
+        if len(normalized) > _MAX_BIND_PARAMETERS:
+            raise CrossWorkspaceSqliteError("invalid_parameters")
+        return normalized
+    if isinstance(parameters, (str, bytes, bytearray)) or not isinstance(parameters, Sequence):
+        raise CrossWorkspaceSqliteError("invalid_parameters")
+    normalized_values = tuple(_validate_bind_value(value) for value in parameters)
+    if len(normalized_values) > _MAX_BIND_PARAMETERS:
+        raise CrossWorkspaceSqliteError("invalid_parameters")
+    return normalized_values
+
+
+def _validate_bind_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value < _SQLITE_INT64_MIN or value > _SQLITE_INT64_MAX:
+            raise CrossWorkspaceSqliteError("invalid_parameters")
+        return value
+    if isinstance(value, _SUPPORTED_VALUE_TYPES):
+        return value
+    raise CrossWorkspaceSqliteError("invalid_parameters")
+
+
+def _authorizer(action_code: int, param1: str | None, param2: str | None, _db_name: str | None, _trigger: str | None) -> int:
+    try:
+        if action_code in _DENIED_ACTION_CODES:
+            return _AUTHORIZE_DENY
+        if action_code == getattr(sqlite3, "SQLITE_FUNCTION", -1):
+            names = {str(value or "").lower() for value in (param1, param2)}
+            if names & _DENIED_FUNCTIONS:
+                return _AUTHORIZE_DENY
+    except Exception:
+        return _AUTHORIZE_DENY
+    return _AUTHORIZE_OK
+
+
+def _deadline_progress_handler(deadline: float) -> Callable[[], int]:
+    def _progress() -> int:
+        try:
+            return 1 if time.monotonic() >= deadline else 0
+        except Exception:
+            return 1
+
+    return _progress
+
+
+def _connect_readonly(db_path: Path, policy: CrossWorkspaceSqlitePolicy) -> sqlite3.Connection:
+    if not db_path.exists():
+        raise CrossWorkspaceSqliteError("database_not_found")
+    try:
+        connection = sqlite3.connect(
+            db_path.resolve().as_uri() + _SQLITE_URI_SUFFIX,
+            uri=True,
+            timeout=max(policy.busy_timeout_ms, 1) / 1000,
+            isolation_level=None,
+            detect_types=0,
+        )
+    except sqlite3.Error as exc:
+        raise _map_sqlite_error(exc, default_code="database_not_found") from exc
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def _execute_query(
+    db_path: Path,
+    statement: str,
+    parameters: Sequence[Any] | Mapping[str, Any],
+    max_rows: int,
+    policy: CrossWorkspaceSqlitePolicy,
+) -> QueryResult:
+    connection = _connect_readonly(db_path, policy)
+    try:
+        connection.execute(f"PRAGMA busy_timeout = {int(policy.busy_timeout_ms)}")
+        connection.execute("PRAGMA query_only = ON")
+        connection.set_authorizer(_authorizer)
+        connection.set_progress_handler(_deadline_progress_handler(time.monotonic() + float(policy.query_timeout_seconds)), 1000)
+        try:
+            cursor = connection.execute(statement, parameters)
+            column_names = _deduplicate_column_names([str(description[0]) for description in (cursor.description or ())])
+            rows: list[dict[str, Any]] = []
+            response_size = _serialized_utf8_size(column_names)
+            truncated = False
+            for raw_row in cursor:
+                row = {name: _sanitize_cell_value(raw_row[index]) for index, name in enumerate(column_names)}
+                response_size += _serialized_utf8_size(row)
+                if response_size > _QUERY_MAX_RESPONSE_BYTES:
+                    raise CrossWorkspaceSqliteError("response_too_large")
+                if len(rows) >= max_rows:
+                    truncated = True
+                    break
+                rows.append(row)
+        except CrossWorkspaceSqliteError:
+            raise
+        except sqlite3.Error as exc:
+            raise _map_sqlite_error(exc, default_code="query_failed") from exc
+        return QueryResult(columns=column_names, rows=rows, row_count=len(rows), truncated=truncated)
+    finally:
+        connection.close()
+
+
+def _sanitize_cell_value(value: Any) -> Any:
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {"__blob__": True, "size": len(bytes(value))}
+    return value
+
+
+def _serialized_utf8_size(value: Any) -> int:
+    return len(json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+
+
+def _deduplicate_column_names(column_names: Sequence[str]) -> list[str]:
+    deduplicated: list[str] = []
+    seen: set[str] = set()
+    duplicate_counts: dict[str, int] = {}
+    for raw_name in column_names:
+        base_name = raw_name or "column"
+        candidate = base_name
+        if candidate in seen:
+            duplicate_counts[base_name] = duplicate_counts.get(base_name, 1) + 1
+            candidate = f"{base_name}__{duplicate_counts[base_name]}"
+            while candidate in seen:
+                duplicate_counts[base_name] += 1
+                candidate = f"{base_name}__{duplicate_counts[base_name]}"
+        else:
+            duplicate_counts.setdefault(base_name, 1)
+        seen.add(candidate)
+        deduplicated.append(candidate)
+    return deduplicated
+
+
+def _prepare_mutation_operations(operations: Sequence[MutationOperation]) -> list[_PreparedMutationOperation]:
+    if not 1 <= len(operations) <= 500:
+        raise CrossWorkspaceSqliteError("invalid_parameters")
+    prepared: list[_PreparedMutationOperation] = []
+    for operation in operations:
+        raw_kind = str(operation.kind or "").strip().lower()
+        if raw_kind not in _MUTATION_KINDS:
+            raise CrossWorkspaceSqliteError("invalid_parameters")
+        kind = cast(MutationKind, raw_kind)
+        table = _validate_identifier(operation.table)
+        values = _validate_value_mapping(operation.values or {})
+        where = _validate_value_mapping(operation.where or {})
+        conflict_columns = _validate_identifier_list(operation.conflict_columns or [])
+        if kind == "insert" and not values:
+            raise CrossWorkspaceSqliteError("invalid_parameters")
+        if kind == "upsert":
+            if not values or not conflict_columns:
+                raise CrossWorkspaceSqliteError("invalid_parameters")
+        if kind in {"update", "delete"} and not where:
+            raise CrossWorkspaceSqliteError("invalid_parameters")
+        if kind == "update" and not values:
+            raise CrossWorkspaceSqliteError("invalid_parameters")
+        prepared.append(
+            _PreparedMutationOperation(
+                kind=kind,
+                table=table,
+                values=values,
+                where=where,
+                conflict_columns=conflict_columns,
+            )
+        )
+    return prepared
+
+
+def _validate_value_mapping(values: Mapping[str, Any]) -> dict[str, Any]:
+    if not values:
+        return {}
+    normalized: dict[str, Any] = {}
+    for key in sorted(values.keys()):
+        normalized[_validate_identifier(key)] = _validate_bind_value(values[key])
+    return normalized
+
+
+def _validate_identifier(name: str) -> str:
+    try:
+        return sqlite_inspector.validate_identifier(name)
+    except HTTPException as exc:
+        raise CrossWorkspaceSqliteError("invalid_sql") from exc
+
+
+def _validate_identifier_list(values: Sequence[str]) -> list[str]:
+    normalized = [_validate_identifier(value) for value in values]
+    if len(set(normalized)) != len(normalized):
+        raise CrossWorkspaceSqliteError("invalid_sql")
+    return sorted(normalized)
+
+
+def _validate_mutation_payload_size(operations: Sequence[_PreparedMutationOperation]) -> None:
+    bytes_total = 2
+    for operation in operations:
+        payload_shape = {
+            "kind": operation.kind,
+            "table": operation.table,
+            "values": {key: _payload_value_shape(value) for key, value in operation.values.items()},
+            "where": {key: _payload_value_shape(value) for key, value in operation.where.items()},
+            "conflict_columns": list(operation.conflict_columns),
+        }
+        if bytes_total > 2:
+            bytes_total += 1
+        bytes_total += len(json.dumps(payload_shape, separators=(",", ":"), sort_keys=True, ensure_ascii=False).encode("utf-8"))
+        bytes_total += _raw_bytes_size(operation.values.values())
+        bytes_total += _raw_bytes_size(operation.where.values())
+        if bytes_total > _MUTATION_MAX_PAYLOAD_BYTES:
+            raise CrossWorkspaceSqliteError("payload_too_large")
+
+
+def _payload_value_shape(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return {"__bytes__": len(value)}
+    return value
+
+
+def _raw_bytes_size(values: Sequence[Any] | Any) -> int:
+    total = 0
+    for value in values:
+        if isinstance(value, bytes):
+            total += len(value)
+    return total
+
+
+def _execute_mutation_transaction(
+    db_path: Path,
+    operations: Sequence[_PreparedMutationOperation],
+    policy: CrossWorkspaceSqlitePolicy,
+) -> list[MutationOperationResult]:
+    if not db_path.exists():
+        raise CrossWorkspaceSqliteError("database_not_found")
+    attempts = len(_RETRY_DELAYS_SECONDS) + 1
+    for attempt in range(attempts):
+        connection: sqlite3.Connection | None = None
+        try:
+            connection = sqlite3.connect(
+                str(db_path),
+                timeout=max(policy.busy_timeout_ms, 1) / 1000,
+                isolation_level=None,
+                detect_types=0,
+            )
+            connection.execute(f"PRAGMA busy_timeout = {int(policy.busy_timeout_ms)}")
+            connection.execute("PRAGMA foreign_keys = ON")
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.set_progress_handler(_deadline_progress_handler(time.monotonic() + float(policy.query_timeout_seconds)), 1000)
+            connection.execute("BEGIN IMMEDIATE")
+            results = [_execute_prepared_mutation(connection, operation) for operation in operations]
+            connection.execute("COMMIT")
+            return results
+        except CrossWorkspaceSqliteError:
+            if connection is not None:
+                _safe_rollback(connection)
+            raise
+        except sqlite3.Error as exc:
+            if connection is not None:
+                _safe_rollback(connection)
+            mapped = _map_sqlite_error(exc, default_code="mutation_failed")
+            if mapped.code == "sqlite_busy" and attempt < attempts - 1:
+                if connection is not None:
+                    connection.close()
+                time.sleep(_RETRY_DELAYS_SECONDS[attempt])
+                continue
+            raise mapped from exc
+        finally:
+            if connection is not None:
+                connection.close()
+    raise CrossWorkspaceSqliteError("sqlite_busy")
+
+
+def _safe_rollback(connection: sqlite3.Connection) -> None:
+    try:
+        connection.execute("ROLLBACK")
+    except sqlite3.Error:
+        return
+
+
+def _execute_prepared_mutation(connection: sqlite3.Connection, operation: _PreparedMutationOperation) -> MutationOperationResult:
+    if operation.kind == "insert":
+        sql, binds = _render_insert(operation)
+    elif operation.kind == "upsert":
+        sql, binds = _render_upsert(operation)
+    elif operation.kind == "update":
+        sql, binds = _render_update(operation)
+    elif operation.kind == "delete":
+        sql, binds = _render_delete(operation)
+    else:
+        raise CrossWorkspaceSqliteError("invalid_parameters")
+    try:
+        cursor = connection.execute(sql, binds)
+    except sqlite3.Error as exc:
+        raise _map_sqlite_error(exc, default_code="mutation_failed") from exc
+    lastrowid: int | None = None
+    if operation.kind in {"insert", "upsert"} and cursor.lastrowid is not None and cursor.rowcount > 0:
+        lastrowid = int(cursor.lastrowid)
+    return MutationOperationResult(kind=operation.kind, rowcount=int(cursor.rowcount), lastrowid=lastrowid)
+
+
+def _render_insert(operation: _PreparedMutationOperation) -> tuple[str, list[Any]]:
+    columns = list(operation.values.keys())
+    placeholders = ", ".join("?" for _ in columns)
+    sql = (
+        f"INSERT INTO {sqlite_inspector.quote_identifier(operation.table)} "
+        f"({', '.join(sqlite_inspector.quote_identifier(column) for column in columns)}) VALUES ({placeholders})"
+    )
+    return sql, [operation.values[column] for column in columns]
+
+
+def _render_upsert(operation: _PreparedMutationOperation) -> tuple[str, list[Any]]:
+    insert_sql, binds = _render_insert(operation)
+    conflict_sql = ", ".join(sqlite_inspector.quote_identifier(column) for column in operation.conflict_columns)
+    update_columns = [column for column in operation.values.keys() if column not in set(operation.conflict_columns)]
+    if not update_columns:
+        return f"{insert_sql} ON CONFLICT ({conflict_sql}) DO NOTHING", binds
+    assignments = ", ".join(f"{sqlite_inspector.quote_identifier(column)} = excluded.{sqlite_inspector.quote_identifier(column)}" for column in update_columns)
+    return f"{insert_sql} ON CONFLICT ({conflict_sql}) DO UPDATE SET {assignments}", binds
+
+
+def _render_update(operation: _PreparedMutationOperation) -> tuple[str, list[Any]]:
+    assignments = ", ".join(f"{sqlite_inspector.quote_identifier(column)} = ?" for column in operation.values.keys())
+    predicate_sql, predicate_binds = _render_predicates(operation.where)
+    sql = f"UPDATE {sqlite_inspector.quote_identifier(operation.table)} SET {assignments} WHERE {predicate_sql}"
+    return sql, [operation.values[column] for column in operation.values.keys()] + predicate_binds
+
+
+def _render_delete(operation: _PreparedMutationOperation) -> tuple[str, list[Any]]:
+    predicate_sql, predicate_binds = _render_predicates(operation.where)
+    sql = f"DELETE FROM {sqlite_inspector.quote_identifier(operation.table)} WHERE {predicate_sql}"
+    return sql, predicate_binds
+
+
+def _render_predicates(where: Mapping[str, Any]) -> tuple[str, list[Any]]:
+    clauses: list[str] = []
+    binds: list[Any] = []
+    for column, value in where.items():
+        quoted = sqlite_inspector.quote_identifier(column)
+        if value is None:
+            clauses.append(f"{quoted} IS NULL")
+        else:
+            clauses.append(f"{quoted} = ?")
+            binds.append(value)
+    return " AND ".join(clauses), binds
+
+
+async def _call_audit_intent(callback: Callable[[AuditIntent], Any], intent: AuditIntent) -> bool:
+    try:
+        result = callback(intent)
+        if asyncio.iscoroutine(result):
+            result = await result
+        return bool(result)
+    except Exception:
+        return False
+
+
+async def _call_audit_outcome(callback: Callable[[AuditOutcome], Any] | None, outcome: AuditOutcome) -> None:
+    if callback is None:
+        return
+    try:
+        result = callback(outcome)
+        if asyncio.iscoroutine(result):
+            await result
+    except Exception:
+        LOGGER.warning("Cross-workspace SQLite audit outcome callback failed", exc_info=True)
+
+
+def _outcome_status_for_error(code: str) -> str:
+    if code == "sqlite_busy":
+        return "busy"
+    if code == "query_timeout":
+        return "timeout"
+    return "rolled_back"
+
+
+def _map_sqlite_error(exc: sqlite3.Error, *, default_code: str) -> CrossWorkspaceSqliteError:
+    error_code = getattr(exc, "sqlite_errorcode", None)
+    message = str(exc).lower()
+    if error_code == _SQLITE_INTERRUPT or "interrupted" in message:
+        return CrossWorkspaceSqliteError("query_timeout")
+    if error_code == _SQLITE_CANTOPEN or "unable to open database file" in message or "readonly" in message:
+        return CrossWorkspaceSqliteError("database_not_found")
+    if error_code in _SQLITE_BUSY_CODES or "database is locked" in message or "database is busy" in message:
+        return CrossWorkspaceSqliteError("sqlite_busy")
+    if "not authorized" in message or "prohibited" in message:
+        return CrossWorkspaceSqliteError("sql_not_allowed")
+    return CrossWorkspaceSqliteError(default_code)
+
+
+def _execute_wal_checkpoint(db_path: Path, policy: CrossWorkspaceSqlitePolicy) -> None:
+    if not db_path.exists():
+        raise CrossWorkspaceSqliteError("database_not_found")
+    try:
+        connection = sqlite3.connect(
+            str(db_path),
+            timeout=max(policy.busy_timeout_ms, 1) / 1000,
+            isolation_level=None,
+            detect_types=0,
+        )
+    except sqlite3.Error as exc:
+        raise _map_sqlite_error(exc, default_code="database_not_found") from exc
+    try:
+        connection.execute(f"PRAGMA busy_timeout = {int(policy.busy_timeout_ms)}")
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    except sqlite3.Error as exc:
+        raise _map_sqlite_error(exc, default_code="mutation_failed") from exc
+    finally:
+        connection.close()

--- a/ragtime/userspace/models.py
+++ b/ragtime/userspace/models.py
@@ -1702,12 +1702,22 @@ class SqliteInspectorForeignKeyInfo(BaseModel):
     on_delete: str
 
 
+SqliteInspectorDatabaseOwnership = Literal["owned", "linked"]
+SqliteInspectorDatabaseAccessMode = Literal["read", "read_write"]
+
+
 class SqliteInspectorDatabaseSummary(BaseModel):
     name: str
     relative_path: str
     size_bytes: int
     table_count: int
-    last_modified_ms: int
+    last_modified_ms: int | None
+    owner_workspace_id: str
+    owner_workspace_name: str
+    ownership: SqliteInspectorDatabaseOwnership
+    access_mode: SqliteInspectorDatabaseAccessMode
+    persistence_mode: SqlitePersistenceMode
+    initialized: bool = True
 
 
 class SqliteInspectorDatabaseListResponse(BaseModel):

--- a/ragtime/userspace/models.py
+++ b/ragtime/userspace/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from ragtime.indexer.models import WorkspaceChatStateResponse
 
@@ -164,6 +164,7 @@ class WorkspaceMember(BaseModel):
 
 
 WorkspaceAgentGrantMode = Literal["read", "read_write"]
+WorkspaceSqliteGrantMode = Literal["none", "read", "read_write"]
 
 
 class WorkspaceAgentGrant(BaseModel):
@@ -179,6 +180,7 @@ class WorkspaceAgentGrant(BaseModel):
     target_workspace_id: str
     target_workspace_name: str | None = None
     access_mode: WorkspaceAgentGrantMode = "read"
+    sqlite_access_mode: WorkspaceSqliteGrantMode = "none"
     granted_by_user_id: str
     granted_by_username: str | None = None
     expires_at: datetime | None = None
@@ -197,6 +199,14 @@ class UpsertWorkspaceAgentGrantRequest(BaseModel):
             "Access mode for cross-workspace agent operations. 'read' allows "
             "list/read/search/screenshot only. 'read_write' additionally "
             "allows file mutations and terminal commands."
+        ),
+    )
+    sqlite_access_mode: WorkspaceSqliteGrantMode | None = Field(
+        default=None,
+        description=(
+            "Optional SQLite access mode for cross-workspace agent operations. "
+            "When omitted, existing grants preserve their SQLite setting and new "
+            "grants default to 'none'."
         ),
     )
 
@@ -1839,6 +1849,90 @@ class SqliteInspectorSqlQueryResponse(BaseModel):
     rows: list[dict[str, Any]] = Field(default_factory=list)
     row_count: int = 0
     truncated: bool = False
+
+
+RuntimeBridgeSqliteDatabaseName = Literal["app.sqlite3"]
+RuntimeBridgeSqliteMutationKind = Literal["insert", "upsert", "update", "delete"]
+
+
+class RuntimeBridgeSqliteQueryRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_workspace_id: str = Field(min_length=1)
+    database_name: RuntimeBridgeSqliteDatabaseName = "app.sqlite3"
+    sql: str = Field(min_length=1)
+    parameters: list[Any] | dict[str, Any] | None = None
+    max_rows: int = Field(default=200, ge=1, le=500)
+
+    @field_validator("database_name", mode="before")
+    @classmethod
+    def _normalize_database_name(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+
+class RuntimeBridgeSqliteQueryResponse(BaseModel):
+    target_workspace_id: str
+    database_name: RuntimeBridgeSqliteDatabaseName = "app.sqlite3"
+    columns: list[str] = Field(default_factory=list)
+    rows: list[dict[str, Any]] = Field(default_factory=list)
+    row_count: int = 0
+    truncated: bool = False
+
+
+class RuntimeBridgeSqliteMutationOperation(BaseModel):
+    kind: RuntimeBridgeSqliteMutationKind
+    table: str = Field(min_length=1)
+    values: dict[str, Any] | None = None
+    where: dict[str, Any] | None = None
+    conflict_columns: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> "RuntimeBridgeSqliteMutationOperation":
+        has_values = bool(self.values)
+        has_where = bool(self.where)
+        has_conflict_columns = bool(self.conflict_columns)
+        if self.kind == "insert":
+            if not has_values or has_where or has_conflict_columns:
+                raise ValueError("insert operations require values and do not accept where or conflict_columns")
+        elif self.kind == "upsert":
+            if not has_values or not has_conflict_columns or has_where:
+                raise ValueError("upsert operations require values and conflict_columns and do not accept where")
+        elif self.kind == "update":
+            if not has_values or not has_where or has_conflict_columns:
+                raise ValueError("update operations require values and where and do not accept conflict_columns")
+        elif self.kind == "delete" and (not has_where or has_values or has_conflict_columns):
+            raise ValueError("delete operations require where and do not accept values or conflict_columns")
+        return self
+
+
+class RuntimeBridgeSqliteMutationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_workspace_id: str = Field(min_length=1)
+    database_name: RuntimeBridgeSqliteDatabaseName = "app.sqlite3"
+    operations: list[RuntimeBridgeSqliteMutationOperation] = Field(min_length=1, max_length=500)
+
+    @field_validator("database_name", mode="before")
+    @classmethod
+    def _normalize_mutation_database_name(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+
+class RuntimeBridgeSqliteMutationOperationResponse(BaseModel):
+    kind: RuntimeBridgeSqliteMutationKind
+    rowcount: int
+    lastrowid: int | None = None
+
+
+class RuntimeBridgeSqliteMutationResponse(BaseModel):
+    target_workspace_id: str
+    database_name: RuntimeBridgeSqliteDatabaseName = "app.sqlite3"
+    operations: list[RuntimeBridgeSqliteMutationOperationResponse] = Field(default_factory=list)
+    fingerprint: str
 
 
 class SqliteInspectorRowMutationRequest(BaseModel):

--- a/ragtime/userspace/planning_contract.py
+++ b/ragtime/userspace/planning_contract.py
@@ -12,13 +12,14 @@ from typing import Any
 
 from ragtime.rag.prompts import _WORKSPACE_CONTINUITY_EXISTING_RULES
 
-PLANNING_CONTRACT_VERSION = "1"
+PLANNING_CONTRACT_VERSION = "2"
 
 _STATIC_BUILDER_RULES: list[str] = [
     "The runtime entrypoint lives in .ragtime/runtime-entrypoint.json; launch commands must use $PORT and bind 0.0.0.0.",
     "When the workspace has selected data tools, dashboards must be wired to live tool data; hardcoded/mock datasets are rejected by validation.",
     "Browser-side live data (context.components[...].execute) is always read-only; writes only happen from workspace server code via the runtime bridge, subject to workspace write policy.",
     "SQLite local persistence (.ragtime/db/app.sqlite3 with numbered migrations) supplements live data for local app state; it never replaces live dashboard datasets.",
+    "Shared SQLite access runs from server code only, needs an explicit target-owner grant, and the owner workspace keeps schema and migrations.",
     "Match the app theme using runtime CSS variables/tokens; avoid hardcoded palettes and custom font stacks.",
     "The preview iframe is cross-origin; workspace code must never read context from window.parent or window.top.",
 ]

--- a/ragtime/userspace/routes.py
+++ b/ragtime/userspace/routes.py
@@ -2788,16 +2788,11 @@ async def get_latest_workspace_sqlite_import_task(
 # ---------------------------------------------------------------------------
 
 
-def _serialize_inspector_database(
-    summary: sqlite_inspector_helpers.DatabaseSummary,
-) -> SqliteInspectorDatabaseSummary:
-    return SqliteInspectorDatabaseSummary(
-        name=summary.name,
-        relative_path=summary.relative_path,
-        size_bytes=summary.size_bytes,
-        table_count=summary.table_count,
-        last_modified_ms=summary.last_modified_ms,
-    )
+def _resolved_sqlite_owner_workspace_id(workspace_id: str, owner_workspace_id: str | None) -> str:
+    candidate = str(owner_workspace_id or "").strip()
+    if not candidate or candidate == workspace_id:
+        return workspace_id
+    return candidate
 
 
 def _serialize_inspector_table(
@@ -2921,7 +2916,7 @@ async def _sqlite_database_list_payload(
     )
     return SqliteInspectorDatabaseListResponse(
         workspace_id=workspace_id,
-        databases=[_serialize_inspector_database(d) for d in databases],
+        databases=databases,
         total_bytes=total_bytes,
         default_database_name=sqlite_inspector_helpers.DEFAULT_DATABASE_NAME,
         persistence_mode=("exclude" if mode == "exclude" else "include"),
@@ -2984,6 +2979,7 @@ async def stream_workspace_sqlite_database_events(
 async def initialize_workspace_sqlite_database(
     workspace_id: str,
     request: SqliteInspectorInitializeRequest = Body(default_factory=SqliteInspectorInitializeRequest),
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -2991,14 +2987,19 @@ async def initialize_workspace_sqlite_database(
         workspace_id,
         user.id,
         database_name=request.database_name,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"initialize database {summary.name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"initialize database {summary.name}",
+    )
     return SqliteInspectorInitializeResponse(
         workspace_id=workspace_id,
-        database=_serialize_inspector_database(summary),
+        database=summary,
         mode_promoted=promoted,
-        persistence_mode="include",
+        persistence_mode=summary.persistence_mode,
     )
 
 
@@ -3009,6 +3010,7 @@ async def initialize_workspace_sqlite_database(
 async def delete_workspace_sqlite_database(
     workspace_id: str,
     database_name: str,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3016,9 +3018,14 @@ async def delete_workspace_sqlite_database(
         workspace_id,
         user.id,
         database_name,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"delete database {database_name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"delete database {database_name}",
+    )
     return SqliteInspectorDeleteDatabaseResponse(
         workspace_id=workspace_id,
         database_name=database_name,
@@ -3029,6 +3036,7 @@ async def delete_workspace_sqlite_database(
 async def export_workspace_sqlite_database(
     workspace_id: str,
     database_name: str,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3036,6 +3044,7 @@ async def export_workspace_sqlite_database(
         workspace_id,
         user.id,
         database_name,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
     return FileResponse(
@@ -3054,6 +3063,7 @@ async def import_workspace_sqlite_database(
     workspace_id: str,
     database_name: str,
     database_file: UploadFile = File(...),
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3066,14 +3076,19 @@ async def import_workspace_sqlite_database(
             user.id,
             database_name,
             tmp_path,
+            owner_workspace_id=owner_workspace_id,
             is_admin=is_admin,
         )
     finally:
         tmp_path.unlink(missing_ok=True)
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"import database {summary.name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"import database {summary.name}",
+    )
     return SqliteInspectorImportDatabaseResponse(
         workspace_id=workspace_id,
-        database=_serialize_inspector_database(summary),
+        database=summary,
         mode_promoted=promoted,
     )
 
@@ -3085,6 +3100,7 @@ async def import_workspace_sqlite_database(
 async def list_workspace_sqlite_tables(
     workspace_id: str,
     database_name: str,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3092,14 +3108,14 @@ async def list_workspace_sqlite_tables(
         workspace_id,
         user.id,
         database_name,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    workspace = await userspace_service.get_workspace(workspace_id, user.id)
     return SqliteInspectorTableListResponse(
         workspace_id=workspace_id,
-        database=_serialize_inspector_database(summary),
+        database=summary,
         tables=[_serialize_inspector_table(t) for t in tables],
-        persistence_mode=workspace.sqlite_persistence_mode,
+        persistence_mode=summary.persistence_mode,
         mode_promoted=False,
     )
 
@@ -3113,6 +3129,7 @@ async def create_workspace_sqlite_table(
     workspace_id: str,
     database_name: str,
     request: SqliteInspectorCreateTableRequest,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3123,9 +3140,14 @@ async def create_workspace_sqlite_table(
         request.name,
         _column_specs_to_definitions(request.columns),
         without_rowid=request.without_rowid,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"create table {request.name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"create table {request.name}",
+    )
     return SqliteInspectorCreateTableResponse(
         workspace_id=workspace_id,
         database_name=database_name,
@@ -3142,6 +3164,7 @@ async def get_workspace_sqlite_table_schema(
     workspace_id: str,
     database_name: str,
     table_name: str,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3150,6 +3173,7 @@ async def get_workspace_sqlite_table_schema(
         user.id,
         database_name,
         table_name,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
     return SqliteInspectorTableSchemaResponse(
@@ -3168,6 +3192,7 @@ async def alter_workspace_sqlite_table(
     database_name: str,
     table_name: str,
     request: SqliteInspectorAlterTableRequest,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3178,9 +3203,14 @@ async def alter_workspace_sqlite_table(
         database_name,
         table_name,
         alterations,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"alter table {table_name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"alter table {table_name}",
+    )
     return SqliteInspectorAlterTableResponse(
         workspace_id=workspace_id,
         database_name=database_name,
@@ -3197,6 +3227,7 @@ async def drop_workspace_sqlite_table(
     workspace_id: str,
     database_name: str,
     table_name: str,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3205,9 +3236,14 @@ async def drop_workspace_sqlite_table(
         user.id,
         database_name,
         table_name,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"drop table {table_name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"drop table {table_name}",
+    )
     return SqliteInspectorDropTableResponse(
         workspace_id=workspace_id,
         database_name=database_name,
@@ -3221,6 +3257,7 @@ async def export_workspace_sqlite_table(
     workspace_id: str,
     database_name: str,
     table_name: str,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3229,6 +3266,7 @@ async def export_workspace_sqlite_table(
         user.id,
         database_name,
         table_name,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
     safe_name = sqlite_inspector_helpers.validate_identifier(table_name, kind="Table name")
@@ -3249,6 +3287,7 @@ async def import_workspace_sqlite_table(
     table_name: str,
     csv_file: UploadFile = File(...),
     replace: bool = Form(default=False),
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3264,9 +3303,14 @@ async def import_workspace_sqlite_table(
         table_name,
         csv_text,
         replace=replace,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"import table {table_name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"import table {table_name}",
+    )
     return SqliteInspectorImportTableResponse(
         workspace_id=workspace_id,
         database_name=database_name,
@@ -3287,6 +3331,7 @@ async def list_workspace_sqlite_rows(
     offset: int = Query(default=0, ge=0),
     order_by: str | None = Query(default=None, max_length=64),
     order_direction: str = Query(default="asc"),
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3299,6 +3344,7 @@ async def list_workspace_sqlite_rows(
         offset=offset,
         order_by=order_by,
         order_direction=order_direction,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
     return SqliteInspectorRowPage(
@@ -3324,6 +3370,7 @@ async def insert_workspace_sqlite_row(
     database_name: str,
     table_name: str,
     request: SqliteInspectorRowMutationRequest,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3333,9 +3380,14 @@ async def insert_workspace_sqlite_row(
         database_name,
         table_name,
         request.values,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"insert row in {table_name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"insert row in {table_name}",
+    )
     return SqliteInspectorRowMutationResponse(
         workspace_id=workspace_id,
         database_name=database_name,
@@ -3354,6 +3406,7 @@ async def update_workspace_sqlite_row(
     database_name: str,
     table_name: str,
     request: SqliteInspectorRowUpdateRequest,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3364,9 +3417,14 @@ async def update_workspace_sqlite_row(
         table_name,
         request.row_key,
         request.values,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"update row in {table_name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"update row in {table_name}",
+    )
     return SqliteInspectorRowMutationResponse(
         workspace_id=workspace_id,
         database_name=database_name,
@@ -3385,6 +3443,7 @@ async def delete_workspace_sqlite_row(
     database_name: str,
     table_name: str,
     request: SqliteInspectorRowDeleteRequest,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3394,9 +3453,14 @@ async def delete_workspace_sqlite_row(
         database_name,
         table_name,
         request.row_key,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
-    await _snapshot_after_sqlite_mutation(workspace_id, user.id, f"delete row from {table_name}")
+    await _snapshot_after_sqlite_mutation(
+        _resolved_sqlite_owner_workspace_id(workspace_id, owner_workspace_id),
+        user.id,
+        f"delete row from {table_name}",
+    )
     return SqliteInspectorRowDeleteResponse(
         workspace_id=workspace_id,
         database_name=database_name,
@@ -3413,6 +3477,7 @@ async def query_workspace_sqlite_database(
     workspace_id: str,
     database_name: str,
     request: SqliteInspectorSqlQueryRequest,
+    owner_workspace_id: str | None = Query(default=None),
     user: Any = Depends(get_current_user),
 ):
     is_admin = user.role == "admin"
@@ -3422,6 +3487,7 @@ async def query_workspace_sqlite_database(
         database_name,
         request.sql,
         max_rows=request.max_rows,
+        owner_workspace_id=owner_workspace_id,
         is_admin=is_admin,
     )
     return SqliteInspectorSqlQueryResponse(

--- a/ragtime/userspace/runtime_routes.py
+++ b/ragtime/userspace/runtime_routes.py
@@ -45,10 +45,15 @@ from ragtime.core.userspace_limits import (
     clamp_userspace_primitive_upload_max_bytes,
 )
 from ragtime.indexer.document_parser import extract_text_from_file_async
+from ragtime.userspace.cross_workspace_sqlite import CrossWorkspaceSqliteError
 from ragtime.userspace.html_templates import render_preview_host_unreachable_page_html
 from ragtime.userspace.models import (
     ExecuteComponentRequest,
     ExecuteComponentResponse,
+    RuntimeBridgeSqliteMutationRequest,
+    RuntimeBridgeSqliteMutationResponse,
+    RuntimeBridgeSqliteQueryRequest,
+    RuntimeBridgeSqliteQueryResponse,
     UserSpaceAuthMethod,
     UserSpaceBrowserAuthorization,
     UserSpaceBrowserAuthRequest,
@@ -103,6 +108,22 @@ _PRIMITIVE_JOBS: dict[tuple[str, str], dict[str, Any]] = {}
 # must be kept byte-for-byte in sync. Changing the prefix on only one side
 # silently breaks user-app session persistence in previews.
 _USER_APP_COOKIE_PREFIX = "__ragtime_app_cookie_"
+_RUNTIME_BRIDGE_SQLITE_GENERIC_DETAIL = "Runtime bridge SQLite request failed."
+_RUNTIME_BRIDGE_SQLITE_ERROR_STATUS = {
+    "invalid_sql": 400,
+    "invalid_parameters": 400,
+    "sql_too_large": 400,
+    "payload_too_large": 400,
+    "response_too_large": 400,
+    "row_limit_invalid": 400,
+    "sql_not_allowed": 403,
+    "database_not_found": 404,
+    "sqlite_busy": 409,
+    "audit_unavailable": 503,
+    "query_timeout": 504,
+    "query_failed": 500,
+    "mutation_failed": 500,
+}
 
 
 def _decode_user_app_cookie_name(cookie_name: str) -> str | None:
@@ -1512,6 +1533,20 @@ def _extract_bearer_token(request: Request) -> str | None:
     return None
 
 
+def _require_runtime_bridge_claim(claims: dict[str, Any], key: str) -> str:
+    value = str(claims.get(key) or "").strip()
+    if not value:
+        raise HTTPException(status_code=401, detail="Invalid runtime bridge token")
+    return value
+
+
+def _raise_runtime_bridge_sqlite_error(exc: CrossWorkspaceSqliteError) -> None:
+    status_code = _RUNTIME_BRIDGE_SQLITE_ERROR_STATUS.get(exc.code)
+    if status_code is None:
+        raise HTTPException(status_code=500, detail=_RUNTIME_BRIDGE_SQLITE_GENERIC_DETAIL) from exc
+    raise HTTPException(status_code=status_code, detail=exc.safe_message) from exc
+
+
 def _extract_capability_token_from_websocket(websocket: WebSocket) -> str | None:
     # Capability tokens must travel via Authorization/explicit header only.
     # See _extract_capability_token_from_request.
@@ -2060,6 +2095,83 @@ async def runtime_bridge_execute_component(
         payload,
         session_id=str(claims["session_id"]),
     )
+
+
+@router.post(
+    "/runtime-bridge/sqlite/query",
+    response_model=RuntimeBridgeSqliteQueryResponse,
+)
+@limiter.limit(RUNTIME_BRIDGE_RATE_LIMIT)
+async def runtime_bridge_sqlite_query(
+    request: Request,
+    payload: RuntimeBridgeSqliteQueryRequest,
+):
+    token = _extract_bearer_token(request)
+    claims = await _runtime_service().verify_runtime_bridge_token(token)
+    workspace_id = _require_runtime_bridge_claim(claims, "workspace_id")
+    session_id = _require_runtime_bridge_claim(claims, "session_id")
+    leased_by_user_id = _require_runtime_bridge_claim(claims, "leased_by_user_id")
+    try:
+        return await _userspace_service().query_runtime_bridge_sqlite(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            leased_by_user_id=leased_by_user_id,
+            request=payload,
+        )
+    except HTTPException:
+        raise
+    except CrossWorkspaceSqliteError as exc:
+        _raise_runtime_bridge_sqlite_error(exc)
+    except Exception as exc:
+        logger.exception(
+            "Runtime bridge SQLite query route failed for workspace %s session %s",
+            workspace_id,
+            session_id,
+        )
+        raise HTTPException(status_code=500, detail=_RUNTIME_BRIDGE_SQLITE_GENERIC_DETAIL) from exc
+
+
+@router.post(
+    "/runtime-bridge/sqlite/mutate",
+    response_model=RuntimeBridgeSqliteMutationResponse,
+)
+@limiter.limit(RUNTIME_BRIDGE_RATE_LIMIT)
+async def runtime_bridge_sqlite_mutate(
+    request: Request,
+    payload: RuntimeBridgeSqliteMutationRequest,
+):
+    token = _extract_bearer_token(request)
+    claims = await _runtime_service().verify_runtime_bridge_token(token)
+    workspace_id = _require_runtime_bridge_claim(claims, "workspace_id")
+    session_id = _require_runtime_bridge_claim(claims, "session_id")
+    leased_by_user_id = _require_runtime_bridge_claim(claims, "leased_by_user_id")
+    try:
+        response = await _userspace_service().mutate_runtime_bridge_sqlite(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            leased_by_user_id=leased_by_user_id,
+            request=payload,
+        )
+    except HTTPException:
+        raise
+    except CrossWorkspaceSqliteError as exc:
+        _raise_runtime_bridge_sqlite_error(exc)
+    except Exception as exc:
+        logger.exception(
+            "Runtime bridge SQLite mutate route failed for workspace %s session %s",
+            workspace_id,
+            session_id,
+        )
+        raise HTTPException(status_code=500, detail=_RUNTIME_BRIDGE_SQLITE_GENERIC_DETAIL) from exc
+
+    try:
+        await _runtime_service().bump_workspace_generation(payload.target_workspace_id.strip(), "runtime_bridge_sqlite_mutate")
+    except Exception:
+        logger.exception(
+            "Failed to bump runtime bridge SQLite generation for workspace %s",
+            payload.target_workspace_id,
+        )
+    return response
 
 
 @router.get(

--- a/ragtime/userspace/runtime_service.py
+++ b/ragtime/userspace/runtime_service.py
@@ -593,6 +593,12 @@ class UserSpaceRuntimeService:
         ):
             raise HTTPException(status_code=401, detail="Runtime bridge session is not active")
 
+        leased_by_user_id = str(getattr(session, "leasedByUserId", "") or "").strip()
+        if not leased_by_user_id:
+            raise HTTPException(status_code=401, detail="Runtime bridge session is not active")
+
+        claims["leased_by_user_id"] = leased_by_user_id
+
         return claims
 
     async def consume_preview_grant(self, claims: dict[str, Any]) -> None:

--- a/ragtime/userspace/service.py
+++ b/ragtime/userspace/service.py
@@ -23679,19 +23679,19 @@ SELECT json_build_object(
             files_dir.mkdir(parents=True, exist_ok=True)
         source_role = await self._load_workspace_role_without_admin_bypass(db, workspace_id=source_workspace_id, user_id=user_id)
         target_role = await self._load_workspace_role_without_admin_bypass(db, workspace_id=resolved_owner_workspace_id, user_id=user_id)
-        access_mode = self._effective_cross_workspace_sqlite_access_mode(
+        linked_access_mode = self._effective_cross_workspace_sqlite_access_mode(
             source_role=source_role,
             target_role=target_role,
             sqlite_access_mode=authorization.get("sqlite_access_mode", "none"),
         )
-        if access_mode is None:
+        if linked_access_mode is None:
             raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
         summary = self._build_sqlite_inspector_database_summary(
             database_name=database_name,
             owner_workspace_id=resolved_owner_workspace_id,
             owner_workspace_name=str(getattr(workspace_record, "name", "") or ""),
             ownership="linked",
-            access_mode=cast(SqliteInspectorDatabaseAccessMode, access_mode),
+            access_mode=cast(SqliteInspectorDatabaseAccessMode, linked_access_mode),
             persistence_mode=self._sqlite_persistence_mode_from_record(workspace_record),
             database_summary=await self._load_sqlite_database_summary(files_dir, database_name),
         )

--- a/ragtime/userspace/service.py
+++ b/ragtime/userspace/service.py
@@ -180,6 +180,9 @@ from ragtime.userspace.models import (
     RuntimeRestartBatchTaskPhase,
     RuntimeRestartWorkspacePhase,
     ShareAccessMode,
+    SqliteInspectorDatabaseAccessMode,
+    SqliteInspectorDatabaseOwnership,
+    SqliteInspectorDatabaseSummary,
     SqlitePersistenceMode,
     SwitchSnapshotBranchRequest,
     UpdateSnapshotRequest,
@@ -23375,18 +23378,261 @@ SELECT json_build_object(
             files_dir.mkdir(parents=True, exist_ok=True)
         return files_dir, promoted
 
+    @staticmethod
+    def _normalize_sqlite_owner_workspace_id(source_workspace_id: str, owner_workspace_id: str | None) -> str:
+        candidate = str(owner_workspace_id or "").strip()
+        if not candidate or candidate == source_workspace_id:
+            return source_workspace_id
+        return candidate
+
+    @staticmethod
+    def _sqlite_persistence_mode_from_record(record: Any) -> SqlitePersistenceMode:
+        return cast(
+            SqlitePersistenceMode,
+            _normalize_sqlite_persistence_mode(
+                str(
+                    getattr(
+                        record,
+                        "sqlitePersistenceMode",
+                        getattr(record, "sqlite_persistence_mode", "include"),
+                    )
+                    or "include"
+                )
+            ),
+        )
+
+    @staticmethod
+    def _sqlite_inspector_access_mode_for_owned_role(
+        role: WorkspaceRole | None,
+        *,
+        is_admin: bool,
+    ) -> SqliteInspectorDatabaseAccessMode:
+        if is_admin or UserSpaceService._workspace_role_allows(role, "editor"):
+            return "read_write"
+        return "read"
+
+    @staticmethod
+    def _build_sqlite_inspector_database_summary(
+        *,
+        database_name: str,
+        owner_workspace_id: str,
+        owner_workspace_name: str,
+        ownership: SqliteInspectorDatabaseOwnership,
+        access_mode: SqliteInspectorDatabaseAccessMode,
+        persistence_mode: SqlitePersistenceMode,
+        database_summary: sqlite_inspector_helpers.DatabaseSummary | None,
+    ) -> SqliteInspectorDatabaseSummary:
+        if database_summary is None:
+            return SqliteInspectorDatabaseSummary(
+                name=database_name,
+                relative_path=f"{sqlite_inspector_helpers.MANAGED_DB_DIRNAME}/{database_name}",
+                size_bytes=0,
+                table_count=0,
+                last_modified_ms=None,
+                owner_workspace_id=owner_workspace_id,
+                owner_workspace_name=owner_workspace_name,
+                ownership=ownership,
+                access_mode=access_mode,
+                persistence_mode=persistence_mode,
+                initialized=False,
+            )
+        return SqliteInspectorDatabaseSummary(
+            name=database_summary.name,
+            relative_path=database_summary.relative_path,
+            size_bytes=database_summary.size_bytes,
+            table_count=database_summary.table_count,
+            last_modified_ms=database_summary.last_modified_ms,
+            owner_workspace_id=owner_workspace_id,
+            owner_workspace_name=owner_workspace_name,
+            ownership=ownership,
+            access_mode=access_mode,
+            persistence_mode=persistence_mode,
+            initialized=True,
+        )
+
+    async def _load_sqlite_database_summary(
+        self,
+        files_dir: Path,
+        database_name: str,
+    ) -> sqlite_inspector_helpers.DatabaseSummary | None:
+        databases, _ = await asyncio.to_thread(sqlite_inspector_helpers.list_databases, files_dir)
+        return next((database for database in databases if database.name == database_name), None)
+
+    async def _record_linked_sqlite_mutation_best_effort(
+        self,
+        *,
+        source_workspace_id: str,
+        target_workspace_id: str,
+        user_id: str,
+        grant_id: str | None,
+        operation: str,
+    ) -> None:
+        if not grant_id:
+            return
+        try:
+            await self._record_runtime_audit_event(
+                target_workspace_id,
+                user_id,
+                "sqlite_inspector.linked_mutation",
+                {
+                    "source_workspace_id": source_workspace_id,
+                    "target_workspace_id": target_workspace_id,
+                    "grant_id": grant_id,
+                    "operation": operation,
+                    "database_name": sqlite_inspector_helpers.DEFAULT_DATABASE_NAME,
+                },
+            )
+        except Exception:
+            logger.exception("Failed to record linked SQLite inspector audit event for workspace %s", target_workspace_id)
+
+    async def _resolve_sqlite_inspector_database(
+        self,
+        source_workspace_id: str,
+        user_id: str,
+        database_name: str,
+        *,
+        owner_workspace_id: str | None,
+        require_write: bool,
+        is_admin: bool,
+        promote_mode: bool = False,
+        ensure_files_dir: bool = False,
+    ) -> tuple[Path, bool, SqliteInspectorDatabaseSummary, str | None]:
+        resolved_owner_workspace_id = self._normalize_sqlite_owner_workspace_id(source_workspace_id, owner_workspace_id)
+        db = await get_db()
+
+        if resolved_owner_workspace_id == source_workspace_id:
+            workspace = await self._enforce_workspace_access(
+                source_workspace_id,
+                user_id,
+                required_role="editor" if require_write else None,
+                is_admin=is_admin,
+            )
+            promoted = False
+            if promote_mode:
+                promoted = await self._ensure_sqlite_mode_included(source_workspace_id)
+                workspace.sqlite_persistence_mode = "include"
+            files_dir = self._workspace_files_dir(source_workspace_id)
+            if ensure_files_dir:
+                files_dir.mkdir(parents=True, exist_ok=True)
+            role = None if is_admin else await self._load_workspace_role_without_admin_bypass(db, workspace_id=source_workspace_id, user_id=user_id)
+            access_mode = self._sqlite_inspector_access_mode_for_owned_role(role, is_admin=is_admin)
+            summary = self._build_sqlite_inspector_database_summary(
+                database_name=database_name,
+                owner_workspace_id=source_workspace_id,
+                owner_workspace_name=workspace.name,
+                ownership="owned",
+                access_mode=access_mode,
+                persistence_mode=cast(SqlitePersistenceMode, workspace.sqlite_persistence_mode),
+                database_summary=await self._load_sqlite_database_summary(files_dir, database_name),
+            )
+            return files_dir, promoted, summary, None
+
+        if database_name != sqlite_inspector_helpers.DEFAULT_DATABASE_NAME:
+            raise HTTPException(status_code=404, detail="Linked database not found")
+
+        authorization = await self._authorize_runtime_bridge_cross_workspace_sqlite(
+            source_workspace_id=source_workspace_id,
+            target_workspace_id=resolved_owner_workspace_id,
+            leased_by_user_id=user_id,
+            require_target_role="editor" if require_write else "viewer",
+            require_sqlite_mode="read_write" if require_write else "read",
+        )
+        workspace_record = await db.workspace.find_unique(where={"id": resolved_owner_workspace_id})
+        if workspace_record is None:
+            raise HTTPException(status_code=404, detail="Linked database not found")
+        promoted = False
+        if promote_mode:
+            promoted = await self._ensure_sqlite_mode_included(resolved_owner_workspace_id)
+            setattr(workspace_record, "sqlitePersistenceMode", "include")
+            setattr(workspace_record, "sqlite_persistence_mode", "include")
+        files_dir = self._workspace_files_dir(resolved_owner_workspace_id)
+        if ensure_files_dir:
+            files_dir.mkdir(parents=True, exist_ok=True)
+        source_role = await self._load_workspace_role_without_admin_bypass(db, workspace_id=source_workspace_id, user_id=user_id)
+        target_role = await self._load_workspace_role_without_admin_bypass(db, workspace_id=resolved_owner_workspace_id, user_id=user_id)
+        access_mode = self._effective_cross_workspace_sqlite_access_mode(
+            source_role=source_role,
+            target_role=target_role,
+            sqlite_access_mode=authorization.get("sqlite_access_mode", "none"),
+        )
+        if access_mode is None:
+            raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
+        summary = self._build_sqlite_inspector_database_summary(
+            database_name=database_name,
+            owner_workspace_id=resolved_owner_workspace_id,
+            owner_workspace_name=str(getattr(workspace_record, "name", "") or ""),
+            ownership="linked",
+            access_mode=cast(SqliteInspectorDatabaseAccessMode, access_mode),
+            persistence_mode=self._sqlite_persistence_mode_from_record(workspace_record),
+            database_summary=await self._load_sqlite_database_summary(files_dir, database_name),
+        )
+        return files_dir, promoted, summary, authorization.get("grant_id")
+
     async def list_sqlite_databases(
         self,
         workspace_id: str,
         user_id: str,
         *,
         is_admin: bool = False,
-    ) -> tuple[list[sqlite_inspector_helpers.DatabaseSummary], int, str]:
+    ) -> tuple[list[SqliteInspectorDatabaseSummary], int, str]:
         workspace = await self._enforce_workspace_access(workspace_id, user_id, is_admin=is_admin)
         files_dir = self._workspace_files_dir(workspace_id)
-        databases, total_bytes = await asyncio.to_thread(sqlite_inspector_helpers.list_databases, files_dir)
+        databases, _ = await asyncio.to_thread(sqlite_inspector_helpers.list_databases, files_dir)
         mode = _normalize_sqlite_persistence_mode(workspace.sqlite_persistence_mode)
-        return databases, total_bytes, mode
+        db = await get_db()
+        role = None if is_admin else await self._load_workspace_role_without_admin_bypass(db, workspace_id=workspace_id, user_id=user_id)
+        access_mode = self._sqlite_inspector_access_mode_for_owned_role(role, is_admin=is_admin)
+        owned_summaries = [
+            self._build_sqlite_inspector_database_summary(
+                database_name=database.name,
+                owner_workspace_id=workspace_id,
+                owner_workspace_name=workspace.name,
+                ownership="owned",
+                access_mode=access_mode,
+                persistence_mode=cast(SqlitePersistenceMode, mode),
+                database_summary=database,
+            )
+            for database in sorted(databases, key=lambda item: item.name.casefold())
+        ]
+        linked_targets = await self.list_accessible_cross_workspace_sqlite_targets(workspace_id, user_id)
+        if not linked_targets:
+            total_bytes = sum(summary.size_bytes for summary in owned_summaries if summary.initialized)
+            return owned_summaries, total_bytes, mode
+
+        target_workspace_ids = [target["workspace_id"] for target in linked_targets]
+        target_records: dict[str, Any] = {}
+        workspace_model = getattr(db, "workspace", None)
+        if workspace_model is not None and hasattr(workspace_model, "find_many"):
+            for record in await workspace_model.find_many(where={"id": {"in": target_workspace_ids}}):
+                target_records[str(getattr(record, "id", "") or "")] = record
+        else:
+            for target_workspace_id in target_workspace_ids:
+                record = await db.workspace.find_unique(where={"id": target_workspace_id})
+                if record is not None:
+                    target_records[target_workspace_id] = record
+
+        linked_summaries: list[SqliteInspectorDatabaseSummary] = []
+        for target in linked_targets:
+            target_workspace_id = target["workspace_id"]
+            record = target_records.get(target_workspace_id)
+            if record is None:
+                continue
+            target_files_dir = self._workspace_files_dir(target_workspace_id)
+            linked_summaries.append(
+                self._build_sqlite_inspector_database_summary(
+                    database_name=sqlite_inspector_helpers.DEFAULT_DATABASE_NAME,
+                    owner_workspace_id=target_workspace_id,
+                    owner_workspace_name=target["workspace_name"],
+                    ownership="linked",
+                    access_mode=cast(SqliteInspectorDatabaseAccessMode, target["access_mode"]),
+                    persistence_mode=self._sqlite_persistence_mode_from_record(record),
+                    database_summary=await self._load_sqlite_database_summary(target_files_dir, sqlite_inspector_helpers.DEFAULT_DATABASE_NAME),
+                )
+            )
+
+        all_summaries = owned_summaries + linked_summaries
+        total_bytes = sum(summary.size_bytes for summary in all_summaries if summary.initialized)
+        return all_summaries, total_bytes, mode
 
     async def initialize_sqlite_database(
         self,
@@ -23394,20 +23640,40 @@ SELECT json_build_object(
         user_id: str,
         *,
         database_name: str | None = None,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
-    ) -> tuple[sqlite_inspector_helpers.DatabaseSummary, bool]:
-        files_dir, promoted = await self._prepare_sqlite_workspace(
+    ) -> tuple[SqliteInspectorDatabaseSummary, bool]:
+        resolved_database_name = database_name or sqlite_inspector_helpers.DEFAULT_DATABASE_NAME
+        files_dir, promoted, database_context, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            resolved_database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
             promote_mode=True,
             ensure_files_dir=True,
         )
-        summary = await asyncio.to_thread(
+        database_summary = await asyncio.to_thread(
             sqlite_inspector_helpers.initialize_database,
             files_dir,
-            database_name or sqlite_inspector_helpers.DEFAULT_DATABASE_NAME,
+            resolved_database_name,
+        )
+        summary = self._build_sqlite_inspector_database_summary(
+            database_name=database_summary.name,
+            owner_workspace_id=database_context.owner_workspace_id,
+            owner_workspace_name=database_context.owner_workspace_name,
+            ownership=database_context.ownership,
+            access_mode=database_context.access_mode,
+            persistence_mode=database_context.persistence_mode,
+            database_summary=database_summary,
+        )
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=summary.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="initialize_database",
         )
         return summary, promoted
 
@@ -23417,15 +23683,27 @@ SELECT json_build_object(
         user_id: str,
         database_name: str,
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> None:
-        files_dir, _ = await self._prepare_sqlite_workspace(
+        files_dir, _, summary, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
         )
+        if not summary.initialized:
+            raise HTTPException(status_code=404, detail="Database not found")
         await asyncio.to_thread(sqlite_inspector_helpers.delete_database, files_dir, database_name)
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=summary.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="delete_database",
+        )
 
     async def export_sqlite_database(
         self,
@@ -23433,13 +23711,19 @@ SELECT json_build_object(
         user_id: str,
         database_name: str,
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> Path:
-        files_dir, _ = await self._prepare_sqlite_workspace(
+        files_dir, _, summary, _ = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=False,
             is_admin=is_admin,
         )
+        if not summary.initialized:
+            raise HTTPException(status_code=404, detail="Database not found")
         return await asyncio.to_thread(sqlite_inspector_helpers.export_database_copy, files_dir, database_name)
 
     async def import_sqlite_database(
@@ -23449,20 +23733,39 @@ SELECT json_build_object(
         database_name: str,
         source_path: Path,
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
-    ) -> tuple[sqlite_inspector_helpers.DatabaseSummary, bool]:
-        files_dir, promoted = await self._prepare_sqlite_workspace(
+    ) -> tuple[SqliteInspectorDatabaseSummary, bool]:
+        files_dir, promoted, database_context, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
             promote_mode=True,
         )
-        summary = await asyncio.to_thread(
+        database_summary = await asyncio.to_thread(
             sqlite_inspector_helpers.import_database_file,
             files_dir,
             database_name,
             source_path,
+        )
+        summary = self._build_sqlite_inspector_database_summary(
+            database_name=database_summary.name,
+            owner_workspace_id=database_context.owner_workspace_id,
+            owner_workspace_name=database_context.owner_workspace_name,
+            ownership=database_context.ownership,
+            access_mode=database_context.access_mode,
+            persistence_mode=database_context.persistence_mode,
+            database_summary=database_summary,
+        )
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=summary.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="import_database",
         )
         return summary, promoted
 
@@ -23472,19 +23775,21 @@ SELECT json_build_object(
         user_id: str,
         database_name: str,
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> tuple[
-        sqlite_inspector_helpers.DatabaseSummary,
+        SqliteInspectorDatabaseSummary,
         list[sqlite_inspector_helpers.TableSummary],
     ]:
-        files_dir, _ = await self._prepare_sqlite_workspace(
+        files_dir, _, summary, _ = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=False,
             is_admin=is_admin,
         )
-        databases, _ = await asyncio.to_thread(sqlite_inspector_helpers.list_databases, files_dir)
-        summary = next((d for d in databases if d.name == database_name), None)
-        if summary is None:
+        if not summary.initialized:
             raise HTTPException(status_code=404, detail="Database not found")
         tables = await asyncio.to_thread(sqlite_inspector_helpers.list_tables, files_dir, database_name)
         return summary, tables
@@ -23498,13 +23803,16 @@ SELECT json_build_object(
         columns: list[sqlite_inspector_helpers.ColumnDefinition],
         *,
         without_rowid: bool = False,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> tuple[sqlite_inspector_helpers.TableSummary, bool]:
-        files_dir, promoted = await self._prepare_sqlite_workspace(
+        files_dir, promoted, database_context, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
             promote_mode=True,
             ensure_files_dir=True,
         )
@@ -23516,6 +23824,13 @@ SELECT json_build_object(
             columns,
             without_rowid=without_rowid,
         )
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=database_context.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="create_table",
+        )
         return summary, promoted
 
     async def get_sqlite_table_schema(
@@ -23525,13 +23840,19 @@ SELECT json_build_object(
         database_name: str,
         table_name: str,
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> sqlite_inspector_helpers.TableSchema:
-        files_dir, _ = await self._prepare_sqlite_workspace(
+        files_dir, _, summary, _ = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=False,
             is_admin=is_admin,
         )
+        if not summary.initialized:
+            raise HTTPException(status_code=404, detail="Database not found")
         return await asyncio.to_thread(
             sqlite_inspector_helpers.get_table_schema,
             files_dir,
@@ -23547,13 +23868,16 @@ SELECT json_build_object(
         table_name: str,
         alterations: list[sqlite_inspector_helpers.TableAlteration],
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> tuple[sqlite_inspector_helpers.TableSchema, bool]:
-        files_dir, promoted = await self._prepare_sqlite_workspace(
+        files_dir, promoted, database_context, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
             promote_mode=True,
         )
         schema = await asyncio.to_thread(
@@ -23562,6 +23886,13 @@ SELECT json_build_object(
             database_name,
             table_name,
             alterations,
+        )
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=database_context.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="alter_table",
         )
         return schema, promoted
 
@@ -23572,13 +23903,16 @@ SELECT json_build_object(
         database_name: str,
         table_name: str,
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> bool:
-        files_dir, promoted = await self._prepare_sqlite_workspace(
+        files_dir, promoted, database_context, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
             promote_mode=True,
         )
         await asyncio.to_thread(
@@ -23586,6 +23920,13 @@ SELECT json_build_object(
             files_dir,
             database_name,
             table_name,
+        )
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=database_context.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="drop_table",
         )
         return promoted
 
@@ -23596,13 +23937,19 @@ SELECT json_build_object(
         database_name: str,
         table_name: str,
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> str:
-        files_dir, _ = await self._prepare_sqlite_workspace(
+        files_dir, _, summary, _ = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=False,
             is_admin=is_admin,
         )
+        if not summary.initialized:
+            raise HTTPException(status_code=404, detail="Database not found")
         return await asyncio.to_thread(
             sqlite_inspector_helpers.export_table_csv,
             files_dir,
@@ -23619,13 +23966,16 @@ SELECT json_build_object(
         csv_text: str,
         *,
         replace: bool = False,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> tuple[sqlite_inspector_helpers.TableSummary, bool]:
-        files_dir, promoted = await self._prepare_sqlite_workspace(
+        files_dir, promoted, database_context, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
             promote_mode=True,
         )
         summary = await asyncio.to_thread(
@@ -23635,6 +23985,13 @@ SELECT json_build_object(
             table_name,
             csv_text,
             replace=replace,
+        )
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=database_context.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="import_table",
         )
         return summary, promoted
 
@@ -23649,13 +24006,19 @@ SELECT json_build_object(
         offset: int = 0,
         order_by: str | None = None,
         order_direction: str = "asc",
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> sqlite_inspector_helpers.RowPage:
-        files_dir, _ = await self._prepare_sqlite_workspace(
+        files_dir, _, summary, _ = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=False,
             is_admin=is_admin,
         )
+        if not summary.initialized:
+            raise HTTPException(status_code=404, detail="Database not found")
         return await asyncio.to_thread(
             sqlite_inspector_helpers.list_rows,
             files_dir,
@@ -23675,13 +24038,16 @@ SELECT json_build_object(
         table_name: str,
         values: dict[str, Any],
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> tuple[dict[str, Any], bool]:
-        files_dir, promoted = await self._prepare_sqlite_workspace(
+        files_dir, promoted, summary, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
             promote_mode=True,
         )
         row = await asyncio.to_thread(
@@ -23690,6 +24056,13 @@ SELECT json_build_object(
             database_name,
             table_name,
             values,
+        )
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=summary.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="insert_row",
         )
         return row, promoted
 
@@ -23702,13 +24075,16 @@ SELECT json_build_object(
         row_key: dict[str, Any],
         values: dict[str, Any],
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> tuple[dict[str, Any], bool]:
-        files_dir, promoted = await self._prepare_sqlite_workspace(
+        files_dir, promoted, summary, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
             promote_mode=True,
         )
         row = await asyncio.to_thread(
@@ -23718,6 +24094,13 @@ SELECT json_build_object(
             table_name,
             row_key,
             values,
+        )
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=summary.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="update_row",
         )
         return row, promoted
 
@@ -23729,13 +24112,16 @@ SELECT json_build_object(
         table_name: str,
         row_key: dict[str, Any],
         *,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> bool:
-        files_dir, promoted = await self._prepare_sqlite_workspace(
+        files_dir, promoted, summary, grant_id = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=True,
             is_admin=is_admin,
-            required_role="editor",
             promote_mode=True,
         )
         await asyncio.to_thread(
@@ -23744,6 +24130,13 @@ SELECT json_build_object(
             database_name,
             table_name,
             row_key,
+        )
+        await self._record_linked_sqlite_mutation_best_effort(
+            source_workspace_id=workspace_id,
+            target_workspace_id=summary.owner_workspace_id,
+            user_id=user_id,
+            grant_id=grant_id,
+            operation="delete_row",
         )
         return promoted
 
@@ -23755,13 +24148,19 @@ SELECT json_build_object(
         sql: str,
         *,
         max_rows: int = 200,
+        owner_workspace_id: str | None = None,
         is_admin: bool = False,
     ) -> sqlite_inspector_helpers.QueryResult:
-        files_dir, _ = await self._prepare_sqlite_workspace(
+        files_dir, _, summary, _ = await self._resolve_sqlite_inspector_database(
             workspace_id,
             user_id,
+            database_name,
+            owner_workspace_id=owner_workspace_id,
+            require_write=False,
             is_admin=is_admin,
         )
+        if not summary.initialized:
+            raise HTTPException(status_code=404, detail="Database not found")
         return await asyncio.to_thread(
             sqlite_inspector_helpers.execute_readonly_query,
             files_dir,

--- a/ragtime/userspace/service.py
+++ b/ragtime/userspace/service.py
@@ -487,6 +487,12 @@ class _RuntimeBridgeSqliteAuthorizationResult(TypedDict, total=False):
     sqlite_access_mode: WorkspaceSqliteGrantMode
 
 
+class _EffectiveCrossWorkspaceSqliteAccess(TypedDict):
+    target_workspace_id: str
+    workspace_name: str
+    access_mode: Literal["read", "read_write"]
+
+
 class _RuntimeBridgeSqliteRateLimitBucket:
     __slots__ = ("timestamps", "last_active")
 
@@ -14925,6 +14931,126 @@ class UserSpaceService:
             return None
         return self._coerce_workspace_role_value(getattr(member, "role", None))
 
+    def _effective_cross_workspace_sqlite_access_mode(
+        self,
+        *,
+        source_role: WorkspaceRole | None,
+        target_role: WorkspaceRole | None,
+        sqlite_access_mode: WorkspaceSqliteGrantMode,
+    ) -> Literal["read", "read_write"] | None:
+        if not self._workspace_role_allows(source_role, "viewer"):
+            return None
+        if not self._workspace_role_allows(target_role, "viewer"):
+            return None
+        if sqlite_access_mode == "read_write":
+            if self._workspace_role_allows(target_role, "editor"):
+                return "read_write"
+            return "read"
+        if sqlite_access_mode == "read":
+            return "read"
+        return None
+
+    async def list_accessible_cross_workspace_sqlite_targets(
+        self,
+        source_workspace_id: str,
+        leased_by_user_id: str,
+    ) -> list[dict[str, str]]:
+        db = await get_db()
+        source_role = await self._load_workspace_role_without_admin_bypass(
+            db,
+            workspace_id=source_workspace_id,
+            user_id=leased_by_user_id,
+        )
+        if not self._workspace_role_allows(source_role, "viewer"):
+            return []
+
+        model = self._workspace_agent_grant_model(db)
+        if model is None:
+            return []
+
+        grants = await model.find_many(
+            where={"sourceWorkspaceId": source_workspace_id},
+            order={"targetWorkspaceId": "asc"},
+        )
+        if not grants:
+            return []
+
+        now = utc_now()
+        candidate_grants: list[tuple[str, WorkspaceSqliteGrantMode]] = []
+        for grant in grants:
+            target_workspace_id = str(getattr(grant, "targetWorkspaceId", "") or "")
+            if not target_workspace_id or target_workspace_id == source_workspace_id:
+                continue
+            expires_at = getattr(grant, "expiresAt", None)
+            if expires_at is not None and coerce_utc_datetime(expires_at) < now:
+                continue
+            sqlite_access_mode = self._normalize_sqlite_grant_mode(getattr(grant, "sqliteAccessMode", "none"))
+            if sqlite_access_mode == "none":
+                continue
+            candidate_grants.append((target_workspace_id, sqlite_access_mode))
+        if not candidate_grants:
+            return []
+
+        target_workspace_ids = sorted({target_workspace_id for target_workspace_id, _sqlite_access_mode in candidate_grants})
+
+        workspace_model = getattr(db, "workspace", None)
+        workspace_map: dict[str, Any] = {}
+        if workspace_model is not None and hasattr(workspace_model, "find_many"):
+            workspaces = await workspace_model.find_many(where={"id": {"in": target_workspace_ids}})
+            workspace_map = {str(getattr(workspace, "id", "") or ""): workspace for workspace in workspaces}
+        else:
+            for target_workspace_id in target_workspace_ids:
+                workspace = await db.workspace.find_unique(where={"id": target_workspace_id})
+                if workspace is not None:
+                    workspace_map[target_workspace_id] = workspace
+
+        member_model = getattr(db, "workspacemember", None)
+        member_roles: dict[str, WorkspaceRole | None] = {}
+        if member_model is not None and hasattr(member_model, "find_many"):
+            memberships = await member_model.find_many(
+                where={
+                    "workspaceId": {"in": target_workspace_ids},
+                    "userId": leased_by_user_id,
+                }
+            )
+            member_roles = {
+                str(getattr(member, "workspaceId", "") or ""): self._coerce_workspace_role_value(getattr(member, "role", None)) for member in memberships
+            }
+
+        accessible_targets: list[_EffectiveCrossWorkspaceSqliteAccess] = []
+        for target_workspace_id, sqlite_access_mode in candidate_grants:
+            workspace = workspace_map.get(target_workspace_id)
+            if workspace is None:
+                continue
+            target_role = member_roles.get(target_workspace_id)
+            if target_role is None and str(getattr(workspace, "ownerUserId", "") or "") == leased_by_user_id:
+                target_role = "owner"
+            effective_access_mode = self._effective_cross_workspace_sqlite_access_mode(
+                source_role=source_role,
+                target_role=target_role,
+                sqlite_access_mode=sqlite_access_mode,
+            )
+            if effective_access_mode is None:
+                continue
+            accessible_targets.append(
+                {
+                    "target_workspace_id": target_workspace_id,
+                    "workspace_name": str(getattr(workspace, "name", "") or ""),
+                    "access_mode": effective_access_mode,
+                }
+            )
+
+        accessible_targets.sort(key=lambda item: (item["workspace_name"].casefold(), item["target_workspace_id"]))
+        return [
+            {
+                "workspace_id": item["target_workspace_id"],
+                "workspace_name": item["workspace_name"],
+                "database_name": "app.sqlite3",
+                "access_mode": item["access_mode"],
+            }
+            for item in accessible_targets
+        ]
+
     async def _authorize_runtime_bridge_cross_workspace_sqlite(
         self,
         *,
@@ -14943,8 +15069,6 @@ class UserSpaceService:
             workspace_id=source_workspace_id,
             user_id=leased_by_user_id,
         )
-        if not self._workspace_role_allows(source_role, "viewer"):
-            raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
 
         target_role = await self._load_workspace_role_without_admin_bypass(
             db,
@@ -14971,8 +15095,13 @@ class UserSpaceService:
             raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
 
         sqlite_access_mode = self._normalize_sqlite_grant_mode(getattr(grant, "sqliteAccessMode", "none"))
+        effective_access_mode = self._effective_cross_workspace_sqlite_access_mode(
+            source_role=source_role,
+            target_role=target_role,
+            sqlite_access_mode=sqlite_access_mode,
+        )
         allowed_modes = {"read", "read_write"} if require_sqlite_mode == "read" else {"read_write"}
-        if sqlite_access_mode not in allowed_modes:
+        if effective_access_mode not in allowed_modes:
             raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
 
         return {

--- a/ragtime/userspace/service.py
+++ b/ragtime/userspace/service.py
@@ -18,6 +18,7 @@ import tarfile
 import tempfile
 import time as _time
 import zipfile
+from collections import deque
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache, partial
@@ -129,6 +130,17 @@ from ragtime.userspace.cloud_mounts import (
     google_drive_scope_error_message,
     has_google_drive_scope,
 )
+from ragtime.userspace.cross_workspace_sqlite import (
+    AuditIdentityContext as CrossWorkspaceSqliteAuditIdentityContext,
+)
+from ragtime.userspace.cross_workspace_sqlite import (
+    CrossWorkspaceSqliteBroker,
+    CrossWorkspaceSqliteError,
+    CrossWorkspaceSqlitePolicy,
+)
+from ragtime.userspace.cross_workspace_sqlite import (
+    MutationOperation as CrossWorkspaceSqliteMutationOperation,
+)
 from ragtime.userspace.models import (
     ArtifactType,
     BrowseCloudMountSourceRequest,
@@ -159,6 +171,11 @@ from ragtime.userspace.models import (
     MountSourceUnavailableKind,
     PaginatedWorkspacesResponse,
     RenameUserSpaceObjectStorageObjectRequest,
+    RuntimeBridgeSqliteMutationOperationResponse,
+    RuntimeBridgeSqliteMutationRequest,
+    RuntimeBridgeSqliteMutationResponse,
+    RuntimeBridgeSqliteQueryRequest,
+    RuntimeBridgeSqliteQueryResponse,
     RuntimeOperationPhase,
     RuntimeRestartBatchTaskPhase,
     RuntimeRestartWorkspacePhase,
@@ -253,6 +270,7 @@ from ragtime.userspace.models import (
     WorkspaceScmProvider,
     WorkspaceScmRemoteRole,
     WorkspaceShareSlugAvailabilityResponse,
+    WorkspaceSqliteGrantMode,
     WorkspaceSqliteImportTaskPhase,
     WorkspaceToolOptionState,
 )
@@ -459,6 +477,19 @@ class _ShareAuthorizationResult(TypedDict, total=False):
     expires_at: datetime | None
     granted_role: str
     can_edit: bool
+
+
+class _RuntimeBridgeSqliteAuthorizationResult(TypedDict, total=False):
+    grant_id: str
+    sqlite_access_mode: WorkspaceSqliteGrantMode
+
+
+class _RuntimeBridgeSqliteRateLimitBucket:
+    __slots__ = ("timestamps", "last_active")
+
+    def __init__(self) -> None:
+        self.timestamps: deque[float] = deque()
+        self.last_active: float = 0.0
 
 
 class _GitCommandResult:
@@ -1111,6 +1142,13 @@ _WORKSPACE_OBJECT_STORAGE_DEFAULT_BUCKET_ENV_KEY = "RAGTIME_OBJECT_STORAGE_DEFAU
 _WORKSPACE_OBJECT_STORAGE_FORCE_PATH_STYLE_ENV_KEY = "RAGTIME_OBJECT_STORAGE_FORCE_PATH_STYLE"
 _WORKSPACE_OBJECT_STORAGE_REGION_ENV_KEY = "RAGTIME_OBJECT_STORAGE_REGION"
 _WORKSPACE_OBJECT_STORAGE_ENABLED_ENV_KEY = "RAGTIME_OBJECT_STORAGE_ENABLED"
+_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL = "Cross-workspace SQLite access denied"
+_RUNTIME_BRIDGE_SQLITE_RATE_LIMIT_DETAIL = "Cross-workspace SQLite rate limit exceeded"
+_RUNTIME_BRIDGE_SQLITE_SOURCE_EQUALS_TARGET_DETAIL = "Source and target workspaces must differ"
+_RUNTIME_BRIDGE_SQLITE_RATE_LIMIT_MAX_CALLS = 120
+_RUNTIME_BRIDGE_SQLITE_RATE_LIMIT_WINDOW_SECONDS = 60.0
+_RUNTIME_BRIDGE_SQLITE_RATE_LIMIT_MAX_KEYS = 10_000
+_RUNTIME_BRIDGE_SQLITE_AUDIT_EVENT_TYPE = "runtime_bridge_sqlite"
 
 # ---------------------------------------------------------------------------
 # Node framework detection from command strings
@@ -1414,6 +1452,7 @@ class UserSpaceService:
         self._sqlite_import_tasks_dir.mkdir(parents=True, exist_ok=True)
         self._execution_proofs: dict[str, dict[str, _ExecutionProofRecord]] = {}
         self._live_data_execution_warnings: dict[str, _LiveDataExecutionWarningRecord] = {}
+        self._runtime_bridge_sqlite_rate_limits: dict[tuple[str, str], _RuntimeBridgeSqliteRateLimitBucket] = {}
         # TTL-cached entrypoint status per workspace: {workspace_id: (EntrypointStatus, timestamp)}
         self._entrypoint_status_cache: dict[str, tuple[EntrypointStatus, float]] = {}
         # Short-lived file list cache: {workspace_id: (result, include_dirs, timestamp)}
@@ -14654,6 +14693,19 @@ class UserSpaceService:
             return "read_write"
         return "read"
 
+    @staticmethod
+    def _normalize_sqlite_grant_mode(value: Any) -> WorkspaceSqliteGrantMode:
+        raw = value if isinstance(value, str) else str(getattr(value, "value", value) or "")
+        if raw == "read_write":
+            return "read_write"
+        if raw == "read":
+            return "read"
+        return "none"
+
+    @staticmethod
+    def _workspace_user_is_owner(workspace: UserSpaceWorkspace, user_id: str) -> bool:
+        return workspace.owner_user_id == user_id
+
     def _agent_grant_from_record(
         self,
         record: Any,
@@ -14669,6 +14721,7 @@ class UserSpaceService:
             target_workspace_id=str(getattr(record, "targetWorkspaceId", "") or ""),
             target_workspace_name=target_workspace_name,
             access_mode=self._normalize_agent_grant_mode(getattr(record, "accessMode", "read")),
+            sqlite_access_mode=self._normalize_sqlite_grant_mode(getattr(record, "sqliteAccessMode", "none")),
             granted_by_user_id=str(getattr(record, "grantedByUserId", "") or ""),
             granted_by_username=granted_by_username,
             expires_at=getattr(record, "expiresAt", None),
@@ -14701,6 +14754,243 @@ class UserSpaceService:
         if required_role == "owner":
             return role == "owner"
         return False
+
+    @staticmethod
+    def _coerce_workspace_role_value(value: Any) -> WorkspaceRole | None:
+        raw = value if isinstance(value, str) else str(getattr(value, "value", value) or "")
+        if raw in {"owner", "editor", "viewer"}:
+            return cast(WorkspaceRole, raw)
+        return None
+
+    def _runtime_bridge_cross_workspace_sqlite_broker(self) -> CrossWorkspaceSqliteBroker:
+        return CrossWorkspaceSqliteBroker(CrossWorkspaceSqlitePolicy())
+
+    def _consume_runtime_bridge_sqlite_rate_limit(self, session_id: str, target_workspace_id: str) -> None:
+        now = _time.monotonic()
+        window_start = now - _RUNTIME_BRIDGE_SQLITE_RATE_LIMIT_WINDOW_SECONDS
+        key = (session_id, target_workspace_id)
+        stale_keys: list[tuple[str, str]] = []
+        least_recent_key: tuple[str, str] | None = None
+        least_recent_at: float | None = None
+
+        for existing_key, existing_bucket in list(self._runtime_bridge_sqlite_rate_limits.items()):
+            while existing_bucket.timestamps and existing_bucket.timestamps[0] <= window_start:
+                existing_bucket.timestamps.popleft()
+            if not existing_bucket.timestamps:
+                stale_keys.append(existing_key)
+                continue
+            if least_recent_at is None or existing_bucket.last_active < least_recent_at:
+                least_recent_at = existing_bucket.last_active
+                least_recent_key = existing_key
+
+        for stale_key in stale_keys:
+            self._runtime_bridge_sqlite_rate_limits.pop(stale_key, None)
+
+        bucket = self._runtime_bridge_sqlite_rate_limits.get(key)
+        if bucket is None:
+            if len(self._runtime_bridge_sqlite_rate_limits) >= _RUNTIME_BRIDGE_SQLITE_RATE_LIMIT_MAX_KEYS:
+                eviction_key = least_recent_key
+                if eviction_key is None and self._runtime_bridge_sqlite_rate_limits:
+                    eviction_key = next(iter(self._runtime_bridge_sqlite_rate_limits))
+                if eviction_key is not None:
+                    self._runtime_bridge_sqlite_rate_limits.pop(eviction_key, None)
+            bucket = _RuntimeBridgeSqliteRateLimitBucket()
+            self._runtime_bridge_sqlite_rate_limits[key] = bucket
+
+        while bucket.timestamps and bucket.timestamps[0] <= window_start:
+            bucket.timestamps.popleft()
+        if len(bucket.timestamps) >= _RUNTIME_BRIDGE_SQLITE_RATE_LIMIT_MAX_CALLS:
+            raise HTTPException(status_code=429, detail=_RUNTIME_BRIDGE_SQLITE_RATE_LIMIT_DETAIL)
+        bucket.timestamps.append(now)
+        bucket.last_active = now
+
+    @staticmethod
+    def _runtime_bridge_sqlite_http_error_code(exc: HTTPException) -> str:
+        if exc.status_code == 400:
+            return "source_equals_target"
+        if exc.status_code == 429:
+            return "rate_limited"
+        return "forbidden"
+
+    def _build_runtime_bridge_sqlite_audit_payload(
+        self,
+        *,
+        source_workspace_id: str,
+        target_workspace_id: str,
+        session_id: str,
+        leased_by_user_id: str,
+        operation: Literal["query", "mutate"],
+        grant_id: str | None = None,
+        sqlite_access_mode: WorkspaceSqliteGrantMode | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "source_workspace_id": source_workspace_id,
+            "target_workspace_id": target_workspace_id,
+            "session_id": session_id,
+            "leased_by_user_id": leased_by_user_id,
+            "operation": operation,
+        }
+        if grant_id:
+            payload["grant_id"] = grant_id
+        if sqlite_access_mode is not None:
+            payload["grant_mode"] = sqlite_access_mode
+        return payload
+
+    async def _record_runtime_bridge_sqlite_event_best_effort(
+        self,
+        *,
+        workspace_id: str,
+        user_id: str,
+        session_id: str,
+        payload: dict[str, Any],
+    ) -> None:
+        try:
+            await self._record_runtime_audit_event(
+                workspace_id,
+                user_id,
+                _RUNTIME_BRIDGE_SQLITE_AUDIT_EVENT_TYPE,
+                payload,
+                session_id=session_id,
+            )
+        except Exception:  # noqa: BLE001 - audit is best effort
+            logger.exception(
+                "Failed to record runtime bridge SQLite audit event for workspace %s",
+                workspace_id,
+            )
+
+    async def _audit_runtime_bridge_sqlite_denied(
+        self,
+        *,
+        source_workspace_id: str,
+        target_workspace_id: str,
+        session_id: str,
+        leased_by_user_id: str,
+        operation: Literal["query", "mutate"],
+        error_code: str,
+        sql_digest: str | None = None,
+        fingerprint: str | None = None,
+        operation_count: int | None = None,
+        grant_id: str | None = None,
+        sqlite_access_mode: WorkspaceSqliteGrantMode | None = None,
+    ) -> None:
+        payload = self._build_runtime_bridge_sqlite_audit_payload(
+            source_workspace_id=source_workspace_id,
+            target_workspace_id=target_workspace_id,
+            session_id=session_id,
+            leased_by_user_id=leased_by_user_id,
+            operation=operation,
+            grant_id=grant_id,
+            sqlite_access_mode=sqlite_access_mode,
+        )
+        payload.update(
+            {
+                "phase": "denied",
+                "status": "denied",
+                "error_code": error_code,
+            }
+        )
+        if sql_digest is not None:
+            payload["sql_digest"] = sql_digest
+        if fingerprint is not None:
+            payload["fingerprint"] = fingerprint
+        if operation_count is not None:
+            payload["operation_count"] = operation_count
+        await self._record_runtime_bridge_sqlite_event_best_effort(
+            workspace_id=source_workspace_id,
+            user_id=leased_by_user_id,
+            session_id=session_id,
+            payload=payload,
+        )
+
+    async def _load_workspace_role_without_admin_bypass(
+        self,
+        db: Any,
+        *,
+        workspace_id: str,
+        user_id: str,
+    ) -> WorkspaceRole | None:
+        workspace = await db.workspace.find_unique(where={"id": workspace_id})
+        if workspace is None:
+            return None
+        if str(getattr(workspace, "ownerUserId", "") or "") == user_id:
+            return "owner"
+        member_model = getattr(db, "workspacemember", None)
+        if member_model is None:
+            return None
+        member = await member_model.find_first(where={"workspaceId": workspace_id, "userId": user_id})
+        if member is None:
+            return None
+        return self._coerce_workspace_role_value(getattr(member, "role", None))
+
+    async def _authorize_runtime_bridge_cross_workspace_sqlite(
+        self,
+        *,
+        source_workspace_id: str,
+        target_workspace_id: str,
+        leased_by_user_id: str,
+        require_target_role: Literal["viewer", "editor"],
+        require_sqlite_mode: Literal["read", "read_write"],
+    ) -> _RuntimeBridgeSqliteAuthorizationResult:
+        if target_workspace_id == source_workspace_id:
+            raise HTTPException(status_code=400, detail=_RUNTIME_BRIDGE_SQLITE_SOURCE_EQUALS_TARGET_DETAIL)
+
+        db = await get_db()
+        source_role = await self._load_workspace_role_without_admin_bypass(
+            db,
+            workspace_id=source_workspace_id,
+            user_id=leased_by_user_id,
+        )
+        if not self._workspace_role_allows(source_role, "viewer"):
+            raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
+
+        target_role = await self._load_workspace_role_without_admin_bypass(
+            db,
+            workspace_id=target_workspace_id,
+            user_id=leased_by_user_id,
+        )
+        if not self._workspace_role_allows(target_role, require_target_role):
+            raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
+
+        model = self._workspace_agent_grant_model(db)
+        if model is None:
+            raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
+        grant = await model.find_first(
+            where={
+                "sourceWorkspaceId": source_workspace_id,
+                "targetWorkspaceId": target_workspace_id,
+            }
+        )
+        if grant is None:
+            raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
+
+        expires_at = getattr(grant, "expiresAt", None)
+        if expires_at is not None and coerce_utc_datetime(expires_at) < utc_now():
+            raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
+
+        sqlite_access_mode = self._normalize_sqlite_grant_mode(getattr(grant, "sqliteAccessMode", "none"))
+        allowed_modes = {"read", "read_write"} if require_sqlite_mode == "read" else {"read_write"}
+        if sqlite_access_mode not in allowed_modes:
+            raise HTTPException(status_code=403, detail=_RUNTIME_BRIDGE_SQLITE_FORBIDDEN_DETAIL)
+
+        return {
+            "grant_id": str(getattr(grant, "id", "") or ""),
+            "sqlite_access_mode": sqlite_access_mode,
+        }
+
+    @staticmethod
+    def _build_runtime_bridge_sqlite_mutation_operations(
+        request: RuntimeBridgeSqliteMutationRequest,
+    ) -> list[CrossWorkspaceSqliteMutationOperation]:
+        return [
+            CrossWorkspaceSqliteMutationOperation(
+                kind=operation.kind,
+                table=operation.table,
+                values=operation.values,
+                where=operation.where,
+                conflict_columns=operation.conflict_columns,
+            )
+            for operation in request.operations
+        ]
 
     async def list_workspace_agent_grants(
         self,
@@ -14797,6 +15087,8 @@ class UserSpaceService:
             )
 
         access_mode: WorkspaceAgentGrantMode = "read_write" if request.access_mode == "read_write" else "read"
+        sqlite_mode_explicitly_set = "sqlite_access_mode" in request.model_fields_set
+        requested_sqlite_access_mode = self._normalize_sqlite_grant_mode(request.sqlite_access_mode)
 
         source_workspace = await self._enforce_workspace_access(
             source_workspace_id,
@@ -14825,6 +15117,15 @@ class UserSpaceService:
                 "targetWorkspaceId": target_workspace_id,
             }
         )
+        sqlite_access_mode = (
+            requested_sqlite_access_mode if sqlite_mode_explicitly_set else self._normalize_sqlite_grant_mode(getattr(existing, "sqliteAccessMode", "none"))
+        )
+
+        if sqlite_mode_explicitly_set and not self._workspace_user_is_owner(target_workspace, user_id):
+            raise HTTPException(
+                status_code=403,
+                detail="Only the target workspace owner can change SQLite access for a cross-workspace agent grant",
+            )
 
         now = utc_now()
         if existing is None:
@@ -14833,6 +15134,7 @@ class UserSpaceService:
                     "sourceWorkspaceId": source_workspace_id,
                     "targetWorkspaceId": target_workspace_id,
                     "accessMode": access_mode,
+                    "sqliteAccessMode": sqlite_access_mode,
                     "grantedByUserId": user_id,
                     "createdAt": now,
                     "updatedAt": now,
@@ -14844,6 +15146,7 @@ class UserSpaceService:
                 where={"id": existing.id},
                 data={
                     "accessMode": access_mode,
+                    **({"sqliteAccessMode": sqlite_access_mode} if sqlite_mode_explicitly_set else {}),
                     "grantedByUserId": user_id,
                     "updatedAt": now,
                 },
@@ -14856,6 +15159,7 @@ class UserSpaceService:
                 "source_workspace_id": source_workspace_id,
                 "target_workspace_id": target_workspace_id,
                 "access_mode": access_mode,
+                "sqlite_access_mode": sqlite_access_mode,
             }
             await self._record_runtime_audit_event(
                 source_workspace_id,
@@ -14901,26 +15205,41 @@ class UserSpaceService:
             return False
 
         access_mode = self._normalize_agent_grant_mode(getattr(existing, "accessMode", "read"))
-        allowed = False
-        try:
-            await self._enforce_workspace_access(
-                source_workspace_id,
-                user_id,
-                required_role="editor",
-                is_admin=is_admin,
-            )
-            allowed = True
-        except HTTPException as exc:
-            if exc.status_code not in {403, 404}:
-                raise
+        sqlite_access_mode = self._normalize_sqlite_grant_mode(getattr(existing, "sqliteAccessMode", "none"))
 
-        if not allowed:
-            await self._enforce_workspace_access(
+        if sqlite_access_mode != "none":
+            target_workspace = await self._enforce_workspace_access(
                 target_workspace_id,
                 user_id,
-                required_role="editor" if access_mode == "read_write" else "viewer",
+                required_role="viewer",
                 is_admin=is_admin,
             )
+            if not self._workspace_user_is_owner(target_workspace, user_id):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Only the target workspace owner can revoke a cross-workspace agent grant with SQLite access",
+                )
+        else:
+            allowed = False
+            try:
+                await self._enforce_workspace_access(
+                    source_workspace_id,
+                    user_id,
+                    required_role="editor",
+                    is_admin=is_admin,
+                )
+                allowed = True
+            except HTTPException as exc:
+                if exc.status_code not in {403, 404}:
+                    raise
+
+            if not allowed:
+                await self._enforce_workspace_access(
+                    target_workspace_id,
+                    user_id,
+                    required_role="editor" if access_mode == "read_write" else "viewer",
+                    is_admin=is_admin,
+                )
 
         await model.delete(where={"id": existing.id})
 
@@ -14928,6 +15247,7 @@ class UserSpaceService:
             audit_payload = {
                 "source_workspace_id": source_workspace_id,
                 "target_workspace_id": target_workspace_id,
+                "sqlite_access_mode": sqlite_access_mode,
             }
             await self._record_runtime_audit_event(
                 source_workspace_id,
@@ -21466,6 +21786,330 @@ class UserSpaceService:
             tool_type=result.tool_type,
         )
         return result.response
+
+    async def query_runtime_bridge_sqlite(
+        self,
+        *,
+        workspace_id: str,
+        session_id: str,
+        leased_by_user_id: str,
+        request: RuntimeBridgeSqliteQueryRequest,
+    ) -> RuntimeBridgeSqliteQueryResponse:
+        target_workspace_id = request.target_workspace_id.strip()
+        sql_digest = hashlib.sha256(request.sql.encode("utf-8")).hexdigest()
+        try:
+            self._consume_runtime_bridge_sqlite_rate_limit(session_id, target_workspace_id)
+        except HTTPException as exc:
+            if exc.status_code == 429:
+                await self._audit_runtime_bridge_sqlite_denied(
+                    source_workspace_id=workspace_id,
+                    target_workspace_id=target_workspace_id,
+                    session_id=session_id,
+                    leased_by_user_id=leased_by_user_id,
+                    operation="query",
+                    error_code="rate_limited",
+                    sql_digest=sql_digest,
+                )
+            raise
+
+        authorization: _RuntimeBridgeSqliteAuthorizationResult | None = None
+        try:
+            authorization = await self._authorize_runtime_bridge_cross_workspace_sqlite(
+                source_workspace_id=workspace_id,
+                target_workspace_id=target_workspace_id,
+                leased_by_user_id=leased_by_user_id,
+                require_target_role="viewer",
+                require_sqlite_mode="read",
+            )
+        except HTTPException as exc:
+            if exc.status_code in {400, 403}:
+                await self._audit_runtime_bridge_sqlite_denied(
+                    source_workspace_id=workspace_id,
+                    target_workspace_id=target_workspace_id,
+                    session_id=session_id,
+                    leased_by_user_id=leased_by_user_id,
+                    operation="query",
+                    error_code=self._runtime_bridge_sqlite_http_error_code(exc),
+                    sql_digest=sql_digest,
+                )
+            raise
+
+        broker = self._runtime_bridge_cross_workspace_sqlite_broker()
+        files_dir = self._workspace_files_dir(target_workspace_id)
+        started_at = _time.monotonic()
+        try:
+            result = await broker.query(
+                files_dir,
+                request.sql,
+                parameters=request.parameters,
+                max_rows=request.max_rows,
+            )
+        except CrossWorkspaceSqliteError as exc:
+            payload = self._build_runtime_bridge_sqlite_audit_payload(
+                source_workspace_id=workspace_id,
+                target_workspace_id=target_workspace_id,
+                session_id=session_id,
+                leased_by_user_id=leased_by_user_id,
+                operation="query",
+                grant_id=authorization.get("grant_id"),
+                sqlite_access_mode=authorization.get("sqlite_access_mode"),
+            )
+            payload.update(
+                {
+                    "phase": "outcome",
+                    "status": "failed",
+                    "sql_digest": sql_digest,
+                    "row_count": 0,
+                    "duration_ms": int((_time.monotonic() - started_at) * 1000),
+                    "error_code": exc.code,
+                }
+            )
+            await self._record_runtime_bridge_sqlite_event_best_effort(
+                workspace_id=target_workspace_id,
+                user_id=leased_by_user_id,
+                session_id=session_id,
+                payload=payload,
+            )
+            raise
+        except Exception:
+            payload = self._build_runtime_bridge_sqlite_audit_payload(
+                source_workspace_id=workspace_id,
+                target_workspace_id=target_workspace_id,
+                session_id=session_id,
+                leased_by_user_id=leased_by_user_id,
+                operation="query",
+                grant_id=authorization.get("grant_id"),
+                sqlite_access_mode=authorization.get("sqlite_access_mode"),
+            )
+            payload.update(
+                {
+                    "phase": "outcome",
+                    "status": "failed",
+                    "sql_digest": sql_digest,
+                    "row_count": 0,
+                    "duration_ms": int((_time.monotonic() - started_at) * 1000),
+                    "error_code": "query_failed",
+                }
+            )
+            await self._record_runtime_bridge_sqlite_event_best_effort(
+                workspace_id=target_workspace_id,
+                user_id=leased_by_user_id,
+                session_id=session_id,
+                payload=payload,
+            )
+            raise
+
+        payload = self._build_runtime_bridge_sqlite_audit_payload(
+            source_workspace_id=workspace_id,
+            target_workspace_id=target_workspace_id,
+            session_id=session_id,
+            leased_by_user_id=leased_by_user_id,
+            operation="query",
+            grant_id=authorization.get("grant_id"),
+            sqlite_access_mode=authorization.get("sqlite_access_mode"),
+        )
+        payload.update(
+            {
+                "phase": "outcome",
+                "status": "succeeded",
+                "sql_digest": sql_digest,
+                "row_count": result.row_count,
+                "duration_ms": int((_time.monotonic() - started_at) * 1000),
+                "error_code": None,
+            }
+        )
+        await self._record_runtime_bridge_sqlite_event_best_effort(
+            workspace_id=target_workspace_id,
+            user_id=leased_by_user_id,
+            session_id=session_id,
+            payload=payload,
+        )
+        return RuntimeBridgeSqliteQueryResponse(
+            target_workspace_id=target_workspace_id,
+            database_name=request.database_name,
+            columns=result.columns,
+            rows=result.rows,
+            row_count=result.row_count,
+            truncated=result.truncated,
+        )
+
+    async def mutate_runtime_bridge_sqlite(
+        self,
+        *,
+        workspace_id: str,
+        session_id: str,
+        leased_by_user_id: str,
+        request: RuntimeBridgeSqliteMutationRequest,
+    ) -> RuntimeBridgeSqliteMutationResponse:
+        target_workspace_id = request.target_workspace_id.strip()
+        broker = self._runtime_bridge_cross_workspace_sqlite_broker()
+        operations = self._build_runtime_bridge_sqlite_mutation_operations(request)
+        fingerprint = broker.fingerprint_operations(operations)
+        operation_count = len(operations)
+        try:
+            self._consume_runtime_bridge_sqlite_rate_limit(session_id, target_workspace_id)
+        except HTTPException as exc:
+            if exc.status_code == 429:
+                await self._audit_runtime_bridge_sqlite_denied(
+                    source_workspace_id=workspace_id,
+                    target_workspace_id=target_workspace_id,
+                    session_id=session_id,
+                    leased_by_user_id=leased_by_user_id,
+                    operation="mutate",
+                    error_code="rate_limited",
+                    fingerprint=fingerprint,
+                    operation_count=operation_count,
+                )
+            raise
+
+        authorization: _RuntimeBridgeSqliteAuthorizationResult | None = None
+        try:
+            authorization = await self._authorize_runtime_bridge_cross_workspace_sqlite(
+                source_workspace_id=workspace_id,
+                target_workspace_id=target_workspace_id,
+                leased_by_user_id=leased_by_user_id,
+                require_target_role="editor",
+                require_sqlite_mode="read_write",
+            )
+        except HTTPException as exc:
+            if exc.status_code in {400, 403}:
+                await self._audit_runtime_bridge_sqlite_denied(
+                    source_workspace_id=workspace_id,
+                    target_workspace_id=target_workspace_id,
+                    session_id=session_id,
+                    leased_by_user_id=leased_by_user_id,
+                    operation="mutate",
+                    error_code=self._runtime_bridge_sqlite_http_error_code(exc),
+                    fingerprint=fingerprint,
+                    operation_count=operation_count,
+                )
+            raise
+
+        files_dir = self._workspace_files_dir(target_workspace_id)
+        started_at = _time.monotonic()
+        base_payload = self._build_runtime_bridge_sqlite_audit_payload(
+            source_workspace_id=workspace_id,
+            target_workspace_id=target_workspace_id,
+            session_id=session_id,
+            leased_by_user_id=leased_by_user_id,
+            operation="mutate",
+            grant_id=authorization.get("grant_id"),
+            sqlite_access_mode=authorization.get("sqlite_access_mode"),
+        )
+
+        async def _audit_intent(intent: Any) -> bool:
+            payload = dict(base_payload)
+            payload.update(
+                {
+                    "phase": "intent",
+                    "fingerprint": intent.fingerprint,
+                    "operation_count": intent.operation_count,
+                }
+            )
+            return await self._record_runtime_audit_event(
+                target_workspace_id,
+                leased_by_user_id,
+                _RUNTIME_BRIDGE_SQLITE_AUDIT_EVENT_TYPE,
+                payload,
+                session_id=session_id,
+            )
+
+        async def _audit_outcome(outcome: Any) -> None:
+            payload = dict(base_payload)
+            payload.update(
+                {
+                    "phase": "outcome",
+                    "fingerprint": outcome.fingerprint,
+                    "operation_count": outcome.operation_count,
+                    "status": outcome.status,
+                    "error_code": outcome.error_code,
+                    "duration_ms": int((_time.monotonic() - started_at) * 1000),
+                }
+            )
+            await self._record_runtime_bridge_sqlite_event_best_effort(
+                workspace_id=target_workspace_id,
+                user_id=leased_by_user_id,
+                session_id=session_id,
+                payload=payload,
+            )
+
+        result = await broker.mutate(
+            files_dir,
+            operations,
+            audit_context=CrossWorkspaceSqliteAuditIdentityContext(
+                actor_id=leased_by_user_id,
+                request_id=session_id,
+            ),
+            audit_intent_callback=_audit_intent,
+            audit_outcome_callback=_audit_outcome,
+        )
+
+        try:
+            await broker.checkpoint(files_dir)
+        except Exception as exc:  # noqa: BLE001 - committed mutation must still succeed
+            logger.exception(
+                "Runtime bridge SQLite checkpoint failed for workspace %s",
+                target_workspace_id,
+            )
+            payload = dict(base_payload)
+            payload.update(
+                {
+                    "phase": "post_commit_failure",
+                    "fingerprint": result.fingerprint,
+                    "operation_count": len(result.operations),
+                    "status": "committed",
+                    "error_code": "checkpoint_failed",
+                }
+            )
+            await self._record_runtime_bridge_sqlite_event_best_effort(
+                workspace_id=target_workspace_id,
+                user_id=leased_by_user_id,
+                session_id=session_id,
+                payload=payload,
+            )
+        else:
+            try:
+                await self.create_snapshot(
+                    target_workspace_id,
+                    leased_by_user_id,
+                    "Runtime bridge SQLite mutation",
+                    auto_sync_to_scm=False,
+                )
+            except Exception:  # noqa: BLE001 - committed mutation must still succeed
+                logger.exception(
+                    "Runtime bridge SQLite snapshot failed for workspace %s",
+                    target_workspace_id,
+                )
+                payload = dict(base_payload)
+                payload.update(
+                    {
+                        "phase": "post_commit_failure",
+                        "fingerprint": result.fingerprint,
+                        "operation_count": len(result.operations),
+                        "status": "committed",
+                        "error_code": "snapshot_failed",
+                    }
+                )
+                await self._record_runtime_bridge_sqlite_event_best_effort(
+                    workspace_id=target_workspace_id,
+                    user_id=leased_by_user_id,
+                    session_id=session_id,
+                    payload=payload,
+                )
+
+        return RuntimeBridgeSqliteMutationResponse(
+            target_workspace_id=target_workspace_id,
+            database_name=request.database_name,
+            operations=[
+                RuntimeBridgeSqliteMutationOperationResponse(
+                    kind=operation.kind,
+                    rowcount=operation.rowcount,
+                    lastrowid=operation.lastrowid,
+                )
+                for operation in result.operations
+            ],
+            fingerprint=result.fingerprint,
+        )
 
     async def _execute_shared_component_for_workspace_id(
         self,

--- a/tests/test_tool_access_chat.py
+++ b/tests/test_tool_access_chat.py
@@ -488,6 +488,211 @@ class ConversationToolEndpointAclTests(unittest.IsolatedAsyncioTestCase):
 
 
 class ConversationToolPromptAclTests(unittest.IsolatedAsyncioTestCase):
+    async def _build_userspace_runtime_context_for_prompt_test(
+        self,
+        *,
+        get_runtime_session: mock.AsyncMock | None = None,
+        list_accessible_targets: mock.AsyncMock | None = None,
+        build_mode_prompt: mock.Mock | None = None,
+    ) -> tuple[dict[str, Any], mock.AsyncMock, mock.AsyncMock, mock.Mock]:
+        rag = rag_components.RAGComponents.__new__(rag_components.RAGComponents)
+        rag._tool_configs = [
+            {"id": "tool-3", "name": "Flapping Tool", "tool_type": "postgres"},
+        ]
+        rag._app_settings = {}
+        rag._index_metadata = []
+        rag._request_prompt_cache = {}
+
+        workspace = SimpleNamespace(
+            id="workspace-1",
+            owner_user_id="owner-1",
+            tool_selection_mode="custom",
+            selected_tool_ids=["tool-3"],
+            selected_tool_group_ids=[],
+            sqlite_persistence_mode="include",
+        )
+        runtime_tools = [SimpleNamespace(name="query_flapping_tool")]
+        runtime_session_mock = get_runtime_session or mock.AsyncMock(return_value=SimpleNamespace(session=None))
+        target_mock = list_accessible_targets or mock.AsyncMock(return_value=[])
+        prompt_mock = build_mode_prompt or mock.Mock(return_value="MODE_PROMPT")
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                mock.patch.object(
+                    rag,
+                    "_apply_conversation_tool_overrides",
+                    mock.AsyncMock(return_value=list(runtime_tools)),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_service.get_workspace",
+                    mock.AsyncMock(return_value=workspace),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.resolve_effective_tool_ids",
+                    mock.AsyncMock(side_effect=resolve_effective_tool_ids),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_service.filter_tool_ids_for_workspace_owner",
+                    mock.AsyncMock(return_value=["tool-3"]),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.repository.list_healthy_enabled_tool_ids",
+                    mock.AsyncMock(return_value=["tool-3"]),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.repository.list_enabled_tool_ids",
+                    mock.AsyncMock(return_value=["tool-3"]),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.repository.get_tool_ids_for_groups",
+                    mock.AsyncMock(return_value=[]),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_service.list_workspace_env_var_summaries",
+                    mock.AsyncMock(return_value=[]),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_service.list_workspace_mounts",
+                    mock.AsyncMock(return_value=[]),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_service.list_mountable_sources",
+                    mock.AsyncMock(return_value=[]),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_service.get_workspace_object_storage_summary",
+                    mock.AsyncMock(return_value=None),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_service.list_workspace_preview_diagnostic_summary",
+                    mock.AsyncMock(return_value=None),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_runtime_service.get_devserver_status",
+                    mock.AsyncMock(return_value=None),
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_runtime_service.get_runtime_session",
+                    runtime_session_mock,
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.userspace_service.list_accessible_cross_workspace_sqlite_targets",
+                    target_mock,
+                    create=True,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    rag,
+                    "_create_userspace_file_tools",
+                    mock.AsyncMock(return_value=[]),
+                )
+            )
+            stack.enter_context(mock.patch.object(rag, "_create_spawn_subagents_tool", mock.AsyncMock(return_value=None)))
+            stack.enter_context(
+                mock.patch.object(
+                    rag,
+                    "_apply_mode_specific_tool_description_overrides",
+                    side_effect=lambda tools, **_: tools,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    rag,
+                    "_wrap_userspace_runtime_tools_for_execution_proofs",
+                    side_effect=lambda tools, *_: tools,
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    rag,
+                    "_wrap_runtime_tools_with_request_state",
+                    side_effect=lambda tools, **_: (tools, {}),
+                )
+            )
+            stack.enter_context(mock.patch.object(rag, "_build_userspace_continuity_prompt", mock.AsyncMock(return_value="CONTINUITY")))
+            stack.enter_context(mock.patch.object(rag, "_build_userspace_env_var_turn_hint", return_value=""))
+            stack.enter_context(mock.patch.object(rag, "_build_userspace_runtime_status_turn_hint", return_value=""))
+            stack.enter_context(mock.patch.object(rag, "_build_userspace_env_var_prompt_fragment", return_value=""))
+            stack.enter_context(mock.patch.object(rag, "_build_userspace_mount_prompt_fragment", return_value=""))
+            stack.enter_context(mock.patch.object(rag, "_build_userspace_object_storage_prompt_fragment", return_value=""))
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.build_userspace_mode_prompt_addition",
+                    prompt_mock,
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.build_userspace_entrypoint_nudge",
+                    return_value="ENTRYPOINT_NUDGE",
+                )
+            )
+            stack.enter_context(
+                mock.patch(
+                    "ragtime.rag.components.build_userspace_diagnostics_turn_reminder_line",
+                    return_value="",
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    rag_components.userspace_service,
+                    "get_workspace_entrypoint_status",
+                    return_value=SimpleNamespace(state="valid", framework="react", command="npm run dev", cwd="."),
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    rag_components.userspace_service,
+                    "is_default_static_entrypoint",
+                    return_value=False,
+                )
+            )
+            request_context = await rag._build_request_runtime_context(
+                is_ui=False,
+                executor=cast(Any, SimpleNamespace(tools=list(runtime_tools))),
+                blocked_tool_names=None,
+                workspace_context={"workspace_id": "workspace-1", "user_id": "viewer-1"},
+                add_chat_visualization_prompt=False,
+                user_id="viewer-1",
+                current_user_context={
+                    "user_id": "viewer-1",
+                    "username": "viewer",
+                    "display_name": "Viewer",
+                    "is_admin": False,
+                },
+            )
+
+        return request_context, runtime_session_mock, target_mock, prompt_mock
+
     async def test_conversation_write_override_fails_closed_without_user_identity(self) -> None:
         rag = rag_components.RAGComponents.__new__(rag_components.RAGComponents)
         rag._tool_configs = [
@@ -822,6 +1027,64 @@ class ConversationToolPromptAclTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIn("Flapping Tool", prompt)
         self.assertNotIn("Healthy Tool", prompt)
+
+    async def test_userspace_runtime_context_uses_active_lease_identity_for_shared_sqlite_targets(self) -> None:
+        targets = [
+            {
+                "workspace_id": "workspace-2",
+                "workspace_name": "Shared Workspace",
+                "database_name": "app.sqlite3",
+                "access_mode": "read_write",
+            }
+        ]
+        request_context, runtime_session_mock, target_mock, prompt_mock = await self._build_userspace_runtime_context_for_prompt_test(
+            get_runtime_session=mock.AsyncMock(return_value=SimpleNamespace(session=SimpleNamespace(leased_by_user_id="lease-user-1"))),
+            list_accessible_targets=mock.AsyncMock(return_value=targets),
+        )
+
+        self.assertIn("ENTRYPOINT_NUDGE", request_context["prompt_additions"])
+        runtime_session_mock.assert_awaited_once_with("workspace-1", "viewer-1")
+        target_mock.assert_awaited_once_with("workspace-1", "lease-user-1")
+        prompt_mock.assert_called_once()
+        self.assertEqual(prompt_mock.call_args.kwargs["shared_sqlite_databases"], targets)
+
+    async def test_userspace_runtime_context_falls_back_to_request_user_for_shared_sqlite_targets_without_session(self) -> None:
+        request_context, runtime_session_mock, target_mock, prompt_mock = await self._build_userspace_runtime_context_for_prompt_test(
+            get_runtime_session=mock.AsyncMock(return_value=SimpleNamespace(session=None)),
+        )
+
+        self.assertIn("ENTRYPOINT_NUDGE", request_context["prompt_additions"])
+        runtime_session_mock.assert_awaited_once_with("workspace-1", "viewer-1")
+        target_mock.assert_awaited_once_with("workspace-1", "viewer-1")
+        prompt_mock.assert_called_once()
+        self.assertEqual(prompt_mock.call_args.kwargs["shared_sqlite_databases"], [])
+
+    async def test_userspace_runtime_context_omits_shared_sqlite_targets_when_runtime_session_lookup_fails(self) -> None:
+        with self.assertLogs(rag_components.logger, level="WARNING") as captured:
+            request_context, runtime_session_mock, target_mock, prompt_mock = await self._build_userspace_runtime_context_for_prompt_test(
+                get_runtime_session=mock.AsyncMock(side_effect=RuntimeError("session lookup failed")),
+            )
+
+        self.assertIn("ENTRYPOINT_NUDGE", request_context["prompt_additions"])
+        runtime_session_mock.assert_awaited_once_with("workspace-1", "viewer-1")
+        target_mock.assert_not_awaited()
+        prompt_mock.assert_called_once()
+        self.assertEqual(prompt_mock.call_args.kwargs["shared_sqlite_databases"], [])
+        self.assertTrue(any("session lookup failed" in message for message in captured.output))
+
+    async def test_userspace_runtime_context_omits_shared_sqlite_targets_when_target_lookup_fails(self) -> None:
+        with self.assertLogs(rag_components.logger, level="WARNING") as captured:
+            request_context, runtime_session_mock, target_mock, prompt_mock = await self._build_userspace_runtime_context_for_prompt_test(
+                get_runtime_session=mock.AsyncMock(return_value=SimpleNamespace(session=SimpleNamespace(leased_by_user_id="lease-user-1"))),
+                list_accessible_targets=mock.AsyncMock(side_effect=RuntimeError("target lookup failed")),
+            )
+
+        self.assertIn("ENTRYPOINT_NUDGE", request_context["prompt_additions"])
+        runtime_session_mock.assert_awaited_once_with("workspace-1", "viewer-1")
+        target_mock.assert_awaited_once_with("workspace-1", "lease-user-1")
+        prompt_mock.assert_called_once()
+        self.assertEqual(prompt_mock.call_args.kwargs["shared_sqlite_databases"], [])
+        self.assertTrue(any("target lookup failed" in message for message in captured.output))
 
 
 if __name__ == "__main__":

--- a/tests/test_tool_skill_prompts.py
+++ b/tests/test_tool_skill_prompts.py
@@ -194,7 +194,12 @@ No tools configured. Answer from indexed knowledge sources only (code, documenta
         self.assertIn("If required keys are missing, create placeholder env vars", prompt)
         self.assertIn("### Workspace\n\n- Existing app.", prompt)
         self.assertIn("Persistent User Space dashboards must be live-wired", prompt)
-        self.assertIn("Two-lane persistence contract", prompt)
+        self.assertIn("#### Data and persistence boundaries", prompt)
+        self.assertIn("##### Lane A - Live tool data", prompt)
+        self.assertIn("##### Lane B - Primary workspace SQLite", prompt)
+        self.assertIn("Use the approved execution surface for the current entrypoint", prompt)
+        self.assertIn("Primary workspace SQLite is accessed directly from server code at `.ragtime/db/app.sqlite3`", prompt)
+        self.assertNotIn("Two-lane persistence contract", prompt)
 
     def test_userspace_prompt_selective_availability_names_only_visible_tools(self) -> None:
         prompt = build_userspace_mode_prompt_addition(

--- a/tests/test_userspace_agent_grants.py
+++ b/tests/test_userspace_agent_grants.py
@@ -90,10 +90,17 @@ class _FakeUserTable:
 
 
 class _GrantService(UserSpaceService):
-    def __init__(self, roles: dict[str, str | None]) -> None:
+    def __init__(
+        self,
+        roles: dict[str, str | None],
+        *,
+        owner_user_ids: dict[str, str] | None = None,
+    ) -> None:
         super().__init__()
         self.roles = roles
+        self.owner_user_ids = owner_user_ids or {}
         self.enforcements: list[tuple[str, str | None]] = []
+        self.audit_events: list[tuple[str, str | None, str, dict[str, Any]]] = []
 
     async def _enforce_workspace_access(
         self,
@@ -113,7 +120,10 @@ class _GrantService(UserSpaceService):
         return UserSpaceWorkspace(
             id=workspace_id,
             name=f"Workspace {workspace_id}",
-            owner_user_id="user-1" if role == "owner" else "owner-other",
+            owner_user_id=self.owner_user_ids.get(
+                workspace_id,
+                "user-1" if role == "owner" else "owner-other",
+            ),
             members=([] if role in {None, "owner"} else [WorkspaceMember(user_id=user_id, role=cast(Any, role))]),
             created_at=_NOW,
             updated_at=_NOW,
@@ -129,6 +139,7 @@ class _GrantService(UserSpaceService):
         session_id: str | None = None,
         created_at: datetime | None = None,
     ) -> bool:
+        self.audit_events.append((workspace_id, user_id, event_type, payload))
         return True
 
 
@@ -165,6 +176,9 @@ class UserSpaceAgentGrantTests(unittest.IsolatedAsyncioTestCase):
             [("source", "editor"), ("target", "viewer")],
         )
         self.assertEqual(grant_table.created[0]["accessMode"], "read")
+        self.assertEqual(grant.sqlite_access_mode, "none")
+        self.assertEqual(grant_table.created[0]["sqliteAccessMode"], "none")
+        self.assertEqual(service.audit_events[0][3]["sqlite_access_mode"], "none")
 
     async def test_read_write_grant_requires_target_editor(self) -> None:
         service = _GrantService({"source": "editor", "target": "viewer"})
@@ -244,6 +258,262 @@ class UserSpaceAgentGrantTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual([grant.id for grant in grants], ["read-grant"])
         self.assertEqual(grants[0].source_workspace_name, "Read Source")
+        self.assertEqual(grants[0].sqlite_access_mode, "none")
+
+    async def test_legacy_missing_sqlite_mode_maps_to_none(self) -> None:
+        service = _GrantService({"source": "editor"})
+        grant_table = _FakeWorkspaceAgentGrantTable(
+            [
+                SimpleNamespace(
+                    id="legacy-grant",
+                    sourceWorkspaceId="source",
+                    targetWorkspaceId="target",
+                    accessMode="read",
+                    grantedByUserId="user-1",
+                    expiresAt=None,
+                    createdAt=_NOW,
+                    updatedAt=_NOW,
+                )
+            ]
+        )
+        fake_db = SimpleNamespace(
+            workspaceagentgrant=grant_table,
+            workspace=_FakeWorkspaceTable({"source": "Source", "target": "Target"}),
+            user=_FakeUserTable(),
+        )
+
+        async def _fake_get_db() -> SimpleNamespace:
+            return fake_db
+
+        with patch("ragtime.userspace.service.get_db", new=_fake_get_db):
+            grants = await service.list_workspace_agent_grants(
+                "source",
+                "user-2",
+                direction="source",
+            )
+
+        self.assertEqual(len(grants), 1)
+        self.assertEqual(grants[0].sqlite_access_mode, "none")
+
+    async def test_omitted_sqlite_mode_preserves_existing_non_none_value(self) -> None:
+        service = _GrantService(
+            {"source": "editor", "target": "owner"},
+            owner_user_ids={"target": "user-2"},
+        )
+        existing_row = SimpleNamespace(
+            id="grant-existing",
+            sourceWorkspaceId="source",
+            targetWorkspaceId="target",
+            accessMode="read",
+            sqliteAccessMode="read_write",
+            grantedByUserId="user-1",
+            expiresAt=None,
+            createdAt=_NOW,
+            updatedAt=_NOW,
+        )
+        grant_table = _FakeWorkspaceAgentGrantTable([existing_row])
+        fake_db = SimpleNamespace(
+            workspaceagentgrant=grant_table,
+            workspace=_FakeWorkspaceTable({"source": "Source", "target": "Target"}),
+            user=_FakeUserTable(),
+        )
+
+        async def _fake_get_db() -> SimpleNamespace:
+            return fake_db
+
+        with patch("ragtime.userspace.service.get_db", new=_fake_get_db):
+            grant = await service.upsert_workspace_agent_grant(
+                "source",
+                UpsertWorkspaceAgentGrantRequest(
+                    target_workspace_id="target",
+                    access_mode="read",
+                ),
+                "user-2",
+            )
+
+        self.assertEqual(grant.sqlite_access_mode, "read_write")
+        self.assertEqual(existing_row.sqliteAccessMode, "read_write")
+        self.assertNotIn("sqliteAccessMode", grant_table.updated[0]["data"])
+        self.assertEqual(service.audit_events[0][3]["sqlite_access_mode"], "read_write")
+
+    async def test_explicit_sqlite_mode_requires_real_target_owner(self) -> None:
+        for sqlite_access_mode in ("none", "read", "read_write"):
+            with self.subTest(sqlite_access_mode=sqlite_access_mode):
+                service = _GrantService(
+                    {"source": "editor", "target": "editor"},
+                    owner_user_ids={"target": "owner-other"},
+                )
+                fake_db = SimpleNamespace(
+                    workspaceagentgrant=_FakeWorkspaceAgentGrantTable(),
+                    workspace=_FakeWorkspaceTable({"source": "Source", "target": "Target"}),
+                    user=_FakeUserTable(),
+                )
+
+                async def _fake_get_db() -> SimpleNamespace:
+                    return fake_db
+
+                with patch("ragtime.userspace.service.get_db", new=_fake_get_db):
+                    with self.assertRaises(HTTPException) as raised:
+                        await service.upsert_workspace_agent_grant(
+                            "source",
+                            UpsertWorkspaceAgentGrantRequest(
+                                target_workspace_id="target",
+                                access_mode="read",
+                                sqlite_access_mode=sqlite_access_mode,
+                            ),
+                            "user-2",
+                        )
+
+                self.assertEqual(raised.exception.status_code, 403)
+
+    async def test_admin_without_target_ownership_is_denied_explicit_sqlite_mode(self) -> None:
+        service = _GrantService(
+            {"source": None, "target": None},
+            owner_user_ids={"target": "owner-other"},
+        )
+        fake_db = SimpleNamespace(
+            workspaceagentgrant=_FakeWorkspaceAgentGrantTable(),
+            workspace=_FakeWorkspaceTable({"source": "Source", "target": "Target"}),
+            user=_FakeUserTable(),
+        )
+
+        async def _fake_get_db() -> SimpleNamespace:
+            return fake_db
+
+        with patch("ragtime.userspace.service.get_db", new=_fake_get_db):
+            with self.assertRaises(HTTPException) as raised:
+                await service.upsert_workspace_agent_grant(
+                    "source",
+                    UpsertWorkspaceAgentGrantRequest(
+                        target_workspace_id="target",
+                        access_mode="read",
+                        sqlite_access_mode="read",
+                    ),
+                    "user-2",
+                    is_admin=True,
+                )
+
+        self.assertEqual(raised.exception.status_code, 403)
+
+    async def test_target_owner_can_grant_and_downgrade_sqlite_access(self) -> None:
+        service = _GrantService(
+            {"source": "editor", "target": "owner"},
+            owner_user_ids={"target": "user-2"},
+        )
+        grant_table = _FakeWorkspaceAgentGrantTable()
+        fake_db = SimpleNamespace(
+            workspaceagentgrant=grant_table,
+            workspace=_FakeWorkspaceTable({"source": "Source", "target": "Target"}),
+            user=_FakeUserTable(),
+        )
+
+        async def _fake_get_db() -> SimpleNamespace:
+            return fake_db
+
+        with patch("ragtime.userspace.service.get_db", new=_fake_get_db):
+            created = await service.upsert_workspace_agent_grant(
+                "source",
+                UpsertWorkspaceAgentGrantRequest(
+                    target_workspace_id="target",
+                    access_mode="read",
+                    sqlite_access_mode="read_write",
+                ),
+                "user-2",
+            )
+            downgraded = await service.upsert_workspace_agent_grant(
+                "source",
+                UpsertWorkspaceAgentGrantRequest(
+                    target_workspace_id="target",
+                    access_mode="read",
+                    sqlite_access_mode="none",
+                ),
+                "user-2",
+            )
+
+        self.assertEqual(created.sqlite_access_mode, "read_write")
+        self.assertEqual(downgraded.sqlite_access_mode, "none")
+        self.assertEqual(grant_table.created[0]["sqliteAccessMode"], "read_write")
+        self.assertEqual(grant_table.updated[0]["data"]["sqliteAccessMode"], "none")
+
+    async def test_source_side_revoke_is_denied_for_active_sqlite_grant(self) -> None:
+        service = _GrantService(
+            {"source": "editor", "target": "viewer"},
+            owner_user_ids={"target": "owner-other"},
+        )
+        grant_table = _FakeWorkspaceAgentGrantTable(
+            [
+                SimpleNamespace(
+                    id="sqlite-grant",
+                    sourceWorkspaceId="source",
+                    targetWorkspaceId="target",
+                    accessMode="read",
+                    sqliteAccessMode="read",
+                    grantedByUserId="user-1",
+                    expiresAt=None,
+                    createdAt=_NOW,
+                    updatedAt=_NOW,
+                )
+            ]
+        )
+        fake_db = SimpleNamespace(
+            workspaceagentgrant=grant_table,
+            workspace=_FakeWorkspaceTable({"source": "Source", "target": "Target"}),
+            user=_FakeUserTable(),
+        )
+
+        async def _fake_get_db() -> SimpleNamespace:
+            return fake_db
+
+        with patch("ragtime.userspace.service.get_db", new=_fake_get_db):
+            with self.assertRaises(HTTPException) as raised:
+                await service.revoke_workspace_agent_grant(
+                    "source",
+                    "target",
+                    "user-2",
+                )
+
+        self.assertEqual(raised.exception.status_code, 403)
+        self.assertEqual(grant_table.deleted, [])
+
+    async def test_target_owner_can_revoke_active_sqlite_grant(self) -> None:
+        service = _GrantService(
+            {"source": None, "target": "owner"},
+            owner_user_ids={"target": "user-2"},
+        )
+        grant_table = _FakeWorkspaceAgentGrantTable(
+            [
+                SimpleNamespace(
+                    id="sqlite-grant",
+                    sourceWorkspaceId="source",
+                    targetWorkspaceId="target",
+                    accessMode="read",
+                    sqliteAccessMode="read_write",
+                    grantedByUserId="user-1",
+                    expiresAt=None,
+                    createdAt=_NOW,
+                    updatedAt=_NOW,
+                )
+            ]
+        )
+        fake_db = SimpleNamespace(
+            workspaceagentgrant=grant_table,
+            workspace=_FakeWorkspaceTable({"source": "Source", "target": "Target"}),
+            user=_FakeUserTable(),
+        )
+
+        async def _fake_get_db() -> SimpleNamespace:
+            return fake_db
+
+        with patch("ragtime.userspace.service.get_db", new=_fake_get_db):
+            revoked = await service.revoke_workspace_agent_grant(
+                "source",
+                "target",
+                "user-2",
+            )
+
+        self.assertTrue(revoked)
+        self.assertEqual(grant_table.deleted, [{"id": "sqlite-grant"}])
+        self.assertEqual(service.audit_events[0][3]["sqlite_access_mode"], "read_write")
 
     async def test_revoke_allows_target_viewer_to_remove_read_grant(self) -> None:
         service = _GrantService({"source": None, "target": "viewer"})
@@ -283,6 +553,7 @@ class UserSpaceAgentGrantTests(unittest.IsolatedAsyncioTestCase):
             service.enforcements,
             [("source", "editor"), ("target", "viewer")],
         )
+        self.assertEqual(service.audit_events[0][3]["sqlite_access_mode"], "none")
 
 
 if __name__ == "__main__":

--- a/tests/test_userspace_cross_workspace_sqlite.py
+++ b/tests/test_userspace_cross_workspace_sqlite.py
@@ -1,0 +1,654 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+import importlib
+import sqlite3
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from ragtime.userspace.cross_workspace_sqlite import AuditOutcome
+
+
+def _mod():
+    return importlib.import_module("ragtime.userspace.cross_workspace_sqlite")
+
+
+def _policy(**overrides):
+    mod = _mod()
+    values = {}
+    values.update(overrides)
+    return mod.CrossWorkspaceSqlitePolicy(**values)
+
+
+def _broker(**policy_overrides):
+    mod = _mod()
+    return mod.CrossWorkspaceSqliteBroker(_policy(**policy_overrides))
+
+
+def _files_dir(tmp_path: Path) -> Path:
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    return files_dir
+
+
+def _db_path(files_dir: Path) -> Path:
+    db_path = files_dir / ".ragtime" / "db" / "app.sqlite3"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return db_path
+
+
+def _init_db(files_dir: Path) -> Path:
+    db_path = _db_path(files_dir)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, payload BLOB, qty INTEGER DEFAULT 0)")
+        conn.commit()
+    return db_path
+
+
+async def _allow_audit(_intent) -> bool:
+    return True
+
+
+def _run(awaitable):
+    return asyncio.run(awaitable)
+
+
+def _assert_broker_error(exc_info: pytest.ExceptionInfo[Exception], code: str) -> None:
+    error = exc_info.value
+    assert getattr(error, "code") == code
+    assert isinstance(str(error), str)
+
+
+def test_query_allows_reads_and_supports_positional_and_named_parameters(tmp_path: Path) -> None:
+    files_dir = _files_dir(tmp_path)
+    db_path = _init_db(files_dir)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("INSERT INTO items (id, name, payload, qty) VALUES (?, ?, ?, ?)", (1, "Ada", b"abc", 3))
+        conn.execute("INSERT INTO items (id, name, qty) VALUES (?, ?, ?)", (2, "Grace", 7))
+        conn.commit()
+
+    positional = _run(_broker().query(files_dir, "SELECT name FROM items WHERE id = ?", parameters=[1]))
+    assert positional.rows == [{"name": "Ada"}]
+
+    named = _run(
+        _broker().query(
+            files_dir,
+            "SELECT name, payload FROM items WHERE qty = :qty",
+            parameters={"qty": 3},
+        )
+    )
+    assert named.rows == [{"name": "Ada", "payload": {"__blob__": True, "size": 3}}]
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "DELETE FROM items",
+        "CREATE TABLE nope (id INTEGER)",
+        "PRAGMA user_version",
+        "ATTACH DATABASE ':memory:' AS extra",
+        "SELECT load_extension('test')",
+    ],
+)
+def test_query_rejects_mutation_ddl_pragma_attach_and_extension_attempts(tmp_path: Path, sql: str) -> None:
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, sql))
+    _assert_broker_error(exc_info, "sql_not_allowed")
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "WITH cte AS (SELECT 1) DELETE FROM items WHERE id = 1",
+        "WITH cte AS (SELECT 1) UPDATE items SET name = 'x' WHERE id = 1",
+        "EXPLAIN DELETE FROM items WHERE id = 1",
+    ],
+)
+def test_query_authorizer_blocks_write_ctes_and_explain_writes(tmp_path: Path, sql: str) -> None:
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, sql))
+    _assert_broker_error(exc_info, "sql_not_allowed")
+
+
+def test_query_enforces_sql_row_parameter_and_response_limits(tmp_path: Path) -> None:
+    files_dir = _files_dir(tmp_path)
+    db_path = _init_db(files_dir)
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            "INSERT INTO items (id, name) VALUES (?, ?)",
+            [(idx, "x" * 4096) for idx in range(1, 400)],
+        )
+        conn.commit()
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "SELECT 1", max_rows=0))
+    _assert_broker_error(exc_info, "row_limit_invalid")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "S" * (32 * 1024 + 1)))
+    _assert_broker_error(exc_info, "sql_too_large")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "SELECT ?", parameters=object()))
+    _assert_broker_error(exc_info, "invalid_parameters")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "SELECT ?", parameters=list(range(501))))
+    _assert_broker_error(exc_info, "invalid_parameters")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "SELECT ?", parameters={1: "bad-key"}))
+    _assert_broker_error(exc_info, "invalid_parameters")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "SELECT ?", parameters=[2**63]))
+    _assert_broker_error(exc_info, "invalid_parameters")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, 123))
+    _assert_broker_error(exc_info, "invalid_sql")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "SELECT 1", max_rows="10"))
+    _assert_broker_error(exc_info, "row_limit_invalid")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "SELECT 1", max_rows=True))
+    _assert_broker_error(exc_info, "row_limit_invalid")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "SELECT name FROM items", max_rows=399))
+    _assert_broker_error(exc_info, "response_too_large")
+
+
+def test_query_missing_database_maps_to_database_not_found(tmp_path: Path) -> None:
+    files_dir = _files_dir(tmp_path)
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().query(files_dir, "SELECT 1"))
+    _assert_broker_error(exc_info, "database_not_found")
+
+
+def test_query_maps_timeouts_and_supports_readonly_wal_databases(tmp_path: Path) -> None:
+    files_dir = _files_dir(tmp_path)
+    db_path = _init_db(files_dir)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("INSERT INTO items (id, name) VALUES (?, ?)", (1, "wal"))
+        conn.commit()
+
+    wal_result = _run(_broker().query(files_dir, "SELECT name FROM items"))
+    assert wal_result.rows == [{"name": "wal"}]
+
+    timeout_broker = _broker()
+    timeout_broker.policy.query_timeout_seconds = 0.001
+    with pytest.raises(Exception) as exc_info:
+        _run(
+            timeout_broker.query(
+                files_dir,
+                "WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM cnt WHERE x < 10000000) SELECT max(x) FROM cnt",
+            )
+        )
+    _assert_broker_error(exc_info, "query_timeout")
+
+
+def test_query_renames_duplicate_output_columns_without_data_loss(tmp_path: Path) -> None:
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+
+    result = _run(_broker().query(files_dir, "SELECT 1 AS x, 2 AS x, 3 AS x"))
+
+    assert result.columns == ["x", "x__2", "x__3"]
+    assert result.rows == [{"x": 1, "x__2": 2, "x__3": 3}]
+
+
+def test_mutate_runs_atomic_insert_upsert_update_and_delete_transaction(tmp_path: Path) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+
+    result = _run(
+        _broker().mutate(
+            files_dir,
+            [
+                mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada", "qty": 1}),
+                mod.MutationOperation(kind="upsert", table="items", values={"id": 1, "name": "Ada Lovelace", "qty": 2}, conflict_columns=["id"]),
+                mod.MutationOperation(kind="insert", table="items", values={"id": 2, "name": "Grace", "qty": 4}),
+                mod.MutationOperation(kind="update", table="items", values={"qty": 5}, where={"id": 2}),
+                mod.MutationOperation(kind="delete", table="items", where={"id": 1}),
+            ],
+            audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+            audit_intent_callback=_allow_audit,
+        )
+    )
+
+    assert [entry.rowcount for entry in result.operations] == [1, 1, 1, 1, 1]
+    assert result.operations[0].lastrowid is not None
+    assert result.operations[1].lastrowid is not None
+
+    rows = _run(_broker().query(files_dir, "SELECT id, name, qty FROM items ORDER BY id"))
+    assert rows.rows == [{"id": 2, "name": "Grace", "qty": 5}]
+
+
+def test_mutate_rejects_empty_predicates_unsafe_identifiers_operation_count_and_payload_size(tmp_path: Path) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+
+    with pytest.raises(Exception) as exc_info:
+        _run(
+            _broker().mutate(
+                files_dir,
+                [mod.MutationOperation(kind="update", table="items", values={"name": "Ada"}, where={})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                audit_intent_callback=_allow_audit,
+            )
+        )
+    _assert_broker_error(exc_info, "invalid_parameters")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(
+            _broker().mutate(
+                files_dir,
+                [mod.MutationOperation(kind="delete", table="items", where={})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                audit_intent_callback=_allow_audit,
+            )
+        )
+    _assert_broker_error(exc_info, "invalid_parameters")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(
+            _broker().mutate(
+                files_dir,
+                [mod.MutationOperation(kind="insert", table="items;drop", values={"id": 1})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                audit_intent_callback=_allow_audit,
+            )
+        )
+    _assert_broker_error(exc_info, "invalid_sql")
+
+    too_many = [mod.MutationOperation(kind="insert", table="items", values={"id": idx}) for idx in range(1, 502)]
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().mutate(files_dir, too_many, audit_context=mod.AuditIdentityContext(actor_id="user-1"), audit_intent_callback=_allow_audit))
+    _assert_broker_error(exc_info, "invalid_parameters")
+
+    with pytest.raises(Exception) as exc_info:
+        _run(
+            _broker().mutate(
+                files_dir,
+                [mod.MutationOperation(kind="insert", table="items", values={"id": 2**63, "name": "Ada"})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                audit_intent_callback=_allow_audit,
+            )
+        )
+    _assert_broker_error(exc_info, "invalid_parameters")
+
+    too_large = [mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "x" * (1024 * 1024)})]
+    with pytest.raises(Exception) as exc_info:
+        _run(_broker().mutate(files_dir, too_large, audit_context=mod.AuditIdentityContext(actor_id="user-1"), audit_intent_callback=_allow_audit))
+    _assert_broker_error(exc_info, "payload_too_large")
+
+
+def test_mutate_rolls_back_on_failure_and_reports_outcomes_without_values(tmp_path: Path) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+    outcomes: list[AuditOutcome] = []
+
+    async def outcome_callback(outcome: AuditOutcome) -> None:
+        outcomes.append(outcome)
+
+    with pytest.raises(Exception) as exc_info:
+        _run(
+            _broker().mutate(
+                files_dir,
+                [
+                    mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada"}),
+                    mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Duplicate"}),
+                ],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1", request_id="req-1"),
+                audit_intent_callback=_allow_audit,
+                audit_outcome_callback=outcome_callback,
+            )
+        )
+    _assert_broker_error(exc_info, "mutation_failed")
+
+    rows = _run(_broker().query(files_dir, "SELECT id, name FROM items"))
+    assert rows.rows == []
+    assert outcomes
+    serialized = repr(outcomes[0])
+    assert "Ada" not in serialized
+    assert "Duplicate" not in serialized
+
+
+def test_mutate_committed_success_reports_outcome_and_swallowed_callback_failures_do_not_change_result(tmp_path: Path) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+    outcomes: list[AuditOutcome] = []
+
+    async def outcome_callback(outcome: AuditOutcome) -> None:
+        outcomes.append(outcome)
+
+    result = _run(
+        _broker().mutate(
+            files_dir,
+            [mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada"})],
+            audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+            audit_intent_callback=_allow_audit,
+            audit_outcome_callback=outcome_callback,
+        )
+    )
+
+    assert result.operations[0].rowcount == 1
+    assert len(outcomes) == 1
+    assert outcomes[0].status == "committed"
+    assert outcomes[0].error_code is None
+
+    async def failing_outcome_callback(_outcome: AuditOutcome) -> None:
+        raise RuntimeError("ignored outcome failure")
+
+    second_result = _run(
+        _broker().mutate(
+            files_dir,
+            [mod.MutationOperation(kind="insert", table="items", values={"id": 2, "name": "Grace"})],
+            audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+            audit_intent_callback=_allow_audit,
+            audit_outcome_callback=failing_outcome_callback,
+        )
+    )
+
+    assert second_result.operations[0].rowcount == 1
+    rows = _run(_broker().query(files_dir, "SELECT id, name FROM items ORDER BY id"))
+    assert rows.rows == [{"id": 1, "name": "Ada"}, {"id": 2, "name": "Grace"}]
+
+
+def test_upsert_do_nothing_reports_zero_rows_when_all_supplied_columns_are_conflict_columns(tmp_path: Path) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+
+    _run(
+        _broker().mutate(
+            files_dir,
+            [mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada"})],
+            audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+            audit_intent_callback=_allow_audit,
+        )
+    )
+
+    result = _run(
+        _broker().mutate(
+            files_dir,
+            [mod.MutationOperation(kind="upsert", table="items", values={"id": 1}, conflict_columns=["id"])],
+            audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+            audit_intent_callback=_allow_audit,
+        )
+    )
+
+    assert result.operations[0].rowcount == 0
+    rows = _run(_broker().query(files_dir, "SELECT id, name FROM items"))
+    assert rows.rows == [{"id": 1, "name": "Ada"}]
+
+
+def test_mutate_maps_busy_errors_after_retries(tmp_path: Path) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    db_path = _init_db(files_dir)
+
+    blocker = sqlite3.connect(db_path, isolation_level=None, timeout=0.1)
+    blocker.execute("PRAGMA journal_mode=WAL")
+    blocker.execute("BEGIN IMMEDIATE")
+    try:
+        busy_broker = _broker()
+        busy_broker.policy.busy_timeout_ms = 1
+        with pytest.raises(Exception) as exc_info:
+            _run(
+                busy_broker.mutate(
+                    files_dir,
+                    [mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada"})],
+                    audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                    audit_intent_callback=_allow_audit,
+                )
+            )
+        _assert_broker_error(exc_info, "sqlite_busy")
+    finally:
+        blocker.execute("ROLLBACK")
+        blocker.close()
+
+
+def test_mutate_serializes_writes_to_the_same_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+    broker = _broker()
+    original = mod._execute_mutation_transaction
+    order: list[str] = []
+
+    def slow_execute(*args, **kwargs):
+        order.append("start")
+        time.sleep(0.15)
+        try:
+            return original(*args, **kwargs)
+        finally:
+            order.append("end")
+
+    monkeypatch.setattr(mod, "_execute_mutation_transaction", slow_execute)
+
+    async def run_pair() -> None:
+        await asyncio.gather(
+            broker.mutate(
+                files_dir,
+                [mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada"})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                audit_intent_callback=_allow_audit,
+            ),
+            broker.mutate(
+                files_dir,
+                [mod.MutationOperation(kind="insert", table="items", values={"id": 2, "name": "Grace"})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                audit_intent_callback=_allow_audit,
+            ),
+        )
+
+    _run(run_pair())
+    assert order == ["start", "end", "start", "end"]
+
+
+def test_mutation_outcome_callback_runs_outside_database_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+    broker = _broker()
+    original = mod._execute_mutation_transaction
+    order: list[str] = []
+    call_index = 0
+
+    def slow_execute(*args, **kwargs):
+        nonlocal call_index
+        call_index += 1
+        current = call_index
+        order.append(f"execute-start:{current}")
+        time.sleep(0.05)
+        try:
+            return original(*args, **kwargs)
+        finally:
+            order.append(f"execute-end:{current}")
+
+    monkeypatch.setattr(mod, "_execute_mutation_transaction", slow_execute)
+
+    async def outcome_callback(outcome: AuditOutcome) -> None:
+        order.append(f"outcome-start:{outcome.identity_context.request_id}")
+        if outcome.identity_context.request_id == "first":
+            await asyncio.sleep(0.2)
+        order.append(f"outcome-end:{outcome.identity_context.request_id}")
+
+    async def run_pair() -> None:
+        first = asyncio.create_task(
+            broker.mutate(
+                files_dir,
+                [mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada"})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1", request_id="first"),
+                audit_intent_callback=_allow_audit,
+                audit_outcome_callback=outcome_callback,
+            )
+        )
+        await asyncio.sleep(0.01)
+        second = asyncio.create_task(
+            broker.mutate(
+                files_dir,
+                [mod.MutationOperation(kind="insert", table="items", values={"id": 2, "name": "Grace"})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1", request_id="second"),
+                audit_intent_callback=_allow_audit,
+                audit_outcome_callback=outcome_callback,
+            )
+        )
+        await asyncio.gather(first, second)
+
+    _run(run_pair())
+    assert order.index("execute-start:2") < order.index("outcome-end:first")
+
+
+def test_checkpoint_uses_safe_worker_for_wal_truncate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    db_path = _init_db(files_dir)
+    calls: list[Path] = []
+
+    def fake_execute_wal_checkpoint(path: Path, _policy) -> None:
+        calls.append(path)
+
+    monkeypatch.setattr(mod, "_execute_wal_checkpoint", fake_execute_wal_checkpoint, raising=False)
+
+    _run(_broker().checkpoint(files_dir))
+
+    assert calls == [db_path]
+
+
+def test_checkpoint_and_mutation_share_canonical_path_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+    broker = _broker()
+    order: list[str] = []
+    original_mutation = mod._execute_mutation_transaction
+
+    def slow_execute_mutation(*args, **kwargs):
+        order.append("mutation-start")
+        time.sleep(0.15)
+        try:
+            return original_mutation(*args, **kwargs)
+        finally:
+            order.append("mutation-end")
+
+    def slow_checkpoint(_db_path: Path, _policy) -> None:
+        order.append("checkpoint-start")
+        order.append("checkpoint-end")
+
+    monkeypatch.setattr(mod, "_execute_mutation_transaction", slow_execute_mutation)
+    monkeypatch.setattr(mod, "_execute_wal_checkpoint", slow_checkpoint)
+
+    async def run_pair() -> None:
+        mutate_task = asyncio.create_task(
+            broker.mutate(
+                files_dir,
+                [mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada"})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                audit_intent_callback=_allow_audit,
+            )
+        )
+        await asyncio.sleep(0.01)
+        checkpoint_task = asyncio.create_task(broker.checkpoint(files_dir))
+        await asyncio.gather(mutate_task, checkpoint_task)
+
+    _run(run_pair())
+    assert order == ["mutation-start", "mutation-end", "checkpoint-start", "checkpoint-end"]
+
+
+def test_mutation_lock_registry_uses_weak_lifetime_storage(tmp_path: Path) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+    db_path = mod._resolve_managed_db_path(files_dir)
+
+    box = mod._mutation_lock_for(db_path)
+    assert db_path.resolve() in mod._MUTATION_LOCKS
+
+    del box
+    gc.collect()
+    assert db_path.resolve() not in mod._MUTATION_LOCKS
+
+
+def test_audit_intent_failure_prevents_writes_and_fingerprint_excludes_values(tmp_path: Path) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+    broker = _broker()
+    seen_intents: list[object] = []
+
+    async def deny_intent(intent) -> bool:
+        seen_intents.append(intent)
+        return False
+
+    operation_a = mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada"})
+    operation_b = mod.MutationOperation(kind="insert", table="items", values={"id": 2, "name": "Grace"})
+
+    assert broker.fingerprint_operations([operation_a]) == broker.fingerprint_operations([operation_b])
+
+    with pytest.raises(Exception) as exc_info:
+        _run(
+            broker.mutate(
+                files_dir,
+                [operation_a],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                audit_intent_callback=deny_intent,
+            )
+        )
+    _assert_broker_error(exc_info, "audit_unavailable")
+    assert seen_intents
+
+    rows = _run(_broker().query(files_dir, "SELECT id, name FROM items"))
+    assert rows.rows == []
+
+
+def test_unexpected_transaction_worker_error_maps_to_mutation_failed_and_reports_failure_outcome(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _mod()
+    files_dir = _files_dir(tmp_path)
+    _init_db(files_dir)
+    outcomes: list[AuditOutcome] = []
+
+    async def outcome_callback(outcome: AuditOutcome) -> None:
+        outcomes.append(outcome)
+
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(mod, "_execute_mutation_transaction", explode)
+
+    with pytest.raises(Exception) as exc_info:
+        _run(
+            _broker().mutate(
+                files_dir,
+                [mod.MutationOperation(kind="insert", table="items", values={"id": 1, "name": "Ada"})],
+                audit_context=mod.AuditIdentityContext(actor_id="user-1"),
+                audit_intent_callback=_allow_audit,
+                audit_outcome_callback=outcome_callback,
+            )
+        )
+
+    _assert_broker_error(exc_info, "mutation_failed")
+    assert len(outcomes) == 1
+    assert outcomes[0].status == "rolled_back"
+    assert outcomes[0].error_code == "mutation_failed"
+    assert "Ada" not in repr(outcomes[0])

--- a/tests/test_userspace_cross_workspace_sqlite_service.py
+++ b/tests/test_userspace_cross_workspace_sqlite_service.py
@@ -102,9 +102,7 @@ class _FakeBroker:
         )
 
     def fingerprint_operations(self, operations: Sequence[cross_workspace_sqlite_mod.MutationOperation]) -> str:
-        return cross_workspace_sqlite_mod.CrossWorkspaceSqliteBroker(
-            cross_workspace_sqlite_mod.CrossWorkspaceSqlitePolicy()
-        ).fingerprint_operations(operations)
+        return cross_workspace_sqlite_mod.CrossWorkspaceSqliteBroker(cross_workspace_sqlite_mod.CrossWorkspaceSqlitePolicy()).fingerprint_operations(operations)
 
     async def query(self, workspace_files_dir: Path, sql: str, *, parameters: object = None, max_rows: int = 200):
         self.query_calls.append(

--- a/tests/test_userspace_cross_workspace_sqlite_service.py
+++ b/tests/test_userspace_cross_workspace_sqlite_service.py
@@ -1,0 +1,779 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from collections.abc import Sequence
+from contextlib import ExitStack
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TypedDict
+from unittest import mock
+
+from fastapi import HTTPException
+
+from ragtime.userspace import cross_workspace_sqlite as cross_workspace_sqlite_mod
+from ragtime.userspace.models import (
+    RuntimeBridgeSqliteMutationOperation,
+    RuntimeBridgeSqliteMutationRequest,
+    RuntimeBridgeSqliteMutationResponse,
+    RuntimeBridgeSqliteQueryRequest,
+    RuntimeBridgeSqliteQueryResponse,
+)
+from ragtime.userspace.service import UserSpaceService
+
+_NOW = datetime(2026, 8, 5, tzinfo=timezone.utc)
+
+
+@dataclass
+class _WorkspaceRow:
+    owner_user_id: str
+    name: str
+
+
+class _CapturedAuditEvent(TypedDict):
+    workspace_id: str
+    user_id: str | None
+    event_type: str
+    payload: dict[str, object]
+    session_id: str | None
+    created_at: datetime | None
+
+
+class _FakeWorkspaceTable:
+    def __init__(self, rows: dict[str, _WorkspaceRow]) -> None:
+        self.rows = rows
+        self.find_unique_calls = 0
+
+    async def find_unique(self, *, where: dict[str, str], include: dict[str, object] | None = None) -> SimpleNamespace | None:
+        self.find_unique_calls += 1
+        workspace_id = str(where.get("id") or "")
+        row = self.rows.get(workspace_id)
+        if row is None:
+            return None
+        return SimpleNamespace(id=workspace_id, ownerUserId=row.owner_user_id, name=row.name)
+
+
+class _FakeWorkspaceMemberTable:
+    def __init__(self, roles: dict[tuple[str, str], str]) -> None:
+        self.roles = roles
+        self.find_first_calls = 0
+
+    async def find_first(self, *, where: dict[str, str]) -> SimpleNamespace | None:
+        self.find_first_calls += 1
+        key = (str(where.get("workspaceId") or ""), str(where.get("userId") or ""))
+        role = self.roles.get(key)
+        if role is None:
+            return None
+        return SimpleNamespace(workspaceId=key[0], userId=key[1], role=role)
+
+
+class _FakeGrantTable:
+    def __init__(self, rows: list[SimpleNamespace] | None = None) -> None:
+        self.rows = rows or []
+        self.find_first_calls = 0
+
+    async def find_first(self, *, where: dict[str, str]) -> SimpleNamespace | None:
+        self.find_first_calls += 1
+        for row in self.rows:
+            if str(getattr(row, "sourceWorkspaceId", "") or "") == str(where.get("sourceWorkspaceId") or "") and str(
+                getattr(row, "targetWorkspaceId", "") or ""
+            ) == str(where.get("targetWorkspaceId") or ""):
+                return row
+        return None
+
+
+class _FakeUserTable:
+    async def find_unique(self, **_: object) -> SimpleNamespace | None:  # pragma: no cover - should never be called here
+        raise AssertionError("cross-workspace SQLite auth must not query global user role")
+
+
+class _FakeBroker:
+    def __init__(self) -> None:
+        self.query_calls: list[dict[str, object]] = []
+        self.mutate_calls: list[dict[str, object]] = []
+        self.checkpoint_calls: list[Path] = []
+        self.query_result = cross_workspace_sqlite_mod.QueryResult(columns=["id"], rows=[{"id": 1}], row_count=1, truncated=False)
+        self.mutation_result = cross_workspace_sqlite_mod.MutationResult(
+            operations=[cross_workspace_sqlite_mod.MutationOperationResult(kind="insert", rowcount=1, lastrowid=7)],
+            fingerprint="fingerprint-1",
+        )
+
+    def fingerprint_operations(self, operations: Sequence[cross_workspace_sqlite_mod.MutationOperation]) -> str:
+        return cross_workspace_sqlite_mod.CrossWorkspaceSqliteBroker(
+            cross_workspace_sqlite_mod.CrossWorkspaceSqlitePolicy()
+        ).fingerprint_operations(operations)
+
+    async def query(self, workspace_files_dir: Path, sql: str, *, parameters: object = None, max_rows: int = 200):
+        self.query_calls.append(
+            {
+                "workspace_files_dir": workspace_files_dir,
+                "sql": sql,
+                "parameters": parameters,
+                "max_rows": max_rows,
+            }
+        )
+        return self.query_result
+
+    async def mutate(
+        self,
+        workspace_files_dir: Path,
+        operations: Sequence[cross_workspace_sqlite_mod.MutationOperation],
+        *,
+        audit_context: cross_workspace_sqlite_mod.AuditIdentityContext,
+        audit_intent_callback,
+        audit_outcome_callback=None,
+    ):
+        self.mutate_calls.append(
+            {
+                "workspace_files_dir": workspace_files_dir,
+                "operations": operations,
+                "audit_context": audit_context,
+            }
+        )
+        intent = cross_workspace_sqlite_mod.AuditIntent(
+            fingerprint=self.mutation_result.fingerprint,
+            operation_count=len(operations),
+            identity_context=audit_context,
+        )
+        ok = audit_intent_callback(intent)
+        if hasattr(ok, "__await__"):
+            ok = await ok
+        if not ok:
+            raise cross_workspace_sqlite_mod.CrossWorkspaceSqliteError("audit_unavailable")
+        if audit_outcome_callback is not None:
+            outcome = cross_workspace_sqlite_mod.AuditOutcome(
+                fingerprint=self.mutation_result.fingerprint,
+                operation_count=len(operations),
+                identity_context=audit_context,
+                status="committed",
+                error_code=None,
+            )
+            result = audit_outcome_callback(outcome)
+            if hasattr(result, "__await__"):
+                await result
+        return self.mutation_result
+
+    async def checkpoint(self, workspace_files_dir: Path) -> None:
+        self.checkpoint_calls.append(workspace_files_dir)
+
+
+class RuntimeBridgeCrossWorkspaceSqliteServiceTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.service = UserSpaceService()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace_root = Path(self.temp_dir.name)
+        self.broker = _FakeBroker()
+        self.audit_events: list[_CapturedAuditEvent] = []
+        self.service._runtime_bridge_sqlite_rate_limits.clear()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _db(
+        self,
+        *,
+        roles: dict[tuple[str, str], str] | None = None,
+        grant_rows: list[SimpleNamespace] | None = None,
+        workspace_rows: dict[str, _WorkspaceRow] | None = None,
+        with_grant_model: bool = True,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            workspace=_FakeWorkspaceTable(
+                workspace_rows
+                or {
+                    "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source"),
+                    "target-ws": _WorkspaceRow(owner_user_id="owner-target", name="Target"),
+                }
+            ),
+            workspacemember=_FakeWorkspaceMemberTable(roles or {}),
+            workspaceagentgrant=_FakeGrantTable(grant_rows) if with_grant_model else None,
+            user=_FakeUserTable(),
+        )
+
+    def _grant(self, *, sqlite_access_mode: str = "read", expires_at: datetime | None = None) -> SimpleNamespace:
+        return SimpleNamespace(
+            id="grant-1",
+            sourceWorkspaceId="source-ws",
+            targetWorkspaceId="target-ws",
+            accessMode="read",
+            sqliteAccessMode=sqlite_access_mode,
+            expiresAt=expires_at,
+        )
+
+    def _patch_common(self, fake_db: SimpleNamespace) -> tuple[mock._patch, ...]:
+        async def _fake_get_db() -> SimpleNamespace:
+            return fake_db
+
+        async def _record_runtime_audit_event(
+            workspace_id: str,
+            user_id: str | None,
+            event_type: str,
+            payload: dict[str, object],
+            *,
+            session_id: str | None = None,
+            created_at: datetime | None = None,
+        ) -> bool:
+            self.audit_events.append(
+                {
+                    "workspace_id": workspace_id,
+                    "user_id": user_id,
+                    "event_type": event_type,
+                    "payload": payload,
+                    "session_id": session_id,
+                    "created_at": created_at,
+                }
+            )
+            return True
+
+        return (
+            mock.patch("ragtime.userspace.service.get_db", new=_fake_get_db),
+            mock.patch.object(self.service, "_record_runtime_audit_event", new=_record_runtime_audit_event),
+            mock.patch.object(self.service, "_workspace_files_dir", side_effect=lambda workspace_id: self.workspace_root / workspace_id / "files"),
+            mock.patch.object(
+                self.service,
+                "_runtime_bridge_cross_workspace_sqlite_broker",
+                new=mock.Mock(return_value=self.broker),
+            ),
+        )
+
+    @staticmethod
+    def _insert_operation(**values: object) -> RuntimeBridgeSqliteMutationOperation:
+        return RuntimeBridgeSqliteMutationOperation(kind="insert", table="items", values=values)
+
+    async def test_query_and_mutation_grant_matrix(self) -> None:
+        request_query = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="SELECT 1")
+        request_mutate = RuntimeBridgeSqliteMutationRequest(
+            target_workspace_id="target-ws",
+            operations=[self._insert_operation(id=1)],
+        )
+
+        cases: list[tuple[str, SimpleNamespace | None, bool, bool]] = [
+            ("missing", None, False, False),
+            ("expired", self._grant(sqlite_access_mode="read_write", expires_at=_NOW - timedelta(seconds=1)), False, False),
+            ("none", self._grant(sqlite_access_mode="none"), False, False),
+            ("read", self._grant(sqlite_access_mode="read"), True, False),
+            ("read_write", self._grant(sqlite_access_mode="read_write"), True, True),
+        ]
+        for label, grant_row, expect_query_ok, expect_mutate_ok in cases:
+            with self.subTest(case=label):
+                fake_db = self._db(
+                    roles={
+                        ("source-ws", "leased-user"): "viewer",
+                        ("target-ws", "leased-user"): "editor",
+                    },
+                    grant_rows=([grant_row] if grant_row is not None else []),
+                )
+                with ExitStack() as stack:
+                    for patcher in self._patch_common(fake_db):
+                        stack.enter_context(patcher)
+                    stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+                    if expect_query_ok:
+                        query_response = await self.service.query_runtime_bridge_sqlite(
+                            workspace_id="source-ws",
+                            session_id="sess-1",
+                            leased_by_user_id="leased-user",
+                            request=request_query,
+                        )
+                        self.assertEqual(query_response.target_workspace_id, "target-ws")
+                    else:
+                        with self.assertRaises(HTTPException) as raised:
+                            await self.service.query_runtime_bridge_sqlite(
+                                workspace_id="source-ws",
+                                session_id="sess-1",
+                                leased_by_user_id="leased-user",
+                                request=request_query,
+                            )
+                        self.assertEqual(raised.exception.status_code, 403)
+
+                    if expect_mutate_ok:
+                        mutation_response = await self.service.mutate_runtime_bridge_sqlite(
+                            workspace_id="source-ws",
+                            session_id="sess-1",
+                            leased_by_user_id="leased-user",
+                            request=request_mutate,
+                        )
+                        self.assertEqual(mutation_response.fingerprint, "fingerprint-1")
+                    else:
+                        with self.assertRaises(HTTPException) as raised:
+                            await self.service.mutate_runtime_bridge_sqlite(
+                                workspace_id="source-ws",
+                                session_id="sess-1",
+                                leased_by_user_id="leased-user",
+                                request=request_mutate,
+                            )
+                        self.assertEqual(raised.exception.status_code, 403)
+
+    async def test_revocation_and_downgrade_apply_on_next_call(self) -> None:
+        grant_row = self._grant(sqlite_access_mode="read_write")
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "editor",
+            },
+            grant_rows=[grant_row],
+        )
+        request = RuntimeBridgeSqliteMutationRequest(
+            target_workspace_id="target-ws",
+            operations=[self._insert_operation(id=1)],
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            first = await self.service.mutate_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-1",
+                leased_by_user_id="leased-user",
+                request=request,
+            )
+            self.assertEqual(first.fingerprint, "fingerprint-1")
+            grant_row.sqliteAccessMode = "read"
+            with self.assertRaises(HTTPException) as downgraded:
+                await self.service.mutate_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="leased-user",
+                    request=request,
+                )
+            self.assertEqual(downgraded.exception.status_code, 403)
+            fake_db.workspaceagentgrant.rows.clear()
+            with self.assertRaises(HTTPException) as revoked:
+                await self.service.query_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="leased-user",
+                    request=RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="SELECT 1"),
+                )
+            self.assertEqual(revoked.exception.status_code, 403)
+
+    async def test_removed_source_or_target_membership_is_denied(self) -> None:
+        grant_row = self._grant(sqlite_access_mode="read_write")
+        request_query = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="SELECT 1")
+        request_mutate = RuntimeBridgeSqliteMutationRequest(
+            target_workspace_id="target-ws",
+            operations=[self._insert_operation(id=1)],
+        )
+        cases: list[
+            tuple[
+                dict[tuple[str, str], str],
+                RuntimeBridgeSqliteQueryRequest | RuntimeBridgeSqliteMutationRequest,
+            ]
+        ] = [
+            ({("target-ws", "leased-user"): "editor"}, request_query),
+            ({("source-ws", "leased-user"): "viewer"}, request_mutate),
+        ]
+        for roles, request in cases:
+            with self.subTest(roles=roles):
+                fake_db = self._db(roles=roles, grant_rows=[grant_row])
+                with ExitStack() as stack:
+                    for patcher in self._patch_common(fake_db):
+                        stack.enter_context(patcher)
+                    stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+                    with self.assertRaises(HTTPException) as raised:
+                        if isinstance(request, RuntimeBridgeSqliteQueryRequest):
+                            await self.service.query_runtime_bridge_sqlite(
+                                workspace_id="source-ws",
+                                session_id="sess-1",
+                                leased_by_user_id="leased-user",
+                                request=request,
+                            )
+                        else:
+                            await self.service.mutate_runtime_bridge_sqlite(
+                                workspace_id="source-ws",
+                                session_id="sess-1",
+                                leased_by_user_id="leased-user",
+                                request=request,
+                            )
+                    self.assertEqual(raised.exception.status_code, 403)
+
+    async def test_global_admin_without_memberships_is_denied(self) -> None:
+        fake_db = self._db(roles={}, grant_rows=[self._grant(sqlite_access_mode="read_write")])
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            with self.assertRaises(HTTPException) as raised:
+                await self.service.query_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="admin-user",
+                    request=RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="SELECT 1"),
+                )
+        self.assertEqual(raised.exception.status_code, 403)
+
+    async def test_missing_grant_model_fails_closed_with_fixed_403(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "viewer",
+            },
+            with_grant_model=False,
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            with self.assertRaises(HTTPException) as raised:
+                await self.service.query_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="leased-user",
+                    request=RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="SELECT 1"),
+                )
+        self.assertEqual(raised.exception.status_code, 403)
+        self.assertEqual(str(raised.exception.detail), "Cross-workspace SQLite access denied")
+
+    async def test_target_viewer_can_query_but_cannot_mutate_and_editor_can_mutate(self) -> None:
+        query_request = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="SELECT 1")
+        mutate_request = RuntimeBridgeSqliteMutationRequest(
+            target_workspace_id="target-ws",
+            operations=[self._insert_operation(id=1)],
+        )
+        viewer_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "viewer",
+            },
+            grant_rows=[self._grant(sqlite_access_mode="read_write")],
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(viewer_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            query_response = await self.service.query_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-1",
+                leased_by_user_id="leased-user",
+                request=query_request,
+            )
+            self.assertEqual(query_response.row_count, 1)
+            with self.assertRaises(HTTPException) as raised:
+                await self.service.mutate_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="leased-user",
+                    request=mutate_request,
+                )
+            self.assertEqual(raised.exception.status_code, 403)
+
+        editor_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "editor",
+            },
+            grant_rows=[self._grant(sqlite_access_mode="read_write")],
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(editor_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            mutation_response = await self.service.mutate_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-1",
+                leased_by_user_id="leased-user",
+                request=mutate_request,
+            )
+            self.assertEqual(mutation_response.operations[0].rowcount, 1)
+
+    async def test_session_target_limiter_returns_429_and_separate_keys_do_not_collide(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "viewer",
+                ("target-2", "leased-user"): "viewer",
+            },
+            grant_rows=[
+                self._grant(sqlite_access_mode="read"),
+                SimpleNamespace(
+                    id="grant-2",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-2",
+                    accessMode="read",
+                    sqliteAccessMode="read",
+                    expiresAt=None,
+                ),
+            ],
+            workspace_rows={
+                "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source"),
+                "target-ws": _WorkspaceRow(owner_user_id="owner-target", name="Target"),
+                "target-2": _WorkspaceRow(owner_user_id="owner-target-2", name="Target 2"),
+            },
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            request = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="SELECT 1")
+            for _ in range(120):
+                await self.service.query_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="leased-user",
+                    request=request,
+                )
+            with self.assertRaises(HTTPException) as raised:
+                await self.service.query_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="leased-user",
+                    request=request,
+                )
+            self.assertEqual(raised.exception.status_code, 429)
+
+            other_key_response = await self.service.query_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-1",
+                leased_by_user_id="leased-user",
+                request=RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-2", sql="SELECT 1"),
+            )
+            self.assertEqual(other_key_response.target_workspace_id, "target-2")
+
+            other_session_response = await self.service.query_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-2",
+                leased_by_user_id="leased-user",
+                request=request,
+            )
+            self.assertEqual(other_session_response.target_workspace_id, "target-ws")
+
+    async def test_rate_limited_denials_audit_best_effort_without_values_and_before_auth_queries(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "viewer",
+            },
+            grant_rows=[self._grant(sqlite_access_mode="read")],
+        )
+        request = RuntimeBridgeSqliteQueryRequest(
+            target_workspace_id="target-ws",
+            sql="SELECT secret FROM tokens WHERE code = ?",
+            parameters=["top-secret"],
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            for _ in range(120):
+                await self.service.query_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="leased-user",
+                    request=request,
+                )
+            workspace_calls_before = fake_db.workspace.find_unique_calls
+            member_calls_before = fake_db.workspacemember.find_first_calls
+            grant_calls_before = fake_db.workspaceagentgrant.find_first_calls
+            with self.assertRaises(HTTPException) as raised:
+                await self.service.query_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="leased-user",
+                    request=request,
+                )
+        self.assertEqual(raised.exception.status_code, 429)
+        self.assertEqual(fake_db.workspace.find_unique_calls, workspace_calls_before)
+        self.assertEqual(fake_db.workspacemember.find_first_calls, member_calls_before)
+        self.assertEqual(fake_db.workspaceagentgrant.find_first_calls, grant_calls_before)
+        denied_event = self.audit_events[-1]
+        payload: dict[str, object] = denied_event["payload"]
+        self.assertEqual(payload["phase"], "denied")
+        self.assertEqual(payload["error_code"], "rate_limited")
+        serialized = repr(payload)
+        self.assertNotIn("top-secret", serialized)
+        self.assertNotIn("SELECT secret", serialized)
+
+    async def test_query_audit_uses_digest_without_sql_or_parameters(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "viewer",
+            },
+            grant_rows=[self._grant(sqlite_access_mode="read")],
+        )
+        sql = "SELECT secret FROM tokens WHERE code = ?"
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            await self.service.query_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-1",
+                leased_by_user_id="leased-user",
+                request=RuntimeBridgeSqliteQueryRequest(
+                    target_workspace_id="target-ws",
+                    sql=sql,
+                    parameters=["top-secret"],
+                ),
+            )
+        payload: dict[str, object] = self.audit_events[-1]["payload"]
+        self.assertEqual(payload["sql_digest"], hashlib.sha256(sql.encode("utf-8")).hexdigest())
+        serialized = repr(payload)
+        self.assertNotIn(sql, serialized)
+        self.assertNotIn("top-secret", serialized)
+        self.assertNotIn("parameters", payload)
+
+    async def test_unexpected_query_broker_exception_audits_generic_safe_code_without_raw_text(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "viewer",
+            },
+            grant_rows=[self._grant(sqlite_access_mode="read")],
+        )
+
+        async def explode(*_args, **_kwargs):
+            raise RuntimeError("boom top-secret")
+
+        self.broker.query = explode  # type: ignore[method-assign]
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            with self.assertRaises(RuntimeError):
+                await self.service.query_runtime_bridge_sqlite(
+                    workspace_id="source-ws",
+                    session_id="sess-1",
+                    leased_by_user_id="leased-user",
+                    request=RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="SELECT 1"),
+                )
+        payload: dict[str, object] = self.audit_events[-1]["payload"]
+        self.assertEqual(payload["error_code"], "query_failed")
+        self.assertEqual(payload["status"], "failed")
+        self.assertNotIn("top-secret", repr(payload))
+
+    async def test_mutation_audit_contains_no_values(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "editor",
+            },
+            grant_rows=[self._grant(sqlite_access_mode="read_write")],
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            await self.service.mutate_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-1",
+                leased_by_user_id="leased-user",
+                request=RuntimeBridgeSqliteMutationRequest(
+                    target_workspace_id="target-ws",
+                    operations=[self._insert_operation(name="Ada", secret="42")],
+                ),
+            )
+        serialized = repr([event["payload"] for event in self.audit_events])
+        self.assertNotIn("Ada", serialized)
+        self.assertNotIn("42", serialized)
+
+    async def test_checkpoint_occurs_after_commit_and_before_snapshot(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "editor",
+            },
+            grant_rows=[self._grant(sqlite_access_mode="read_write")],
+        )
+        order: list[str] = []
+
+        async def mutate(*args, **kwargs):
+            order.append("mutate")
+            return await _FakeBroker.mutate(self.broker, *args, **kwargs)
+
+        async def checkpoint(_workspace_files_dir: Path) -> None:
+            order.append("checkpoint")
+
+        async def create_snapshot(*_args, **_kwargs) -> SimpleNamespace:
+            order.append("snapshot")
+            return SimpleNamespace(id="snapshot-1")
+
+        self.broker.mutate = mutate  # type: ignore[method-assign]
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            stack.enter_context(mock.patch.object(self.broker, "checkpoint", new=checkpoint))
+            stack.enter_context(mock.patch.object(self.service, "create_snapshot", new=create_snapshot))
+            await self.service.mutate_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-1",
+                leased_by_user_id="leased-user",
+                request=RuntimeBridgeSqliteMutationRequest(
+                    target_workspace_id="target-ws",
+                    operations=[self._insert_operation(id=1)],
+                ),
+            )
+        self.assertEqual(order, ["mutate", "checkpoint", "snapshot"])
+
+    async def test_checkpoint_failure_skips_snapshot_and_audits_checkpoint_failed(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "editor",
+            },
+            grant_rows=[self._grant(sqlite_access_mode="read_write")],
+        )
+        snapshot_calls = 0
+
+        async def checkpoint(_workspace_files_dir: Path) -> None:
+            raise cross_workspace_sqlite_mod.CrossWorkspaceSqliteError("sqlite_busy")
+
+        async def create_snapshot(*_args, **_kwargs) -> SimpleNamespace:
+            nonlocal snapshot_calls
+            snapshot_calls += 1
+            return SimpleNamespace(id="snapshot-1")
+
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            stack.enter_context(mock.patch.object(self.broker, "checkpoint", new=checkpoint))
+            stack.enter_context(mock.patch.object(self.service, "create_snapshot", new=create_snapshot))
+            mutation_response = await self.service.mutate_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-1",
+                leased_by_user_id="leased-user",
+                request=RuntimeBridgeSqliteMutationRequest(
+                    target_workspace_id="target-ws",
+                    operations=[self._insert_operation(id=1)],
+                ),
+            )
+        self.assertEqual(mutation_response.fingerprint, "fingerprint-1")
+        self.assertEqual(snapshot_calls, 0)
+        self.assertTrue(any(event["payload"].get("error_code") == "checkpoint_failed" for event in self.audit_events))
+
+    async def test_snapshot_failure_audits_snapshot_failed_and_returns_committed_result(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-ws", "leased-user"): "editor",
+            },
+            grant_rows=[self._grant(sqlite_access_mode="read_write")],
+        )
+
+        async def create_snapshot(*_args, **_kwargs) -> SimpleNamespace:
+            raise RuntimeError("snapshot failed")
+
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            stack.enter_context(mock.patch.object(self.service, "create_snapshot", new=create_snapshot))
+            mutation_response = await self.service.mutate_runtime_bridge_sqlite(
+                workspace_id="source-ws",
+                session_id="sess-1",
+                leased_by_user_id="leased-user",
+                request=RuntimeBridgeSqliteMutationRequest(
+                    target_workspace_id="target-ws",
+                    operations=[self._insert_operation(id=1)],
+                ),
+            )
+        self.assertEqual(mutation_response.fingerprint, "fingerprint-1")
+        self.assertTrue(any(event["payload"].get("error_code") == "snapshot_failed" for event in self.audit_events))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_userspace_cross_workspace_sqlite_service.py
+++ b/tests/test_userspace_cross_workspace_sqlite_service.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TypedDict
+from typing import Any, TypedDict
 from unittest import mock
 
 from fastapi import HTTPException
@@ -55,6 +55,17 @@ class _FakeWorkspaceTable:
             return None
         return SimpleNamespace(id=workspace_id, ownerUserId=row.owner_user_id, name=row.name)
 
+    async def find_many(self, *, where: dict[str, Any] | None = None, order: dict[str, str] | None = None) -> list[SimpleNamespace]:
+        workspace_ids = {str(value) for value in (where or {}).get("id", {}).get("in", [])}
+        rows = [
+            SimpleNamespace(id=workspace_id, ownerUserId=row.owner_user_id, name=row.name)
+            for workspace_id, row in self.rows.items()
+            if not workspace_ids or workspace_id in workspace_ids
+        ]
+        if order == {"name": "asc"}:
+            rows.sort(key=lambda row: (str(row.name), str(row.id)))
+        return rows
+
 
 class _FakeWorkspaceMemberTable:
     def __init__(self, roles: dict[tuple[str, str], str]) -> None:
@@ -68,6 +79,15 @@ class _FakeWorkspaceMemberTable:
         if role is None:
             return None
         return SimpleNamespace(workspaceId=key[0], userId=key[1], role=role)
+
+    async def find_many(self, *, where: dict[str, Any] | None = None) -> list[SimpleNamespace]:
+        workspace_ids = {str(value) for value in (where or {}).get("workspaceId", {}).get("in", [])}
+        user_id = str((where or {}).get("userId") or "")
+        return [
+            SimpleNamespace(workspaceId=workspace_id, userId=member_user_id, role=role)
+            for (workspace_id, member_user_id), role in self.roles.items()
+            if (not workspace_ids or workspace_id in workspace_ids) and (not user_id or member_user_id == user_id)
+        ]
 
 
 class _FakeGrantTable:
@@ -83,6 +103,13 @@ class _FakeGrantTable:
             ) == str(where.get("targetWorkspaceId") or ""):
                 return row
         return None
+
+    async def find_many(self, *, where: dict[str, object] | None = None, order: dict[str, str] | None = None) -> list[SimpleNamespace]:
+        source_workspace_id = str((where or {}).get("sourceWorkspaceId") or "")
+        rows = [row for row in self.rows if not source_workspace_id or str(getattr(row, "sourceWorkspaceId", "") or "") == source_workspace_id]
+        if order == {"targetWorkspaceId": "asc"}:
+            rows.sort(key=lambda row: str(getattr(row, "targetWorkspaceId", "") or ""))
+        return rows
 
 
 class _FakeUserTable:
@@ -199,6 +226,204 @@ class RuntimeBridgeCrossWorkspaceSqliteServiceTests(unittest.IsolatedAsyncioTest
             accessMode="read",
             sqliteAccessMode=sqlite_access_mode,
             expiresAt=expires_at,
+        )
+
+    async def test_list_accessible_cross_workspace_sqlite_targets_filters_denied_and_expired_grants(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-read", "leased-user"): "viewer",
+                ("target-write", "leased-user"): "editor",
+                ("target-expired", "leased-user"): "editor",
+                ("target-none", "leased-user"): "editor",
+            },
+            grant_rows=[
+                SimpleNamespace(
+                    id="grant-read",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-read",
+                    accessMode="none",
+                    sqliteAccessMode="read",
+                    expiresAt=None,
+                ),
+                SimpleNamespace(
+                    id="grant-write",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-write",
+                    accessMode="read",
+                    sqliteAccessMode="read_write",
+                    expiresAt=None,
+                ),
+                SimpleNamespace(
+                    id="grant-expired",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-expired",
+                    accessMode="read_write",
+                    sqliteAccessMode="read_write",
+                    expiresAt=_NOW - timedelta(seconds=1),
+                ),
+                SimpleNamespace(
+                    id="grant-none",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-none",
+                    accessMode="read_write",
+                    sqliteAccessMode="none",
+                    expiresAt=None,
+                ),
+            ],
+            workspace_rows={
+                "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source"),
+                "target-read": _WorkspaceRow(owner_user_id="owner-target-read", name="Alpha"),
+                "target-write": _WorkspaceRow(owner_user_id="owner-target-write", name="Beta"),
+                "target-expired": _WorkspaceRow(owner_user_id="owner-target-expired", name="Gamma"),
+                "target-none": _WorkspaceRow(owner_user_id="owner-target-none", name="Delta"),
+            },
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            targets = await self.service.list_accessible_cross_workspace_sqlite_targets(
+                source_workspace_id="source-ws",
+                leased_by_user_id="leased-user",
+            )
+
+        self.assertEqual(
+            targets,
+            [
+                {
+                    "workspace_id": "target-read",
+                    "workspace_name": "Alpha",
+                    "database_name": "app.sqlite3",
+                    "access_mode": "read",
+                },
+                {
+                    "workspace_id": "target-write",
+                    "workspace_name": "Beta",
+                    "database_name": "app.sqlite3",
+                    "access_mode": "read_write",
+                },
+            ],
+        )
+
+    async def test_list_accessible_cross_workspace_sqlite_targets_omits_missing_memberships_and_admin_without_membership(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("target-viewer", "leased-user"): "viewer",
+                ("target-editor", "leased-user"): "editor",
+            },
+            grant_rows=[
+                SimpleNamespace(
+                    id="grant-viewer",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-viewer",
+                    accessMode="read_write",
+                    sqliteAccessMode="read_write",
+                    expiresAt=None,
+                ),
+                SimpleNamespace(
+                    id="grant-editor",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-editor",
+                    accessMode="read",
+                    sqliteAccessMode="read",
+                    expiresAt=None,
+                ),
+            ],
+            workspace_rows={
+                "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source"),
+                "target-viewer": _WorkspaceRow(owner_user_id="owner-target-viewer", name="Viewer Target"),
+                "target-editor": _WorkspaceRow(owner_user_id="owner-target-editor", name="Editor Target"),
+            },
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            missing_source = await self.service.list_accessible_cross_workspace_sqlite_targets(
+                source_workspace_id="source-ws",
+                leased_by_user_id="leased-user",
+            )
+            admin_without_membership = await self.service.list_accessible_cross_workspace_sqlite_targets(
+                source_workspace_id="source-ws",
+                leased_by_user_id="admin-user",
+            )
+
+        self.assertEqual(missing_source, [])
+        self.assertEqual(admin_without_membership, [])
+
+    async def test_list_accessible_cross_workspace_sqlite_targets_is_deterministic_and_degrades_viewer_write_grants(self) -> None:
+        fake_db = self._db(
+            roles={
+                ("source-ws", "leased-user"): "viewer",
+                ("target-z", "leased-user"): "editor",
+                ("target-a", "leased-user"): "viewer",
+                ("target-b", "leased-user"): "editor",
+            },
+            grant_rows=[
+                SimpleNamespace(
+                    id="grant-z",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-z",
+                    accessMode="read",
+                    sqliteAccessMode="read_write",
+                    expiresAt=None,
+                ),
+                SimpleNamespace(
+                    id="grant-a",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-a",
+                    accessMode="read_write",
+                    sqliteAccessMode="read_write",
+                    expiresAt=None,
+                ),
+                SimpleNamespace(
+                    id="grant-b",
+                    sourceWorkspaceId="source-ws",
+                    targetWorkspaceId="target-b",
+                    accessMode="none",
+                    sqliteAccessMode="read",
+                    expiresAt=None,
+                ),
+            ],
+            workspace_rows={
+                "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source"),
+                "target-z": _WorkspaceRow(owner_user_id="owner-target-z", name="Zulu"),
+                "target-a": _WorkspaceRow(owner_user_id="owner-target-a", name="Alpha"),
+                "target-b": _WorkspaceRow(owner_user_id="owner-target-b", name="Beta"),
+            },
+        )
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=_NOW))
+            targets = await self.service.list_accessible_cross_workspace_sqlite_targets(
+                source_workspace_id="source-ws",
+                leased_by_user_id="leased-user",
+            )
+
+        self.assertEqual(
+            targets,
+            [
+                {
+                    "workspace_id": "target-a",
+                    "workspace_name": "Alpha",
+                    "database_name": "app.sqlite3",
+                    "access_mode": "read",
+                },
+                {
+                    "workspace_id": "target-b",
+                    "workspace_name": "Beta",
+                    "database_name": "app.sqlite3",
+                    "access_mode": "read",
+                },
+                {
+                    "workspace_id": "target-z",
+                    "workspace_name": "Zulu",
+                    "database_name": "app.sqlite3",
+                    "access_mode": "read_write",
+                },
+            ],
         )
 
     def _patch_common(self, fake_db: SimpleNamespace) -> tuple[mock._patch, ...]:
@@ -448,6 +673,7 @@ class RuntimeBridgeCrossWorkspaceSqliteServiceTests(unittest.IsolatedAsyncioTest
                 request=query_request,
             )
             self.assertEqual(query_response.row_count, 1)
+            self.assertEqual(self.audit_events[-1]["payload"]["grant_mode"], "read_write")
             with self.assertRaises(HTTPException) as raised:
                 await self.service.mutate_runtime_bridge_sqlite(
                     workspace_id="source-ws",

--- a/tests/test_userspace_linked_sqlite_inspector.py
+++ b/tests/test_userspace_linked_sqlite_inspector.py
@@ -36,9 +36,7 @@ class _FakeWorkspaceTable:
         if row is None:
             return None
         members = [
-            SimpleNamespace(userId=user_id, role=role)
-            for (member_workspace_id, user_id), role in self.roles.items()
-            if member_workspace_id == workspace_id
+            SimpleNamespace(userId=user_id, role=role) for (member_workspace_id, user_id), role in self.roles.items() if member_workspace_id == workspace_id
         ]
         return SimpleNamespace(
             id=workspace_id,
@@ -376,9 +374,7 @@ class LinkedSqliteInspectorServiceTests(unittest.IsolatedAsyncioTestCase):
                 "source-ws", "viewer-user", "app.sqlite3", "select id, name from items", owner_workspace_id="target-ws"
             )
             exported_db = await self.service.export_sqlite_database("source-ws", "viewer-user", "app.sqlite3", owner_workspace_id="target-ws")
-            exported_csv = await self.service.export_sqlite_table_csv(
-                "source-ws", "viewer-user", "app.sqlite3", "items", owner_workspace_id="target-ws"
-            )
+            exported_csv = await self.service.export_sqlite_table_csv("source-ws", "viewer-user", "app.sqlite3", "items", owner_workspace_id="target-ws")
 
         self.assertEqual(summary.owner_workspace_id, "target-ws")
         self.assertEqual(summary.access_mode, "read")
@@ -404,12 +400,8 @@ class LinkedSqliteInspectorServiceTests(unittest.IsolatedAsyncioTestCase):
             for patcher in self._patch_common(fake_db, workspace_rows):
                 stack.enter_context(patcher)
             denied_calls = [
-                lambda: self.service.initialize_sqlite_database(
-                    "source-ws", "viewer-user", database_name="app.sqlite3", owner_workspace_id="target-ws"
-                ),
-                lambda: self.service.import_sqlite_database(
-                    "source-ws", "viewer-user", "app.sqlite3", upload_path, owner_workspace_id="target-ws"
-                ),
+                lambda: self.service.initialize_sqlite_database("source-ws", "viewer-user", database_name="app.sqlite3", owner_workspace_id="target-ws"),
+                lambda: self.service.import_sqlite_database("source-ws", "viewer-user", "app.sqlite3", upload_path, owner_workspace_id="target-ws"),
                 lambda: self.service.delete_sqlite_database("source-ws", "viewer-user", "app.sqlite3", owner_workspace_id="target-ws"),
                 lambda: self.service.create_sqlite_table(
                     "source-ws",
@@ -431,15 +423,11 @@ class LinkedSqliteInspectorServiceTests(unittest.IsolatedAsyncioTestCase):
                 lambda: self.service.import_sqlite_table_csv(
                     "source-ws", "viewer-user", "app.sqlite3", "items", "id,name\n1,Ada\n", owner_workspace_id="target-ws"
                 ),
-                lambda: self.service.insert_sqlite_row(
-                    "source-ws", "viewer-user", "app.sqlite3", "items", {"id": 2}, owner_workspace_id="target-ws"
-                ),
+                lambda: self.service.insert_sqlite_row("source-ws", "viewer-user", "app.sqlite3", "items", {"id": 2}, owner_workspace_id="target-ws"),
                 lambda: self.service.update_sqlite_row(
                     "source-ws", "viewer-user", "app.sqlite3", "items", {"id": 1}, {"name": "Grace"}, owner_workspace_id="target-ws"
                 ),
-                lambda: self.service.delete_sqlite_row(
-                    "source-ws", "viewer-user", "app.sqlite3", "items", {"id": 1}, owner_workspace_id="target-ws"
-                ),
+                lambda: self.service.delete_sqlite_row("source-ws", "viewer-user", "app.sqlite3", "items", {"id": 1}, owner_workspace_id="target-ws"),
             ]
             for call in denied_calls:
                 with self.assertRaises(HTTPException) as raised:
@@ -447,9 +435,7 @@ class LinkedSqliteInspectorServiceTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(raised.exception.status_code, 403)
 
             with self.assertRaises(HTTPException) as linked_name_error:
-                await self.service.initialize_sqlite_database(
-                    "source-ws", "viewer-user", database_name="custom.sqlite3", owner_workspace_id="target-ws"
-                )
+                await self.service.initialize_sqlite_database("source-ws", "viewer-user", database_name="custom.sqlite3", owner_workspace_id="target-ws")
             self.assertEqual(linked_name_error.exception.status_code, 404)
 
     async def test_linked_read_write_operations_mutate_target_promote_target_and_audit(self) -> None:
@@ -494,9 +480,7 @@ class LinkedSqliteInspectorServiceTests(unittest.IsolatedAsyncioTestCase):
                 [sqlite_inspector_helpers.TableAlteration(op="rename_table", new_table_name="records")],
                 owner_workspace_id="target-ws",
             )
-            dropped_promoted = await self.service.drop_sqlite_table(
-                "source-ws", "editor-user", "app.sqlite3", "records", owner_workspace_id="target-ws"
-            )
+            dropped_promoted = await self.service.drop_sqlite_table("source-ws", "editor-user", "app.sqlite3", "records", owner_workspace_id="target-ws")
             await self.service.delete_sqlite_database("source-ws", "editor-user", "app.sqlite3", owner_workspace_id="target-ws")
             initialized_summary, _ = await self.service.initialize_sqlite_database(
                 "source-ws", "editor-user", database_name="app.sqlite3", owner_workspace_id="target-ws"
@@ -504,9 +488,7 @@ class LinkedSqliteInspectorServiceTests(unittest.IsolatedAsyncioTestCase):
             imported_database, _ = await self.service.import_sqlite_database(
                 "source-ws", "editor-user", "app.sqlite3", upload_path, owner_workspace_id="target-ws"
             )
-            linked_summary, linked_tables = await self.service.list_sqlite_tables(
-                "source-ws", "editor-user", "app.sqlite3", owner_workspace_id="target-ws"
-            )
+            linked_summary, linked_tables = await self.service.list_sqlite_tables("source-ws", "editor-user", "app.sqlite3", owner_workspace_id="target-ws")
 
         self.assertTrue(promoted)
         self.assertEqual(created_table.name, "items")

--- a/tests/test_userspace_linked_sqlite_inspector.py
+++ b/tests/test_userspace_linked_sqlite_inspector.py
@@ -1,0 +1,592 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from contextlib import ExitStack
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+from fastapi import HTTPException
+
+from ragtime.userspace import routes as userspace_routes
+from ragtime.userspace import sqlite_inspector as sqlite_inspector_helpers
+from ragtime.userspace.models import SqliteInspectorDatabaseSummary
+from ragtime.userspace.service import UserSpaceService
+
+
+@dataclass
+class _WorkspaceRow:
+    owner_user_id: str
+    name: str
+    sqlite_persistence_mode: str = "exclude"
+
+
+class _FakeWorkspaceTable:
+    def __init__(self, rows: dict[str, _WorkspaceRow], roles: dict[tuple[str, str], str]) -> None:
+        self.rows = rows
+        self.roles = roles
+
+    async def find_unique(self, *, where: dict[str, str], include: dict[str, object] | None = None) -> SimpleNamespace | None:
+        workspace_id = str(where.get("id") or "")
+        row = self.rows.get(workspace_id)
+        if row is None:
+            return None
+        members = [
+            SimpleNamespace(userId=user_id, role=role)
+            for (member_workspace_id, user_id), role in self.roles.items()
+            if member_workspace_id == workspace_id
+        ]
+        return SimpleNamespace(
+            id=workspace_id,
+            ownerUserId=row.owner_user_id,
+            name=row.name,
+            description="",
+            sqlite_persistence_mode=row.sqlite_persistence_mode,
+            sqlitePersistenceMode=row.sqlite_persistence_mode,
+            members=members,
+            toolSelections=[],
+            toolGroupSelections=[],
+            toolOptions=[],
+            owner=SimpleNamespace(id=row.owner_user_id),
+            createdAt=datetime(2026, 8, 6, tzinfo=timezone.utc),
+            updatedAt=datetime(2026, 8, 6, tzinfo=timezone.utc),
+        )
+
+    async def find_many(self, *, where: dict[str, Any] | None = None, order: dict[str, str] | None = None) -> list[SimpleNamespace]:
+        workspace_ids = {str(value) for value in (where or {}).get("id", {}).get("in", [])}
+        rows = []
+        for workspace_id, row in self.rows.items():
+            if workspace_ids and workspace_id not in workspace_ids:
+                continue
+            rows.append(
+                SimpleNamespace(
+                    id=workspace_id,
+                    ownerUserId=row.owner_user_id,
+                    name=row.name,
+                    sqlite_persistence_mode=row.sqlite_persistence_mode,
+                )
+            )
+        if order == {"name": "asc"}:
+            rows.sort(key=lambda item: (str(item.name).casefold(), str(item.id)))
+        return rows
+
+
+class _FakeWorkspaceMemberTable:
+    def __init__(self, roles: dict[tuple[str, str], str]) -> None:
+        self.roles = roles
+
+    async def find_first(self, *, where: dict[str, str]) -> SimpleNamespace | None:
+        key = (str(where.get("workspaceId") or ""), str(where.get("userId") or ""))
+        role = self.roles.get(key)
+        if role is None:
+            return None
+        return SimpleNamespace(workspaceId=key[0], userId=key[1], role=role)
+
+    async def find_many(self, *, where: dict[str, Any] | None = None) -> list[SimpleNamespace]:
+        workspace_ids = {str(value) for value in (where or {}).get("workspaceId", {}).get("in", [])}
+        user_id = str((where or {}).get("userId") or "")
+        return [
+            SimpleNamespace(workspaceId=workspace_id, userId=member_user_id, role=role)
+            for (workspace_id, member_user_id), role in self.roles.items()
+            if (not workspace_ids or workspace_id in workspace_ids) and (not user_id or member_user_id == user_id)
+        ]
+
+
+class _FakeGrantTable:
+    def __init__(self, rows: list[SimpleNamespace]) -> None:
+        self.rows = rows
+
+    async def find_first(self, *, where: dict[str, str]) -> SimpleNamespace | None:
+        for row in self.rows:
+            if str(getattr(row, "sourceWorkspaceId", "") or "") != str(where.get("sourceWorkspaceId") or ""):
+                continue
+            if str(getattr(row, "targetWorkspaceId", "") or "") != str(where.get("targetWorkspaceId") or ""):
+                continue
+            return row
+        return None
+
+    async def find_many(self, *, where: dict[str, object] | None = None, order: dict[str, str] | None = None) -> list[SimpleNamespace]:
+        source_workspace_id = str((where or {}).get("sourceWorkspaceId") or "")
+        rows = [row for row in self.rows if not source_workspace_id or str(getattr(row, "sourceWorkspaceId", "") or "") == source_workspace_id]
+        if order == {"targetWorkspaceId": "asc"}:
+            rows.sort(key=lambda row: str(getattr(row, "targetWorkspaceId", "") or ""))
+        return rows
+
+
+class _FakeUserTable:
+    async def find_unique(self, **_: object) -> SimpleNamespace | None:
+        return None
+
+
+class SqliteInspectorDatabaseSummaryModelTests(unittest.TestCase):
+    def test_linked_database_summary_serializes_identity_access_and_missing_state(self) -> None:
+        summary = SqliteInspectorDatabaseSummary(
+            name="app.sqlite3",
+            relative_path=".ragtime/db/app.sqlite3",
+            size_bytes=0,
+            table_count=0,
+            last_modified_ms=None,
+            owner_workspace_id="target-ws",
+            owner_workspace_name="Target Workspace",
+            ownership="linked",
+            access_mode="read",
+            persistence_mode="exclude",
+            initialized=False,
+        )
+
+        self.assertEqual(
+            summary.model_dump(),
+            {
+                "name": "app.sqlite3",
+                "relative_path": ".ragtime/db/app.sqlite3",
+                "size_bytes": 0,
+                "table_count": 0,
+                "last_modified_ms": None,
+                "owner_workspace_id": "target-ws",
+                "owner_workspace_name": "Target Workspace",
+                "ownership": "linked",
+                "access_mode": "read",
+                "persistence_mode": "exclude",
+                "initialized": False,
+            },
+        )
+
+
+class LinkedSqliteInspectorServiceTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.service = UserSpaceService()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace_root = Path(self.temp_dir.name)
+        self.promoted_workspaces: list[str] = []
+        self.audit_events: list[dict[str, Any]] = []
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _grant(
+        self,
+        target_workspace_id: str,
+        *,
+        sqlite_access_mode: str = "read",
+        grant_id: str | None = None,
+        expires_at: datetime | None = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=grant_id or f"grant-{target_workspace_id}",
+            sourceWorkspaceId="source-ws",
+            targetWorkspaceId=target_workspace_id,
+            accessMode="read_write",
+            sqliteAccessMode=sqlite_access_mode,
+            expiresAt=expires_at,
+        )
+
+    def _db(
+        self,
+        *,
+        workspace_rows: dict[str, _WorkspaceRow],
+        roles: dict[tuple[str, str], str],
+        grant_rows: list[SimpleNamespace],
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            workspace=_FakeWorkspaceTable(workspace_rows, roles),
+            workspacemember=_FakeWorkspaceMemberTable(roles),
+            workspaceagentgrant=_FakeGrantTable(grant_rows),
+            user=_FakeUserTable(),
+        )
+
+    def _workspace_files_dir(self, workspace_id: str) -> Path:
+        return self.workspace_root / workspace_id / "files"
+
+    def _initialize_workspace_database(self, workspace_id: str, database_name: str = "app.sqlite3") -> None:
+        files_dir = self._workspace_files_dir(workspace_id)
+        files_dir.mkdir(parents=True, exist_ok=True)
+        sqlite_inspector_helpers.initialize_database(files_dir, database_name)
+
+    def _create_table_with_rows(self, workspace_id: str, table_name: str = "items") -> None:
+        files_dir = self._workspace_files_dir(workspace_id)
+        sqlite_inspector_helpers.create_table(
+            files_dir,
+            "app.sqlite3",
+            table_name,
+            [
+                sqlite_inspector_helpers.ColumnDefinition(name="id", type="INTEGER", primary_key=True, not_null=True),
+                sqlite_inspector_helpers.ColumnDefinition(name="name", type="TEXT"),
+            ],
+        )
+        sqlite_inspector_helpers.insert_row(files_dir, "app.sqlite3", table_name, {"id": 1, "name": "Ada"})
+
+    def _sqlite_upload_copy(self, source_workspace_id: str) -> Path:
+        source_path = self.workspace_root / f"{source_workspace_id}-upload.sqlite3"
+        sqlite_inspector_helpers.initialize_database(self.workspace_root / source_workspace_id / "upload-files", "upload.sqlite3")
+        original = self.workspace_root / source_workspace_id / "upload-files" / ".ragtime" / "db" / "upload.sqlite3"
+        source_path.write_bytes(original.read_bytes())
+        return source_path
+
+    def _patch_common(self, fake_db: SimpleNamespace, workspace_rows: dict[str, _WorkspaceRow]) -> tuple[mock._patch, ...]:
+        async def _fake_get_db() -> SimpleNamespace:
+            return fake_db
+
+        async def _ensure_sqlite_mode_included(workspace_id: str) -> bool:
+            self.promoted_workspaces.append(workspace_id)
+            row = workspace_rows[workspace_id]
+            if row.sqlite_persistence_mode == "include":
+                return False
+            row.sqlite_persistence_mode = "include"
+            return True
+
+        async def _record_runtime_audit_event(
+            workspace_id: str,
+            user_id: str | None,
+            event_type: str,
+            payload: dict[str, object],
+            *,
+            session_id: str | None = None,
+            created_at: datetime | None = None,
+        ) -> bool:
+            self.audit_events.append(
+                {
+                    "workspace_id": workspace_id,
+                    "user_id": user_id,
+                    "event_type": event_type,
+                    "payload": payload,
+                    "session_id": session_id,
+                    "created_at": created_at,
+                }
+            )
+            return True
+
+        return (
+            mock.patch("ragtime.userspace.service.get_db", new=_fake_get_db),
+            mock.patch.object(self.service, "_workspace_files_dir", side_effect=self._workspace_files_dir),
+            mock.patch.object(self.service, "_ensure_sqlite_mode_included", side_effect=_ensure_sqlite_mode_included),
+            mock.patch.object(self.service, "_record_runtime_audit_event", new=_record_runtime_audit_event),
+            mock.patch.object(self.service, "_sync_runtime_bootstrap_config", return_value=None),
+        )
+
+    async def test_list_sqlite_databases_merges_owned_and_linked_access_modes_and_missing_state(self) -> None:
+        workspace_rows = {
+            "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source Workspace", sqlite_persistence_mode="include"),
+            "target-read": _WorkspaceRow(owner_user_id="owner-read", name="Alpha", sqlite_persistence_mode="include"),
+            "target-readwrite-viewer": _WorkspaceRow(owner_user_id="owner-rw-viewer", name="Beta", sqlite_persistence_mode="include"),
+            "target-readwrite-editor": _WorkspaceRow(owner_user_id="owner-rw-editor", name="beta", sqlite_persistence_mode="exclude"),
+            "target-missing": _WorkspaceRow(owner_user_id="owner-missing", name="Delta", sqlite_persistence_mode="exclude"),
+            "target-expired": _WorkspaceRow(owner_user_id="owner-expired", name="Gamma", sqlite_persistence_mode="include"),
+        }
+        roles = {
+            ("source-ws", "viewer-user"): "viewer",
+            ("target-read", "viewer-user"): "viewer",
+            ("target-readwrite-viewer", "viewer-user"): "viewer",
+            ("target-readwrite-editor", "viewer-user"): "editor",
+            ("target-missing", "viewer-user"): "viewer",
+            ("target-expired", "viewer-user"): "editor",
+        }
+        fake_db = self._db(
+            workspace_rows=workspace_rows,
+            roles=roles,
+            grant_rows=[
+                self._grant("target-read", sqlite_access_mode="read"),
+                self._grant("target-readwrite-viewer", sqlite_access_mode="read_write"),
+                self._grant("target-readwrite-editor", sqlite_access_mode="read_write"),
+                self._grant("target-missing", sqlite_access_mode="read"),
+                self._grant("target-expired", sqlite_access_mode="read", expires_at=datetime(2026, 8, 5, tzinfo=timezone.utc)),
+            ],
+        )
+        self._initialize_workspace_database("source-ws", "zeta.sqlite3")
+        self._initialize_workspace_database("source-ws", "app.sqlite3")
+        self._initialize_workspace_database("target-read")
+        self._create_table_with_rows("target-read")
+        self._initialize_workspace_database("target-readwrite-viewer")
+        self._initialize_workspace_database("target-readwrite-editor")
+
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db, workspace_rows):
+                stack.enter_context(patcher)
+            stack.enter_context(mock.patch("ragtime.userspace.service.utc_now", return_value=datetime(2026, 8, 6, tzinfo=timezone.utc)))
+            databases, total_bytes, mode = await self.service.list_sqlite_databases("source-ws", "viewer-user")
+
+        self.assertEqual(mode, "include")
+        self.assertEqual(
+            [(database.ownership, database.owner_workspace_name, database.name, database.access_mode, database.initialized) for database in databases],
+            [
+                ("owned", "Source Workspace", "app.sqlite3", "read", True),
+                ("owned", "Source Workspace", "zeta.sqlite3", "read", True),
+                ("linked", "Alpha", "app.sqlite3", "read", True),
+                ("linked", "beta", "app.sqlite3", "read_write", True),
+                ("linked", "Beta", "app.sqlite3", "read", True),
+                ("linked", "Delta", "app.sqlite3", "read", False),
+            ],
+        )
+        self.assertEqual(databases[-1].last_modified_ms, None)
+        self.assertEqual(databases[-1].size_bytes, 0)
+        self.assertEqual(databases[-1].table_count, 0)
+        self.assertEqual(databases[-1].persistence_mode, "exclude")
+        self.assertEqual(total_bytes, sum(database.size_bytes for database in databases if database.initialized))
+
+    async def test_list_sqlite_databases_sets_owned_read_write_for_editor_and_omits_linked_for_admin_without_source_membership(self) -> None:
+        workspace_rows = {
+            "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source Workspace", sqlite_persistence_mode="exclude"),
+            "target-ws": _WorkspaceRow(owner_user_id="owner-target", name="Target Workspace", sqlite_persistence_mode="include"),
+        }
+        editor_db = self._db(
+            workspace_rows=workspace_rows,
+            roles={("source-ws", "editor-user"): "editor", ("target-ws", "editor-user"): "editor"},
+            grant_rows=[self._grant("target-ws", sqlite_access_mode="read_write")],
+        )
+        admin_db = self._db(
+            workspace_rows=workspace_rows,
+            roles={("target-ws", "admin-user"): "editor"},
+            grant_rows=[self._grant("target-ws", sqlite_access_mode="read_write")],
+        )
+        self._initialize_workspace_database("source-ws")
+        self._initialize_workspace_database("target-ws")
+
+        with ExitStack() as stack:
+            for patcher in self._patch_common(editor_db, workspace_rows):
+                stack.enter_context(patcher)
+            editor_databases, _, _ = await self.service.list_sqlite_databases("source-ws", "editor-user")
+        self.assertEqual(editor_databases[0].access_mode, "read_write")
+
+        with ExitStack() as stack:
+            for patcher in self._patch_common(admin_db, workspace_rows):
+                stack.enter_context(patcher)
+            admin_databases, _, _ = await self.service.list_sqlite_databases("source-ws", "admin-user", is_admin=True)
+        self.assertEqual([(database.ownership, database.owner_workspace_id) for database in admin_databases], [("owned", "source-ws")])
+
+    async def test_linked_read_operations_allow_queries_exports_and_table_reads(self) -> None:
+        workspace_rows = {
+            "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source Workspace"),
+            "target-ws": _WorkspaceRow(owner_user_id="owner-target", name="Target Workspace", sqlite_persistence_mode="include"),
+        }
+        roles = {("source-ws", "viewer-user"): "viewer", ("target-ws", "viewer-user"): "viewer"}
+        fake_db = self._db(workspace_rows=workspace_rows, roles=roles, grant_rows=[self._grant("target-ws", sqlite_access_mode="read")])
+        self._initialize_workspace_database("target-ws")
+        self._create_table_with_rows("target-ws")
+
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db, workspace_rows):
+                stack.enter_context(patcher)
+            summary, tables = await self.service.list_sqlite_tables("source-ws", "viewer-user", "app.sqlite3", owner_workspace_id="target-ws")
+            schema = await self.service.get_sqlite_table_schema("source-ws", "viewer-user", "app.sqlite3", "items", owner_workspace_id="target-ws")
+            page = await self.service.list_sqlite_rows("source-ws", "viewer-user", "app.sqlite3", "items", owner_workspace_id="target-ws")
+            query = await self.service.execute_sqlite_readonly_query(
+                "source-ws", "viewer-user", "app.sqlite3", "select id, name from items", owner_workspace_id="target-ws"
+            )
+            exported_db = await self.service.export_sqlite_database("source-ws", "viewer-user", "app.sqlite3", owner_workspace_id="target-ws")
+            exported_csv = await self.service.export_sqlite_table_csv(
+                "source-ws", "viewer-user", "app.sqlite3", "items", owner_workspace_id="target-ws"
+            )
+
+        self.assertEqual(summary.owner_workspace_id, "target-ws")
+        self.assertEqual(summary.access_mode, "read")
+        self.assertEqual([table.name for table in tables], ["items"])
+        self.assertEqual([column.name for column in schema.columns], ["id", "name"])
+        self.assertEqual(page.rows[0]["name"], "Ada")
+        self.assertEqual(query.rows, [{"id": 1, "name": "Ada"}])
+        self.assertTrue(exported_db.exists())
+        self.assertIn("Ada", exported_csv)
+        exported_db.unlink(missing_ok=True)
+
+    async def test_linked_read_denies_write_operations_and_non_default_database_targets(self) -> None:
+        workspace_rows = {
+            "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source Workspace"),
+            "target-ws": _WorkspaceRow(owner_user_id="owner-target", name="Target Workspace"),
+        }
+        roles = {("source-ws", "viewer-user"): "viewer", ("target-ws", "viewer-user"): "viewer"}
+        fake_db = self._db(workspace_rows=workspace_rows, roles=roles, grant_rows=[self._grant("target-ws", sqlite_access_mode="read_write")])
+        self._initialize_workspace_database("target-ws")
+        upload_path = self._sqlite_upload_copy("source-ws")
+
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db, workspace_rows):
+                stack.enter_context(patcher)
+            denied_calls = [
+                lambda: self.service.initialize_sqlite_database(
+                    "source-ws", "viewer-user", database_name="app.sqlite3", owner_workspace_id="target-ws"
+                ),
+                lambda: self.service.import_sqlite_database(
+                    "source-ws", "viewer-user", "app.sqlite3", upload_path, owner_workspace_id="target-ws"
+                ),
+                lambda: self.service.delete_sqlite_database("source-ws", "viewer-user", "app.sqlite3", owner_workspace_id="target-ws"),
+                lambda: self.service.create_sqlite_table(
+                    "source-ws",
+                    "viewer-user",
+                    "app.sqlite3",
+                    "items",
+                    [sqlite_inspector_helpers.ColumnDefinition(name="id", type="INTEGER", primary_key=True)],
+                    owner_workspace_id="target-ws",
+                ),
+                lambda: self.service.alter_sqlite_table(
+                    "source-ws",
+                    "viewer-user",
+                    "app.sqlite3",
+                    "items",
+                    [sqlite_inspector_helpers.TableAlteration(op="rename_table", new_table_name="renamed")],
+                    owner_workspace_id="target-ws",
+                ),
+                lambda: self.service.drop_sqlite_table("source-ws", "viewer-user", "app.sqlite3", "items", owner_workspace_id="target-ws"),
+                lambda: self.service.import_sqlite_table_csv(
+                    "source-ws", "viewer-user", "app.sqlite3", "items", "id,name\n1,Ada\n", owner_workspace_id="target-ws"
+                ),
+                lambda: self.service.insert_sqlite_row(
+                    "source-ws", "viewer-user", "app.sqlite3", "items", {"id": 2}, owner_workspace_id="target-ws"
+                ),
+                lambda: self.service.update_sqlite_row(
+                    "source-ws", "viewer-user", "app.sqlite3", "items", {"id": 1}, {"name": "Grace"}, owner_workspace_id="target-ws"
+                ),
+                lambda: self.service.delete_sqlite_row(
+                    "source-ws", "viewer-user", "app.sqlite3", "items", {"id": 1}, owner_workspace_id="target-ws"
+                ),
+            ]
+            for call in denied_calls:
+                with self.assertRaises(HTTPException) as raised:
+                    await call()
+                self.assertEqual(raised.exception.status_code, 403)
+
+            with self.assertRaises(HTTPException) as linked_name_error:
+                await self.service.initialize_sqlite_database(
+                    "source-ws", "viewer-user", database_name="custom.sqlite3", owner_workspace_id="target-ws"
+                )
+            self.assertEqual(linked_name_error.exception.status_code, 404)
+
+    async def test_linked_read_write_operations_mutate_target_promote_target_and_audit(self) -> None:
+        workspace_rows = {
+            "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source Workspace", sqlite_persistence_mode="exclude"),
+            "target-ws": _WorkspaceRow(owner_user_id="owner-target", name="Target Workspace", sqlite_persistence_mode="exclude"),
+        }
+        roles = {("source-ws", "editor-user"): "viewer", ("target-ws", "editor-user"): "editor"}
+        fake_db = self._db(workspace_rows=workspace_rows, roles=roles, grant_rows=[self._grant("target-ws", sqlite_access_mode="read_write")])
+        self._initialize_workspace_database("target-ws")
+        upload_path = self._sqlite_upload_copy("target-ws")
+
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db, workspace_rows):
+                stack.enter_context(patcher)
+            created_table, promoted = await self.service.create_sqlite_table(
+                "source-ws",
+                "editor-user",
+                "app.sqlite3",
+                "items",
+                [
+                    sqlite_inspector_helpers.ColumnDefinition(name="id", type="INTEGER", primary_key=True, not_null=True),
+                    sqlite_inspector_helpers.ColumnDefinition(name="name", type="TEXT"),
+                ],
+                owner_workspace_id="target-ws",
+            )
+            inserted_row, _ = await self.service.insert_sqlite_row(
+                "source-ws", "editor-user", "app.sqlite3", "items", {"id": 1, "name": "Ada"}, owner_workspace_id="target-ws"
+            )
+            updated_row, _ = await self.service.update_sqlite_row(
+                "source-ws", "editor-user", "app.sqlite3", "items", {"id": 1}, {"name": "Grace"}, owner_workspace_id="target-ws"
+            )
+            await self.service.delete_sqlite_row("source-ws", "editor-user", "app.sqlite3", "items", {"id": 1}, owner_workspace_id="target-ws")
+            imported_table, _ = await self.service.import_sqlite_table_csv(
+                "source-ws", "editor-user", "app.sqlite3", "items", "id,name\n2,Linus\n", replace=True, owner_workspace_id="target-ws"
+            )
+            altered_schema, _ = await self.service.alter_sqlite_table(
+                "source-ws",
+                "editor-user",
+                "app.sqlite3",
+                "items",
+                [sqlite_inspector_helpers.TableAlteration(op="rename_table", new_table_name="records")],
+                owner_workspace_id="target-ws",
+            )
+            dropped_promoted = await self.service.drop_sqlite_table(
+                "source-ws", "editor-user", "app.sqlite3", "records", owner_workspace_id="target-ws"
+            )
+            await self.service.delete_sqlite_database("source-ws", "editor-user", "app.sqlite3", owner_workspace_id="target-ws")
+            initialized_summary, _ = await self.service.initialize_sqlite_database(
+                "source-ws", "editor-user", database_name="app.sqlite3", owner_workspace_id="target-ws"
+            )
+            imported_database, _ = await self.service.import_sqlite_database(
+                "source-ws", "editor-user", "app.sqlite3", upload_path, owner_workspace_id="target-ws"
+            )
+            linked_summary, linked_tables = await self.service.list_sqlite_tables(
+                "source-ws", "editor-user", "app.sqlite3", owner_workspace_id="target-ws"
+            )
+
+        self.assertTrue(promoted)
+        self.assertEqual(created_table.name, "items")
+        self.assertEqual(inserted_row["name"], "Ada")
+        self.assertEqual(updated_row["name"], "Grace")
+        self.assertEqual(imported_table.name, "items")
+        self.assertEqual(altered_schema.name, "records")
+        self.assertFalse(dropped_promoted)
+        self.assertEqual(initialized_summary.owner_workspace_id, "target-ws")
+        self.assertEqual(initialized_summary.persistence_mode, "include")
+        self.assertEqual(imported_database.owner_workspace_id, "target-ws")
+        self.assertEqual(linked_summary.owner_workspace_id, "target-ws")
+        self.assertEqual(workspace_rows["source-ws"].sqlite_persistence_mode, "exclude")
+        self.assertEqual(workspace_rows["target-ws"].sqlite_persistence_mode, "include")
+        self.assertTrue(self.promoted_workspaces)
+        self.assertTrue(all(workspace_id == "target-ws" for workspace_id in self.promoted_workspaces))
+        self.assertEqual([table.name for table in linked_tables], [])
+        linked_audits = [event for event in self.audit_events if event["event_type"] == "sqlite_inspector.linked_mutation"]
+        self.assertTrue(linked_audits)
+        self.assertEqual(
+            linked_audits[0]["payload"],
+            {
+                "source_workspace_id": "source-ws",
+                "target_workspace_id": "target-ws",
+                "grant_id": "grant-target-ws",
+                "operation": mock.ANY,
+                "database_name": "app.sqlite3",
+            },
+        )
+        self.assertNotIn("sql", linked_audits[0]["payload"])
+        self.assertNotIn("values", linked_audits[0]["payload"])
+
+    async def test_linked_write_revocation_takes_effect_on_next_request(self) -> None:
+        workspace_rows = {
+            "source-ws": _WorkspaceRow(owner_user_id="owner-source", name="Source Workspace"),
+            "target-ws": _WorkspaceRow(owner_user_id="owner-target", name="Target Workspace"),
+        }
+        grant = self._grant("target-ws", sqlite_access_mode="read_write")
+        roles = {("source-ws", "editor-user"): "viewer", ("target-ws", "editor-user"): "editor"}
+        fake_db = self._db(workspace_rows=workspace_rows, roles=roles, grant_rows=[grant])
+        self._initialize_workspace_database("target-ws")
+
+        with ExitStack() as stack:
+            for patcher in self._patch_common(fake_db, workspace_rows):
+                stack.enter_context(patcher)
+            await self.service.initialize_sqlite_database("source-ws", "editor-user", owner_workspace_id="target-ws")
+            grant.sqliteAccessMode = "read"
+            with self.assertRaises(HTTPException) as raised:
+                await self.service.create_sqlite_table(
+                    "source-ws",
+                    "editor-user",
+                    "app.sqlite3",
+                    "items",
+                    [sqlite_inspector_helpers.ColumnDefinition(name="id", type="INTEGER", primary_key=True)],
+                    owner_workspace_id="target-ws",
+                )
+        self.assertEqual(raised.exception.status_code, 403)
+
+    async def test_route_linked_delete_snapshots_target_workspace(self) -> None:
+        user = SimpleNamespace(id="user-1", role="editor")
+        delete_mock = mock.AsyncMock(return_value=None)
+        snapshot_mock = mock.AsyncMock(return_value=None)
+
+        with (
+            mock.patch.object(userspace_routes.userspace_service, "delete_sqlite_database", delete_mock),
+            mock.patch.object(userspace_routes, "_snapshot_after_sqlite_mutation", snapshot_mock),
+        ):
+            response = await userspace_routes.delete_workspace_sqlite_database(
+                "source-ws",
+                "app.sqlite3",
+                owner_workspace_id="target-ws",
+                user=user,
+            )
+
+        delete_mock.assert_awaited_once_with(
+            "source-ws",
+            "user-1",
+            "app.sqlite3",
+            owner_workspace_id="target-ws",
+            is_admin=False,
+        )
+        snapshot_mock.assert_awaited_once_with("target-ws", "user-1", "delete database app.sqlite3")
+        self.assertEqual(response.workspace_id, "source-ws")

--- a/tests/test_userspace_planning_context.py
+++ b/tests/test_userspace_planning_context.py
@@ -159,12 +159,25 @@ class PlanningContextTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("enc::", dumped)
 
     async def test_builder_contract_matches_internal_prompts(self) -> None:
-        from ragtime.userspace.planning_contract import build_builder_contract, continuity_rules
+        from ragtime.userspace.planning_contract import (
+            PLANNING_CONTRACT_VERSION,
+            build_builder_contract,
+            continuity_rules,
+        )
 
         contract = build_builder_contract(sqlite_persistence_mode="include", has_live_data_tools=True)
         joined = "\n".join(contract["rules"])
+        self.assertEqual(PLANNING_CONTRACT_VERSION, "2")
+        self.assertEqual(contract["contract_version"], "2")
         self.assertIn("$PORT", joined)
         self.assertIn("0.0.0.0", joined)
+        self.assertIn("Shared SQLite access runs from server code only", joined)
+        self.assertIn("target-owner grant", joined)
+        self.assertIn("owner workspace keeps schema and migrations", joined)
+        self.assertNotIn("/sqlite/query", joined)
+        self.assertNotIn("/sqlite/mutate", joined)
+        self.assertNotIn("RAGTIME_BRIDGE_TOKEN", joined)
+        self.assertNotIn("Authorization: Bearer", joined)
         for rule in _WORKSPACE_CONTINUITY_EXISTING_RULES:
             self.assertIn(rule.lstrip("- ").strip(), contract["rules"])
         self.assertEqual(continuity_rules(), [r.lstrip("- ").strip() for r in _WORKSPACE_CONTINUITY_EXISTING_RULES])

--- a/tests/test_userspace_runtime_bridge_prompts.py
+++ b/tests/test_userspace_runtime_bridge_prompts.py
@@ -24,7 +24,9 @@ class RuntimeBridgePromptTests(unittest.TestCase):
         text = build_userspace_entrypoint_nudge(self._status(), is_default_static=False)
         self.assertIn("RAGTIME_BRIDGE_URL", text)
         self.assertIn("RAGTIME_BRIDGE_TOKEN", text)
-        self.assertIn("execute-component", text)
+        self.assertIn("/execute-component", text)
+        self.assertIn("/sqlite/query", text)
+        self.assertIn("/sqlite/mutate", text)
         self.assertIn(
             "SERVER lane (this bridge, bearer token): follows Workspace Tools access policy.",
             text,
@@ -48,10 +50,28 @@ class RuntimeBridgePromptTests(unittest.TestCase):
         )
         self.assertIn('"request": {"query": "SELECT ... LIMIT 100"}', text)
         self.assertIn('"request": {"method": "GET", "path": "/customers"}', text)
+        self.assertIn('database_name: "app.sqlite3"', text)
+        self.assertIn("parameterized SQL", text)
+        self.assertIn("positional-list or named-dict `parameters`", text)
+        self.assertIn("max_rows` up to 500", text)
+        self.assertIn("`columns`, `rows`, `row_count`, and `truncated`", text)
+        self.assertIn("1..500 structured `insert`, `upsert`, `update`, or `delete` operations", text)
+        self.assertIn("The bridge does not accept raw writable SQL", text)
+        self.assertIn("The target owner must grant Shared SQLite access", text)
+        self.assertIn("Read grants allow queries; Read / Write grants allow structured mutations", text)
+        self.assertIn("source membership plus target viewer membership for query", text)
+        self.assertIn("target editor membership for mutation", text)
+        self.assertIn("The target workspace owns `.ragtime/db/migrations/*.sql` and all DDL", text)
+        self.assertIn("Consumers cannot run DDL, PRAGMA, ATTACH, or extension loading", text)
+        self.assertIn("Handle HTTP 409 as busy, 504 as timeout, and 503 as audit unavailable", text)
+        self.assertIn("A 503 audit failure occurs before writes and is safe to retry", text)
+        self.assertIn("Do not blindly retry other mutation failures", text)
+        self.assertIn("server code only", text)
         self.assertNotIn(
             "Runtime bridge component calls are enforced as read-only and platform-limited; do not attempt writes through this bridge.",
             text,
         )
+        self.assertNotIn("window.__ragtime_context", text)
 
     def test_static_framework_keeps_browser_bridge_guidance_only(self) -> None:
         text = build_userspace_entrypoint_nudge(
@@ -59,6 +79,8 @@ class RuntimeBridgePromptTests(unittest.TestCase):
             is_default_static=True,
         )
         self.assertNotIn("RAGTIME_BRIDGE_URL", text)
+        self.assertNotIn("/sqlite/query", text)
+        self.assertNotIn("/sqlite/mutate", text)
         self.assertIn("context.components", text)
 
     def test_missing_entrypoint_output_unchanged(self) -> None:
@@ -67,3 +89,5 @@ class RuntimeBridgePromptTests(unittest.TestCase):
             is_default_static=False,
         )
         self.assertNotIn("RAGTIME_BRIDGE_URL", text)
+        self.assertNotIn("/sqlite/query", text)
+        self.assertNotIn("/sqlite/mutate", text)

--- a/tests/test_userspace_runtime_bridge_prompts.py
+++ b/tests/test_userspace_runtime_bridge_prompts.py
@@ -1,7 +1,11 @@
 import unittest
 
 from ragtime.core.entrypoint_status import EntrypointState, EntrypointStatus
-from ragtime.rag.prompts import build_userspace_entrypoint_nudge
+from ragtime.rag.prompts import (
+    build_shared_sqlite_prompt_fragment,
+    build_userspace_entrypoint_nudge,
+    build_userspace_mode_prompt_addition,
+)
 
 
 class RuntimeBridgePromptTests(unittest.TestCase):
@@ -25,8 +29,6 @@ class RuntimeBridgePromptTests(unittest.TestCase):
         self.assertIn("RAGTIME_BRIDGE_URL", text)
         self.assertIn("RAGTIME_BRIDGE_TOKEN", text)
         self.assertIn("/execute-component", text)
-        self.assertIn("/sqlite/query", text)
-        self.assertIn("/sqlite/mutate", text)
         self.assertIn(
             "SERVER lane (this bridge, bearer token): follows Workspace Tools access policy.",
             text,
@@ -48,25 +50,8 @@ class RuntimeBridgePromptTests(unittest.TestCase):
             "The runtime token is the backend service identity; backend mutation routes must enforce their own authz/authn and must never expose that token to browser code.",
             text,
         )
-        self.assertIn('"request": {"query": "SELECT ... LIMIT 100"}', text)
-        self.assertIn('"request": {"method": "GET", "path": "/customers"}', text)
-        self.assertIn('database_name: "app.sqlite3"', text)
-        self.assertIn("parameterized SQL", text)
-        self.assertIn("positional-list or named-dict `parameters`", text)
-        self.assertIn("max_rows` up to 500", text)
-        self.assertIn("`columns`, `rows`, `row_count`, and `truncated`", text)
-        self.assertIn("1..500 structured `insert`, `upsert`, `update`, or `delete` operations", text)
-        self.assertIn("The bridge does not accept raw writable SQL", text)
-        self.assertIn("The target owner must grant Shared SQLite access", text)
-        self.assertIn("Read grants allow queries; Read / Write grants allow structured mutations", text)
-        self.assertIn("source membership plus target viewer membership for query", text)
-        self.assertIn("target editor membership for mutation", text)
-        self.assertIn("The target workspace owns `.ragtime/db/migrations/*.sql` and all DDL", text)
-        self.assertIn("Consumers cannot run DDL, PRAGMA, ATTACH, or extension loading", text)
-        self.assertIn("Handle HTTP 409 as busy, 504 as timeout, and 503 as audit unavailable", text)
-        self.assertIn("A 503 audit failure occurs before writes and is safe to retry", text)
-        self.assertIn("Do not blindly retry other mutation failures", text)
-        self.assertIn("server code only", text)
+        self.assertNotIn("/sqlite/query", text)
+        self.assertNotIn("/sqlite/mutate", text)
         self.assertNotIn(
             "Runtime bridge component calls are enforced as read-only and platform-limited; do not attempt writes through this bridge.",
             text,
@@ -91,3 +76,67 @@ class RuntimeBridgePromptTests(unittest.TestCase):
         self.assertNotIn("RAGTIME_BRIDGE_URL", text)
         self.assertNotIn("/sqlite/query", text)
         self.assertNotIn("/sqlite/mutate", text)
+
+    def test_shared_sqlite_prompt_fragment_omits_guidance_for_empty_inventory(self) -> None:
+        self.assertEqual(build_shared_sqlite_prompt_fragment([]), "")
+
+        prompt = build_userspace_mode_prompt_addition(
+            include_sqlite_persistence=False,
+            shared_sqlite_databases=[],
+        )
+
+        self.assertNotIn("/sqlite/query", prompt)
+        self.assertNotIn("/sqlite/mutate", prompt)
+
+    def test_shared_sqlite_prompt_fragment_lists_targets_with_sanitized_permissions(self) -> None:
+        accessible_databases = [
+            {
+                "workspace_id": "ws_beta",
+                "workspace_name": 'Beta\nWorkspace\t"ops"',
+                "database_name": "app.sqlite3",
+                "access_mode": "read_write",
+            },
+            {
+                "workspace_id": "ws_alpha",
+                "workspace_name": "Alpha\r\nWorkspace" + (" x" * 120),
+                "database_name": "app.sqlite3",
+                "access_mode": "read",
+            },
+        ]
+
+        fragment = build_shared_sqlite_prompt_fragment(accessible_databases)
+        prompt = build_userspace_mode_prompt_addition(
+            include_sqlite_persistence=False,
+            shared_sqlite_databases=accessible_databases,
+        )
+
+        self.assertIn("Use Shared SQLite from server code only", fragment)
+        self.assertIn("A server-backed entrypoint is required", fragment)
+        self.assertNotIn("Contract body examples include", fragment)
+        self.assertIn('database_name: "app.sqlite3"', fragment)
+        self.assertIn("parameterized SQL", fragment)
+        self.assertIn("positional-list or named-dict `parameters`", fragment)
+        self.assertIn("max_rows` up to 500", fragment)
+        self.assertIn("`columns`, `rows`, `row_count`, and `truncated`", fragment)
+        self.assertIn("1..500 structured `insert`, `upsert`, `update`, or `delete` operations", fragment)
+        self.assertIn("The bridge does not accept raw writable SQL", fragment)
+        self.assertIn("The target owner must grant Shared SQLite access", fragment)
+        self.assertIn("Read grants allow queries; Read / Write grants allow structured mutations", fragment)
+        self.assertIn("source membership plus target viewer membership for query", fragment)
+        self.assertIn("target editor membership for mutation", fragment)
+        self.assertIn("The target workspace owns `.ragtime/db/migrations/*.sql` and all DDL", fragment)
+        self.assertIn("Consumers cannot run DDL, PRAGMA, ATTACH, or extension loading", fragment)
+        self.assertIn("Handle HTTP 409 as busy, 504 as timeout, and 503 as audit unavailable", fragment)
+        self.assertIn("A 503 audit failure occurs before writes and is safe to retry", fragment)
+        self.assertIn("Do not blindly retry other mutation failures", fragment)
+        self.assertLess(fragment.index("ws_alpha"), fragment.index("ws_beta"))
+        self.assertIn('- Workspace: "Alpha Workspace', fragment)
+        self.assertIn('- Workspace: "Beta Workspace \\"ops\\""', fragment)
+        self.assertIn("- target_workspace_id: `ws_alpha`", fragment)
+        self.assertIn("- target_workspace_id: `ws_beta`", fragment)
+        self.assertIn("- database_name: `app.sqlite3`", fragment)
+        self.assertIn("- effective_permission: Read", fragment)
+        self.assertIn("- effective_permission: Read / Write", fragment)
+        self.assertNotIn("Beta\nWorkspace", fragment)
+        self.assertNotIn("Alpha\r", fragment)
+        self.assertIn(fragment, prompt)

--- a/tests/test_userspace_runtime_bridge_prompts.py
+++ b/tests/test_userspace_runtime_bridge_prompts.py
@@ -26,11 +26,11 @@ class RuntimeBridgePromptTests(unittest.TestCase):
 
     def test_valid_server_entrypoint_includes_bridge_guidance(self) -> None:
         text = build_userspace_entrypoint_nudge(self._status(), is_default_static=False)
-        self.assertIn("RAGTIME_BRIDGE_URL", text)
-        self.assertIn("RAGTIME_BRIDGE_TOKEN", text)
-        self.assertIn("/execute-component", text)
+        self.assertIn("`RAGTIME_BRIDGE_URL`", text)
+        self.assertIn("`RAGTIME_BRIDGE_TOKEN`", text)
+        self.assertIn("`{RAGTIME_BRIDGE_URL}/execute-component`", text)
         self.assertIn(
-            "SERVER lane (this bridge, bearer token): follows Workspace Tools access policy.",
+            "SERVER execution surface (this bridge, bearer token): follows Workspace Tools access policy.",
             text,
         )
         self.assertIn(
@@ -40,6 +40,10 @@ class RuntimeBridgePromptTests(unittest.TestCase):
         self.assertNotIn("global tool config permits writes", text)
         self.assertIn(
             "ALWAYS read-only, regardless of the workspace write toggle.",
+            text,
+        )
+        self.assertIn(
+            "BROWSER execution surface (`context.components[...].execute()` in preview/shared pages):",
             text,
         )
         self.assertIn(
@@ -88,6 +92,73 @@ class RuntimeBridgePromptTests(unittest.TestCase):
         self.assertNotIn("/sqlite/query", prompt)
         self.assertNotIn("/sqlite/mutate", prompt)
 
+    def test_userspace_prompt_combines_data_boundaries_matrix(self) -> None:
+        local_only = build_userspace_mode_prompt_addition(
+            include_sqlite_persistence=True,
+            has_live_data_tools=True,
+            shared_sqlite_databases=[],
+        )
+        shared_only = build_userspace_mode_prompt_addition(
+            include_sqlite_persistence=False,
+            has_live_data_tools=False,
+            shared_sqlite_databases=[
+                {
+                    "workspace_id": "ws_target",
+                    "workspace_name": "Target Workspace",
+                    "database_name": "app.sqlite3",
+                    "access_mode": "read",
+                }
+            ],
+        )
+        both = build_userspace_mode_prompt_addition(
+            include_sqlite_persistence=True,
+            has_live_data_tools=True,
+            shared_sqlite_databases=[
+                {
+                    "workspace_id": "ws_target",
+                    "workspace_name": "Target Workspace",
+                    "database_name": "app.sqlite3",
+                    "access_mode": "read_write",
+                }
+            ],
+        )
+        neither = build_userspace_mode_prompt_addition(
+            include_sqlite_persistence=False,
+            has_live_data_tools=False,
+            shared_sqlite_databases=[],
+        )
+        include_without_live_tools = build_userspace_mode_prompt_addition(
+            include_sqlite_persistence=True,
+            has_live_data_tools=False,
+            shared_sqlite_databases=[],
+        )
+
+        self.assertIn("#### Data and persistence boundaries", local_only)
+        self.assertIn("##### Lane A - Live tool data", local_only)
+        self.assertIn("##### Lane B - Primary workspace SQLite", local_only)
+        self.assertNotIn("##### Shared SQLite target workspaces", local_only)
+
+        self.assertIn("#### Data and persistence boundaries", shared_only)
+        self.assertNotIn("##### Lane A - Live tool data", shared_only)
+        self.assertNotIn("##### Lane B - Primary workspace SQLite", shared_only)
+        self.assertIn("##### Shared SQLite target workspaces", shared_only)
+        self.assertNotIn("Every schema change requires a new numbered migration file", shared_only)
+
+        self.assertIn("#### Data and persistence boundaries", both)
+        self.assertLess(both.index("##### Lane A - Live tool data"), both.index("##### Lane B - Primary workspace SQLite"))
+        self.assertLess(both.index("##### Lane B - Primary workspace SQLite"), both.index("##### Shared SQLite target workspaces"))
+        self.assertIn("These sections define responsibilities, not mandatory work in every turn.", both)
+        self.assertIn("Shared SQLite is not a third persistence lane", both)
+        self.assertIn("`/sqlite/query` and `/sqlite/mutate` are only for cross-workspace access", both)
+        self.assertIn("Browser code must call an app-owned server route", both)
+        self.assertIn("must never call bridge endpoints directly or receive `RAGTIME_BRIDGE_TOKEN`", both)
+
+        self.assertNotIn("#### Data and persistence boundaries", neither)
+
+        self.assertIn("#### Data and persistence boundaries", include_without_live_tools)
+        self.assertNotIn("##### Lane A - Live tool data", include_without_live_tools)
+        self.assertIn("##### Lane B - Primary workspace SQLite", include_without_live_tools)
+
     def test_shared_sqlite_prompt_fragment_lists_targets_with_sanitized_permissions(self) -> None:
         accessible_databases = [
             {
@@ -110,9 +181,11 @@ class RuntimeBridgePromptTests(unittest.TestCase):
             shared_sqlite_databases=accessible_databases,
         )
 
+        self.assertIn("##### Shared SQLite target workspaces", fragment)
         self.assertIn("Use Shared SQLite from server code only", fragment)
         self.assertIn("A server-backed entrypoint is required", fragment)
         self.assertNotIn("Contract body examples include", fragment)
+        self.assertIn("Shared SQLite is not a third persistence lane", fragment)
         self.assertIn('database_name: "app.sqlite3"', fragment)
         self.assertIn("parameterized SQL", fragment)
         self.assertIn("positional-list or named-dict `parameters`", fragment)
@@ -129,6 +202,9 @@ class RuntimeBridgePromptTests(unittest.TestCase):
         self.assertIn("Handle HTTP 409 as busy, 504 as timeout, and 503 as audit unavailable", fragment)
         self.assertIn("A 503 audit failure occurs before writes and is safe to retry", fragment)
         self.assertIn("Do not blindly retry other mutation failures", fragment)
+        self.assertIn("`/sqlite/query` and `/sqlite/mutate` are only for cross-workspace access", fragment)
+        self.assertIn("Browser code must call an app-owned server route", fragment)
+        self.assertIn("must never call bridge endpoints directly or receive `RAGTIME_BRIDGE_TOKEN`", fragment)
         self.assertLess(fragment.index("ws_alpha"), fragment.index("ws_beta"))
         self.assertIn('- Workspace: "Alpha Workspace', fragment)
         self.assertIn('- Workspace: "Beta Workspace \\"ops\\""', fragment)

--- a/tests/test_userspace_runtime_bridge_route.py
+++ b/tests/test_userspace_runtime_bridge_route.py
@@ -2,13 +2,24 @@ from __future__ import annotations
 
 import unittest
 from types import SimpleNamespace
+from typing import cast
 from unittest import mock
 
 from fastapi import HTTPException
 from starlette.requests import Request
+from starlette.routing import Route
 
 import ragtime.userspace.runtime_routes as _RUNTIME_ROUTES
-from ragtime.userspace.models import ExecuteComponentRequest, ExecuteComponentResponse
+from ragtime.userspace.models import (
+    ExecuteComponentRequest,
+    ExecuteComponentResponse,
+    RuntimeBridgeSqliteMutationOperation,
+    RuntimeBridgeSqliteMutationOperationResponse,
+    RuntimeBridgeSqliteMutationRequest,
+    RuntimeBridgeSqliteMutationResponse,
+    RuntimeBridgeSqliteQueryRequest,
+    RuntimeBridgeSqliteQueryResponse,
+)
 
 runtime_bridge_execute_component = _RUNTIME_ROUTES.runtime_bridge_execute_component
 
@@ -32,7 +43,31 @@ def _build_request(path: str, authorization: str | None = None) -> Request:
     )
 
 
+def _route(path: str, method: str = "POST") -> Route | None:
+    return next(
+        (
+            cast(Route, route)
+            for route in _RUNTIME_ROUTES.router.routes
+            if isinstance(route, Route) and route.path == path and method in (route.methods or set())
+        ),
+        None,
+    )
+
+
 class RuntimeBridgeRouteTests(unittest.IsolatedAsyncioTestCase):
+    def _require_route(self, path: str, method: str = "POST") -> Route:
+        route = _route(path, method)
+        self.assertIsNotNone(route, f"{path} route not found on router")
+        return cast(Route, route)
+
+    def test_sqlite_routes_are_rate_limited(self) -> None:
+        for path in (
+            "/indexes/userspace/runtime-bridge/sqlite/query",
+            "/indexes/userspace/runtime-bridge/sqlite/mutate",
+        ):
+            route = self._require_route(path)
+            self.assertTrue(hasattr(route.endpoint, "__wrapped__"), f"{path} is missing the runtime bridge IP rate limit decorator")
+
     async def test_missing_bearer_returns_401(self) -> None:
         request = _build_request("/indexes/userspace/runtime-bridge/execute-component")
         payload = ExecuteComponentRequest(component_id="tool-1", request={"query": "select 1"})
@@ -99,6 +134,232 @@ class RuntimeBridgeRouteTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(ctx.exception.status_code, 401)
         self.assertEqual(ctx.exception.detail, "Runtime session inactive")
+
+    async def test_sqlite_query_missing_bearer_returns_401(self) -> None:
+        route = self._require_route("/indexes/userspace/runtime-bridge/sqlite/query")
+        request = _build_request("/indexes/userspace/runtime-bridge/sqlite/query")
+        payload = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="select 1")
+        runtime_service = SimpleNamespace(
+            verify_runtime_bridge_token=mock.AsyncMock(side_effect=HTTPException(status_code=401, detail="Runtime bridge token required"))
+        )
+
+        with (
+            mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service),
+            self.assertRaises(HTTPException) as ctx,
+        ):
+            await route.endpoint(request, payload)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+        runtime_service.verify_runtime_bridge_token.assert_awaited_once_with(None)
+
+    async def test_sqlite_query_requires_verified_workspace_session_and_leased_user(self) -> None:
+        route = self._require_route("/indexes/userspace/runtime-bridge/sqlite/query")
+        request = _build_request(
+            "/indexes/userspace/runtime-bridge/sqlite/query",
+            authorization="Bearer test-token",
+        )
+        payload = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="select 1")
+        runtime_service = SimpleNamespace(verify_runtime_bridge_token=mock.AsyncMock(return_value={"workspace_id": "ws-1", "session_id": "sess-1"}))
+        userspace_service = SimpleNamespace(query_runtime_bridge_sqlite=mock.AsyncMock())
+
+        with (
+            mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service),
+            mock.patch.object(_RUNTIME_ROUTES, "_userspace_service", return_value=userspace_service),
+            self.assertRaises(HTTPException) as ctx,
+        ):
+            await route.endpoint(request, payload)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertEqual(ctx.exception.detail, "Invalid runtime bridge token")
+        userspace_service.query_runtime_bridge_sqlite.assert_not_awaited()
+
+    async def test_sqlite_query_delegates_exact_verified_identities(self) -> None:
+        route = self._require_route("/indexes/userspace/runtime-bridge/sqlite/query")
+        request = _build_request(
+            "/indexes/userspace/runtime-bridge/sqlite/query",
+            authorization="Bearer test-token",
+        )
+        payload = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="select 1")
+        runtime_service = SimpleNamespace(
+            verify_runtime_bridge_token=mock.AsyncMock(return_value={"workspace_id": "ws-1", "session_id": "sess-1", "leased_by_user_id": "user-1"})
+        )
+        expected = RuntimeBridgeSqliteQueryResponse(
+            target_workspace_id="target-ws",
+            database_name="app.sqlite3",
+            columns=["value"],
+            rows=[{"value": 1}],
+            row_count=1,
+            truncated=False,
+        )
+        userspace_service = SimpleNamespace(query_runtime_bridge_sqlite=mock.AsyncMock(return_value=expected))
+
+        with (
+            mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service),
+            mock.patch.object(_RUNTIME_ROUTES, "_userspace_service", return_value=userspace_service),
+        ):
+            response = await route.endpoint(request, payload)
+
+        self.assertIs(response, expected)
+        userspace_service.query_runtime_bridge_sqlite.assert_awaited_once_with(
+            workspace_id="ws-1",
+            session_id="sess-1",
+            leased_by_user_id="user-1",
+            request=payload,
+        )
+
+    async def test_sqlite_mutate_delegates_exact_verified_identities_and_bumps_generation_best_effort(self) -> None:
+        route = self._require_route("/indexes/userspace/runtime-bridge/sqlite/mutate")
+        request = _build_request(
+            "/indexes/userspace/runtime-bridge/sqlite/mutate",
+            authorization="Bearer test-token",
+        )
+        payload = RuntimeBridgeSqliteMutationRequest(
+            target_workspace_id="target-ws",
+            operations=[RuntimeBridgeSqliteMutationOperation(kind="insert", table="items", values={"id": 1})],
+        )
+        runtime_service = SimpleNamespace(
+            verify_runtime_bridge_token=mock.AsyncMock(return_value={"workspace_id": "ws-1", "session_id": "sess-1", "leased_by_user_id": "user-1"}),
+            bump_workspace_generation=mock.AsyncMock(side_effect=RuntimeError("generation boom")),
+        )
+        expected = RuntimeBridgeSqliteMutationResponse(
+            target_workspace_id="target-ws",
+            database_name="app.sqlite3",
+            operations=[RuntimeBridgeSqliteMutationOperationResponse(kind="insert", rowcount=1, lastrowid=7)],
+            fingerprint="fp-1",
+        )
+        userspace_service = SimpleNamespace(mutate_runtime_bridge_sqlite=mock.AsyncMock(return_value=expected))
+
+        with (
+            mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service),
+            mock.patch.object(_RUNTIME_ROUTES, "_userspace_service", return_value=userspace_service),
+            mock.patch.object(_RUNTIME_ROUTES.logger, "exception") as logger_exception,
+        ):
+            response = await route.endpoint(request, payload)
+
+        self.assertIs(response, expected)
+        userspace_service.mutate_runtime_bridge_sqlite.assert_awaited_once_with(
+            workspace_id="ws-1",
+            session_id="sess-1",
+            leased_by_user_id="user-1",
+            request=payload,
+        )
+        runtime_service.bump_workspace_generation.assert_awaited_once()
+        bump_args = runtime_service.bump_workspace_generation.await_args.args
+        self.assertEqual(bump_args[0], "target-ws")
+        logger_exception.assert_called_once()
+
+    async def test_sqlite_query_maps_broker_codes_to_fixed_http_errors(self) -> None:
+        route = self._require_route("/indexes/userspace/runtime-bridge/sqlite/query")
+        request = _build_request(
+            "/indexes/userspace/runtime-bridge/sqlite/query",
+            authorization="Bearer test-token",
+        )
+        payload = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="select 1")
+        runtime_service = SimpleNamespace(
+            verify_runtime_bridge_token=mock.AsyncMock(return_value={"workspace_id": "ws-1", "session_id": "sess-1", "leased_by_user_id": "user-1"})
+        )
+
+        cases = {
+            "invalid_sql": 400,
+            "invalid_parameters": 400,
+            "sql_too_large": 400,
+            "payload_too_large": 400,
+            "response_too_large": 400,
+            "row_limit_invalid": 400,
+            "sql_not_allowed": 403,
+            "database_not_found": 404,
+            "sqlite_busy": 409,
+            "audit_unavailable": 503,
+            "query_timeout": 504,
+            "query_failed": 500,
+            "mutation_failed": 500,
+        }
+        for code, expected_status in cases.items():
+            with self.subTest(code=code):
+                userspace_service = SimpleNamespace(query_runtime_bridge_sqlite=mock.AsyncMock(side_effect=_RUNTIME_ROUTES.CrossWorkspaceSqliteError(code)))
+                with (
+                    mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service),
+                    mock.patch.object(_RUNTIME_ROUTES, "_userspace_service", return_value=userspace_service),
+                    self.assertRaises(HTTPException) as ctx,
+                ):
+                    await route.endpoint(request, payload)
+                self.assertEqual(ctx.exception.status_code, expected_status)
+                self.assertEqual(ctx.exception.detail, _RUNTIME_ROUTES.CrossWorkspaceSqliteError(code).safe_message)
+
+    async def test_sqlite_query_preserves_service_http_exceptions(self) -> None:
+        route = self._require_route("/indexes/userspace/runtime-bridge/sqlite/query")
+        request = _build_request(
+            "/indexes/userspace/runtime-bridge/sqlite/query",
+            authorization="Bearer test-token",
+        )
+        payload = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="select 1")
+        runtime_service = SimpleNamespace(
+            verify_runtime_bridge_token=mock.AsyncMock(return_value={"workspace_id": "ws-1", "session_id": "sess-1", "leased_by_user_id": "user-1"})
+        )
+        userspace_service = SimpleNamespace(query_runtime_bridge_sqlite=mock.AsyncMock(side_effect=HTTPException(status_code=429, detail="Rate limited")))
+
+        with (
+            mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service),
+            mock.patch.object(_RUNTIME_ROUTES, "_userspace_service", return_value=userspace_service),
+            self.assertRaises(HTTPException) as ctx,
+        ):
+            await route.endpoint(request, payload)
+
+        self.assertEqual(ctx.exception.status_code, 429)
+        self.assertEqual(ctx.exception.detail, "Rate limited")
+
+    async def test_sqlite_query_unknown_broker_code_returns_generic_500(self) -> None:
+        route = self._require_route("/indexes/userspace/runtime-bridge/sqlite/query")
+        request = _build_request(
+            "/indexes/userspace/runtime-bridge/sqlite/query",
+            authorization="Bearer test-token",
+        )
+        payload = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="select 1")
+        runtime_service = SimpleNamespace(
+            verify_runtime_bridge_token=mock.AsyncMock(return_value={"workspace_id": "ws-1", "session_id": "sess-1", "leased_by_user_id": "user-1"})
+        )
+
+        class UnknownCodeError(_RUNTIME_ROUTES.CrossWorkspaceSqliteError):
+            def __init__(self) -> None:
+                Exception.__init__(self, "boom")
+                self.code = "mystery"
+                self.safe_message = "leak me"
+
+        userspace_service = SimpleNamespace(query_runtime_bridge_sqlite=mock.AsyncMock(side_effect=UnknownCodeError()))
+
+        with (
+            mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service),
+            mock.patch.object(_RUNTIME_ROUTES, "_userspace_service", return_value=userspace_service),
+            self.assertRaises(HTTPException) as ctx,
+        ):
+            await route.endpoint(request, payload)
+
+        self.assertEqual(ctx.exception.status_code, 500)
+        self.assertEqual(ctx.exception.detail, "Runtime bridge SQLite request failed.")
+
+    async def test_sqlite_query_unexpected_exception_returns_generic_500_and_logs(self) -> None:
+        route = self._require_route("/indexes/userspace/runtime-bridge/sqlite/query")
+        request = _build_request(
+            "/indexes/userspace/runtime-bridge/sqlite/query",
+            authorization="Bearer test-token",
+        )
+        payload = RuntimeBridgeSqliteQueryRequest(target_workspace_id="target-ws", sql="select 1")
+        runtime_service = SimpleNamespace(
+            verify_runtime_bridge_token=mock.AsyncMock(return_value={"workspace_id": "ws-1", "session_id": "sess-1", "leased_by_user_id": "user-1"})
+        )
+        userspace_service = SimpleNamespace(query_runtime_bridge_sqlite=mock.AsyncMock(side_effect=RuntimeError("secret")))
+
+        with (
+            mock.patch.object(_RUNTIME_ROUTES, "_runtime_service", return_value=runtime_service),
+            mock.patch.object(_RUNTIME_ROUTES, "_userspace_service", return_value=userspace_service),
+            mock.patch.object(_RUNTIME_ROUTES.logger, "exception") as logger_exception,
+            self.assertRaises(HTTPException) as ctx,
+        ):
+            await route.endpoint(request, payload)
+
+        self.assertEqual(ctx.exception.status_code, 500)
+        self.assertEqual(ctx.exception.detail, "Runtime bridge SQLite request failed.")
+        logger_exception.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_userspace_runtime_bridge_sqlite_models.py
+++ b/tests/test_userspace_runtime_bridge_sqlite_models.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from ragtime.userspace.models import (
+    RuntimeBridgeSqliteMutationOperation,
+    RuntimeBridgeSqliteMutationRequest,
+    RuntimeBridgeSqliteQueryRequest,
+)
+
+
+class RuntimeBridgeSqliteModelTests(unittest.TestCase):
+    def test_query_request_forbids_runtime_identity_and_unknown_fields(self) -> None:
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteQueryRequest.model_validate(
+                {
+                    "target_workspace_id": "target-ws",
+                    "sql": "select 1",
+                    "workspace_id": "source-ws",
+                    "session_id": "sess-1",
+                    "leased_by_user_id": "user-1",
+                    "unexpected": True,
+                }
+            )
+
+    def test_query_request_rejects_unsupported_database_name(self) -> None:
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteQueryRequest.model_validate(
+                {
+                    "target_workspace_id": "target-ws",
+                    "database_name": "other.sqlite3",
+                    "sql": "select 1",
+                }
+            )
+
+    def test_query_request_validates_max_rows_bounds(self) -> None:
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteQueryRequest.model_validate(
+                {
+                    "target_workspace_id": "target-ws",
+                    "sql": "select 1",
+                    "max_rows": 0,
+                }
+            )
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteQueryRequest.model_validate(
+                {
+                    "target_workspace_id": "target-ws",
+                    "sql": "select 1",
+                    "max_rows": 501,
+                }
+            )
+
+    def test_query_request_rejects_scalar_and_string_parameters(self) -> None:
+        for parameters in ("bad", 7, 3.5, True):
+            with self.assertRaises(ValidationError):
+                RuntimeBridgeSqliteQueryRequest.model_validate(
+                    {
+                        "target_workspace_id": "target-ws",
+                        "sql": "select 1",
+                        "parameters": parameters,
+                    }
+                )
+
+    def test_query_request_accepts_list_and_dict_parameters(self) -> None:
+        list_request = RuntimeBridgeSqliteQueryRequest.model_validate(
+            {
+                "target_workspace_id": "target-ws",
+                "sql": "select ?",
+                "parameters": [1, "two", None],
+            }
+        )
+        dict_request = RuntimeBridgeSqliteQueryRequest.model_validate(
+            {
+                "target_workspace_id": "target-ws",
+                "sql": "select :value",
+                "parameters": {"value": 1},
+            }
+        )
+
+        self.assertEqual(list_request.parameters, [1, "two", None])
+        self.assertEqual(dict_request.parameters, {"value": 1})
+
+    def test_query_request_defaults_database_name_and_max_rows(self) -> None:
+        request = RuntimeBridgeSqliteQueryRequest.model_validate(
+            {
+                "target_workspace_id": "target-ws",
+                "sql": "select 1",
+            }
+        )
+
+        self.assertEqual(request.database_name, "app.sqlite3")
+        self.assertEqual(request.max_rows, 200)
+
+    def test_mutation_request_forbids_runtime_identity_and_unknown_fields(self) -> None:
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteMutationRequest.model_validate(
+                {
+                    "target_workspace_id": "target-ws",
+                    "operations": [{"kind": "delete", "table": "widgets", "where": {"id": 1}}],
+                    "workspace_id": "source-ws",
+                    "session_id": "sess-1",
+                    "leased_by_user_id": "user-1",
+                    "unexpected": True,
+                }
+            )
+
+    def test_mutation_request_validates_operation_count_bounds(self) -> None:
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteMutationRequest.model_validate(
+                {
+                    "target_workspace_id": "target-ws",
+                    "operations": [],
+                }
+            )
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteMutationRequest.model_validate(
+                {
+                    "target_workspace_id": "target-ws",
+                    "operations": [{"kind": "delete", "table": "widgets", "where": {"id": index}} for index in range(501)],
+                }
+            )
+
+    def test_mutation_operation_accepts_valid_insert_upsert_update_and_delete_shapes(self) -> None:
+        insert_operation = RuntimeBridgeSqliteMutationOperation.model_validate({"kind": "insert", "table": "widgets", "values": {"name": "A"}})
+        upsert_operation = RuntimeBridgeSqliteMutationOperation.model_validate(
+            {
+                "kind": "upsert",
+                "table": "widgets",
+                "values": {"id": 1, "name": "A"},
+                "conflict_columns": ["id"],
+            }
+        )
+        update_operation = RuntimeBridgeSqliteMutationOperation.model_validate(
+            {
+                "kind": "update",
+                "table": "widgets",
+                "values": {"name": "B"},
+                "where": {"id": 1},
+            }
+        )
+        delete_operation = RuntimeBridgeSqliteMutationOperation.model_validate({"kind": "delete", "table": "widgets", "where": {"id": 1}})
+
+        self.assertEqual(insert_operation.kind, "insert")
+        self.assertEqual(upsert_operation.conflict_columns, ["id"])
+        self.assertEqual(update_operation.where, {"id": 1})
+        self.assertEqual(delete_operation.kind, "delete")
+
+    def test_mutation_operation_rejects_malformed_payloads(self) -> None:
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteMutationOperation.model_validate(
+                {
+                    "kind": "insert",
+                    "table": "widgets",
+                    "where": {"id": 1},
+                }
+            )
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteMutationOperation.model_validate(
+                {
+                    "kind": "delete",
+                    "table": "widgets",
+                    "values": {"name": "bad"},
+                }
+            )
+
+    def test_mutation_operation_rejects_upsert_without_conflict_columns(self) -> None:
+        with self.assertRaises(ValidationError) as raised:
+            RuntimeBridgeSqliteMutationOperation.model_validate(
+                {
+                    "kind": "upsert",
+                    "table": "widgets",
+                    "values": {"id": 1, "name": "A"},
+                }
+            )
+
+        self.assertIn("conflict_columns", str(raised.exception))
+
+    def test_mutation_operation_rejects_update_without_where(self) -> None:
+        with self.assertRaises(ValidationError) as raised:
+            RuntimeBridgeSqliteMutationOperation.model_validate(
+                {
+                    "kind": "update",
+                    "table": "widgets",
+                    "values": {"name": "A"},
+                }
+            )
+
+        self.assertIn("where", str(raised.exception))
+
+    def test_mutation_request_rejects_unsupported_database_name(self) -> None:
+        with self.assertRaises(ValidationError):
+            RuntimeBridgeSqliteMutationRequest.model_validate(
+                {
+                    "target_workspace_id": "target-ws",
+                    "database_name": "custom.sqlite3",
+                    "operations": [{"kind": "delete", "table": "widgets", "where": {"id": 1}}],
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_userspace_runtime_bridge_token.py
+++ b/tests/test_userspace_runtime_bridge_token.py
@@ -57,6 +57,7 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
         stopped = mock.Mock()
         stopped.state = "stopped"
         stopped.workspaceId = "ws-1"
+        stopped.leasedByUserId = "user-1"
         with mock.patch.object(
             self.service,
             "_get_runtime_session_record",
@@ -68,6 +69,7 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
         other = mock.Mock()
         other.state = "running"
         other.workspaceId = "ws-2"
+        other.leasedByUserId = "user-1"
         with mock.patch.object(
             self.service,
             "_get_runtime_session_record",
@@ -84,11 +86,27 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(HTTPException):
                 await self.service.verify_runtime_bridge_token(token)
 
+    async def test_verify_rejects_empty_lease_session(self) -> None:
+        token = self.service.build_runtime_bridge_token("ws-1", "sess-1")
+        active = mock.Mock()
+        active.state = "running"
+        active.workspaceId = "ws-1"
+        active.leasedByUserId = "   "
+        with mock.patch.object(
+            self.service,
+            "_get_runtime_session_record",
+            mock.AsyncMock(return_value=active),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await self.service.verify_runtime_bridge_token(token)
+        self.assertEqual(ctx.exception.status_code, 401)
+
     async def test_verify_accepts_active_session(self) -> None:
         token = self.service.build_runtime_bridge_token("ws-1", "sess-1")
         active = mock.Mock()
         active.state = "running"
         active.workspaceId = "ws-1"
+        active.leasedByUserId = "user-7"
         with mock.patch.object(
             self.service,
             "_get_runtime_session_record",
@@ -97,3 +115,4 @@ class RuntimeBridgeTokenTests(unittest.IsolatedAsyncioTestCase):
             claims = await self.service.verify_runtime_bridge_token(token)
         self.assertEqual(claims["workspace_id"], "ws-1")
         self.assertEqual(claims["session_id"], "sess-1")
+        self.assertEqual(claims["leased_by_user_id"], "user-7")

--- a/tests/test_userspace_turn_reminder.py
+++ b/tests/test_userspace_turn_reminder.py
@@ -13,6 +13,7 @@ _prompts = util.module_from_spec(_SPEC)
 _MODULE_STUB_NAMES = [
     "ragtime.core",
     "ragtime.core.entrypoint_status",
+    "ragtime.core.type_coercion",
     "ragtime.core.user_identity",
 ]
 _original_modules = {name: sys.modules.get(name) for name in _MODULE_STUB_NAMES}
@@ -20,6 +21,15 @@ try:
     fake_core_package = types.ModuleType("ragtime.core")
     fake_entrypoint_module = types.ModuleType("ragtime.core.entrypoint_status")
     setattr(fake_entrypoint_module, "EntrypointStatus", object)
+    fake_type_coercion_module = types.ModuleType("ragtime.core.type_coercion")
+    setattr(
+        fake_type_coercion_module,
+        "coerce_nonnegative_int_metadata",
+        lambda value, default=0: max(
+            0,
+            int(value) if str(value).strip().lstrip("-").isdigit() else default,
+        ),
+    )
     fake_user_identity_module = types.ModuleType("ragtime.core.user_identity")
     setattr(
         fake_user_identity_module,
@@ -31,6 +41,7 @@ try:
     )
     sys.modules["ragtime.core"] = fake_core_package
     sys.modules["ragtime.core.entrypoint_status"] = fake_entrypoint_module
+    sys.modules["ragtime.core.type_coercion"] = fake_type_coercion_module
     sys.modules["ragtime.core.user_identity"] = fake_user_identity_module
     _SPEC.loader.exec_module(_prompts)
 finally:
@@ -115,6 +126,13 @@ class UserSpaceTurnReminderTests(unittest.TestCase):
 
         self.assertNotIn("runtime_status_reminder_line", reminder)
         self.assertNotIn("Current runtime blocker", reminder)
+
+    def test_sqlite_turn_reminder_uses_conditional_language(self) -> None:
+        reminder = build_userspace_turn_reminder(include_sqlite_persistence=True)
+
+        self.assertIn("when selected tools are part of the requested feature", reminder)
+        self.assertIn("when local schema needs change", reminder)
+        self.assertNotIn("ensure this delivery includes both live data wiring", reminder)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add owner-controlled Shared SQLite grant modes for read and structured write access
- add a control-plane broker and authenticated runtime-bridge routes for target workspace SQLite databases
- enforce membership, rate limits, value-free audit records, SQLite authorizer restrictions, WAL checkpointing, and snapshots
- use each grant's `sqlite_access_mode` as the sole feature gate; remove global environment and topology switches
- add Agent Access controls, Prisma migration, prompt guidance, and broker/route/service coverage

## Verification
- Python: 1,986 passed, 7 skipped
- Frontend: 419 passed
- Mypy: no issues in 350 files
- TypeScript: `tsc --noEmit` passed
- Frontend production build passed
- Prisma generation and migration deployment passed
- README synchronization and `git diff --check` passed