### PR TITLE
tests: remove trivial copy assertions

### DIFF
--- a/ragtime/frontend/src/App.test.tsx
+++ b/ragtime/frontend/src/App.test.tsx
@@ -324,7 +324,10 @@ describe('App chat fullscreen layout', () => {
     await flushMicrotasks();
     await user.click(screen.getByRole('button', { name: 'Settings' }));
 
-    expect(await screen.findByText('Loading view...')).toBeTruthy();
+    const loadingFallback = await screen.findByText((_, element) =>
+      Boolean(element?.classList.contains('auth-loading')),
+    );
+    expect(loadingFallback.querySelector('.spinner')).toBeTruthy();
 
     settingsPanelModuleGate.resolve();
 
@@ -408,11 +411,13 @@ describe('App chat fullscreen layout', () => {
 
     render(<App />);
 
-    const backupWarning = await screen.findByText('Back Up Your Encryption Key');
-    const backupWarningContainer = backupWarning.closest('div[data-dismiss-key]') as HTMLElement;
+    const backupWarningContainer = (await screen.findByText(
+      (_, element) =>
+        element?.matches('div[data-dismiss-key="ragtime_encryption_backup_reminder"]') ?? false,
+    )) as HTMLElement;
     expect(backupWarningContainer.dataset.dismissKey).toBe('ragtime_encryption_backup_reminder');
     expect(backupWarningContainer.dataset.persistDismiss).toBe('true');
-    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeTruthy();
+    expect(backupWarningContainer.querySelector('button')).toBeTruthy();
 
     const openAction = await screen.findByRole('button', { name: 'Open backup settings' });
     await user.click(openAction);
@@ -431,7 +436,12 @@ describe('App chat fullscreen layout', () => {
         'true',
       );
     });
-    expect(screen.queryByText('Back Up Your Encryption Key')).toBe(null);
+    expect(
+      screen.queryByText(
+        (_, element) =>
+          element?.matches('div[data-dismiss-key="ragtime_encryption_backup_reminder"]') ?? false,
+      ),
+    ).toBe(null);
   });
 
   it('emits one backup completion toast after navigating away from Settings', async () => {
@@ -458,8 +468,6 @@ describe('App chat fullscreen layout', () => {
       vi.advanceTimersByTime(2000);
     });
     await flushMicrotasks();
-    expect(toastApiMock.success).toHaveBeenCalledWith('Server backup completed successfully.');
-
     expect(toastApiMock.success).toHaveBeenCalledTimes(1);
 
     await act(async () => {

--- a/ragtime/frontend/src/components/GitWebhookSettings.test.tsx
+++ b/ragtime/frontend/src/components/GitWebhookSettings.test.tsx
@@ -26,15 +26,6 @@ const gitlabConfig: GitWebhookConfig = {
   created_at: '2026-07-16T12:00:00Z',
 };
 
-const genericConfig: GitWebhookConfig = {
-  enabled: true,
-  paused: false,
-  webhook_url: 'https://ragtime.example/webhooks/git/webhook-789',
-  provider: 'generic',
-  branch: 'develop',
-  created_at: '2026-07-16T12:00:00Z',
-};
-
 const disabledConfig: GitWebhookConfig = {
   enabled: false,
   paused: false,
@@ -124,15 +115,12 @@ describe('GitWebhookSettings', () => {
     );
   });
 
-  it('renders friendly GitLab setup instructions without recent deliveries', () => {
+  it('keeps recent deliveries hidden for GitLab webhooks', () => {
     renderComponent({
       config: gitlabConfig,
       revealedSecret: null,
     });
 
-    expect(
-      screen.getByText("Add this URL and secret in your GitLab project's webhook settings."),
-    ).toBeTruthy();
     expect(screen.queryByText('Recent deliveries')).toBeNull();
   });
 
@@ -201,19 +189,6 @@ describe('GitWebhookSettings', () => {
     expect(screen.queryByRole('button', { name: 'Pause webhook' })).toBeNull();
   });
 
-  it('renders friendly generic provider instructions without technical header wording', () => {
-    renderComponent({
-      config: genericConfig,
-      revealedSecret: 'generic-secret',
-    });
-
-    expect(
-      screen.getByText("Add this URL and secret in your Git provider's webhook settings."),
-    ).toBeTruthy();
-    expect(screen.queryByText(/X-Ragtime-Webhook-Token/)).toBeNull();
-    expect(screen.queryByText(/HMAC/)).toBeNull();
-  });
-
   it('disables action and copy controls when disabled', () => {
     renderComponent({
       config: githubConfig,
@@ -236,16 +211,13 @@ describe('GitWebhookSettings', () => {
     ).toBe(true);
   });
 
-  it('shows the flat setup for disabled configs without an enable action', () => {
+  it('omits enable, secret, and query-token controls for disabled configs', () => {
     renderComponent({
       config: disabledConfig,
     });
 
     expect(screen.queryByText('Webhook delivery is disabled.')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Enable push webhook' })).toBeNull();
-    expect(
-      screen.getByText("Add this URL and secret in your Git provider's webhook settings."),
-    ).toBeTruthy();
     expect(screen.queryByText(/secret unavailable/i)).toBeNull();
     expect(screen.queryByText(/query token/i)).toBeNull();
   });

--- a/ragtime/frontend/src/components/HttpApiConnectionPanel.test.tsx
+++ b/ragtime/frontend/src/components/HttpApiConnectionPanel.test.tsx
@@ -1063,7 +1063,6 @@ describe('HttpApiConnectionPanel', () => {
     ).toBe('items');
     expect(screen.getByText(/agent-settable header names/i)).toBeTruthy();
     expect(screen.getByLabelText('Approved request headers (optional)')).toBeTruthy();
-    expect(screen.getByText(/not used as the request Base URL/i)).toBeTruthy();
     expect(screen.getByText(/does not configure fixed header values/i)).toBeTruthy();
     expect(screen.getByText(/optional dot-path used to select/i)).toBeTruthy();
     expect(screen.queryByLabelText('OpenAPI URL')).toBeNull();

--- a/ragtime/frontend/src/components/HttpApiOAuthConnectPanel.test.tsx
+++ b/ragtime/frontend/src/components/HttpApiOAuthConnectPanel.test.tsx
@@ -59,7 +59,6 @@ describe('HttpApiOAuthConnectPanel', () => {
         }),
       ),
     );
-    expect(screen.getByText('Advanced endpoints')).toBeTruthy();
   });
 
   it('copies the device code, opens the preferred URL, and polls to connected', async () => {

--- a/ragtime/frontend/src/components/ReindexIntervalSelect.test.tsx
+++ b/ragtime/frontend/src/components/ReindexIntervalSelect.test.tsx
@@ -60,9 +60,6 @@ describe('ReindexIntervalSelect', () => {
 
     await user.selectOptions(screen.getByLabelText('Auto Re-index Interval'), '24');
     expect(screen.getByRole('dialog', { name: 'Disable webhook delivery?' })).toBeTruthy();
-    expect(
-      screen.getByText('Switching away from webhook delivery will re-enable scheduled updates.'),
-    ).toBeTruthy();
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(onWebhookDeliveryChange).not.toHaveBeenCalled();

--- a/ragtime/frontend/src/components/ToolAccessEditor.test.tsx
+++ b/ragtime/frontend/src/components/ToolAccessEditor.test.tsx
@@ -92,7 +92,6 @@ describe('ToolAccessEditor', () => {
     render(<Harness />);
 
     expect(screen.getByText('Default')).toBeTruthy();
-    expect(screen.getByText(/when no override matches/i)).toBeTruthy();
     expect(screen.queryByRole('alert')).toBeNull();
     expect(screen.queryByText(/admins always have full access/i)).toBeNull();
   });
@@ -283,15 +282,11 @@ describe('ToolAccessEditor', () => {
 
     const browseButton = screen.getByRole('button', { name: /browse all/i });
 
-    expect(screen.getByText(/type to search, or/i)).toBeTruthy();
     expect(browseButton).toBeTruthy();
     expect((browseButton as HTMLButtonElement).disabled).toBe(false);
     expect(browseButton.getAttribute('aria-expanded')).toBe('false');
     expect(browseButton.getAttribute('aria-controls')).toBeTruthy();
     expect(screen.queryByRole('listbox', { name: /add users and groups/i })).toBeNull();
-    expect(
-      screen.getByText(/no user or group overrides\. search above to add one\./i),
-    ).toBeTruthy();
   });
 
   it('disables browse when there are no principals left to add', () => {
@@ -548,9 +543,6 @@ describe('ToolAccessEditor', () => {
     await user.click(screen.getByRole('option', { name: 'Inherit' }));
 
     expect(screen.queryByText('Alice Admin')).toBeNull();
-    expect(
-      screen.getByText(/no user or group overrides\. search above to add one\./i),
-    ).toBeTruthy();
   });
 
   it('filters existing rows by the search query and shows a no matches row', async () => {

--- a/ragtime/frontend/src/components/settings/AgentBehaviorSettingsSection.test.tsx
+++ b/ragtime/frontend/src/components/settings/AgentBehaviorSettingsSection.test.tsx
@@ -43,7 +43,6 @@ describe('AgentBehaviorSettingsSection', () => {
 
     expect(screen.getByRole('button', { name: 'Agent Behavior' })).toBeTruthy();
     expect(document.getElementById('setting-agent_behavior')).toBeTruthy();
-    expect(screen.getByText(/global agent execution and tool behavior/i)).toBeTruthy();
     expect(document.getElementById('setting-tool_skills_enabled')).toBeTruthy();
     expect(screen.getByLabelText('Load tools on demand')).toBeTruthy();
     expect((screen.getByLabelText('Load tools on demand') as HTMLInputElement).checked).toBe(true);
@@ -57,21 +56,6 @@ describe('AgentBehaviorSettingsSection', () => {
     expect(screen.getByText('30')).toBeTruthy();
     expect(screen.getByText('5K')).toBeTruthy();
     expect(screen.getByText('6')).toBeTruthy();
-  });
-
-  it('explains on-demand tool loading by default and legacy eager loading when disabled', async () => {
-    const user = userEvent.setup();
-    renderSection();
-
-    expect(
-      screen.getByText(/Only essential tools and the tool-skill controls are sent initially/i),
-    ).toBeTruthy();
-
-    await user.click(screen.getByLabelText('Load tools on demand'));
-
-    expect(
-      screen.getByText(/All eligible tools and schemas are sent with every request/i),
-    ).toBeTruthy();
   });
 
   it('updates the toggle and numeric controls', async () => {

--- a/ragtime/frontend/src/components/settings/McpSettingsSection.test.tsx
+++ b/ragtime/frontend/src/components/settings/McpSettingsSection.test.tsx
@@ -183,7 +183,7 @@ function renderSection({
 }
 
 describe('McpSettingsSection', () => {
-  it('shows OAuth2 as the default selectable auth method without LDAP and explains local plus LDAP sign-in', () => {
+  it('shows OAuth2 as the default selectable auth method without LDAP', () => {
     renderSection({
       settings: buildSettings({
         mcp_default_route_auth_method: undefined as never,
@@ -198,10 +198,9 @@ describe('McpSettingsSection', () => {
       'password',
       'client_credentials',
     ]);
-    expect(screen.getByText(/Local and LDAP users can sign in through OAuth2/i)).toBeTruthy();
   });
 
-  it('shows optional OAuth2 password fallback controls with existing password actions', () => {
+  it('shows optional OAuth2 password fallback controls and existing password actions', () => {
     renderSection({
       settings: buildSettings({
         has_mcp_default_password: true,
@@ -213,7 +212,6 @@ describe('McpSettingsSection', () => {
     expect(screen.getByRole('button', { name: 'Show password' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Generate Password' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Clear' })).toBeTruthy();
-    expect(screen.getByText(/enter a new one to change it/i)).toBeTruthy();
   });
 
   it('shows the exact LDAP bypass warning when an OAuth2 group restriction and fallback password are both configured', async () => {

--- a/ragtime/frontend/src/components/settings/SearchSettingsSection.test.tsx
+++ b/ragtime/frontend/src/components/settings/SearchSettingsSection.test.tsx
@@ -56,30 +56,20 @@ function renderSection({
 }
 
 describe('SearchSettingsSection', () => {
-  it('renders the FAISS concurrency switch card with the default per-index copy', () => {
+  it('renders the FAISS concurrency switch card with the default switch state', () => {
     const { container } = renderSection();
 
     expect(screen.getByRole('button', { name: 'Search Configuration' })).toBeTruthy();
     expect(screen.getByLabelText('Global FAISS search gate')).toBeTruthy();
     expect(document.getElementById('setting-faiss_search_concurrency_mode')).toBeTruthy();
     expect(document.getElementById('search-faiss-concurrency-mode')).toBeTruthy();
-    expect(
-      screen.getByText(
-        'Serialize searches per index while allowing different indexes to search concurrently (default).',
-      ),
-    ).toBeTruthy();
-    expect(
-      screen.getByText(
-        'Use global mode when concurrent vector searches affect server responsiveness. Changes apply to new searches after saving.',
-      ),
-    ).toBeTruthy();
     expect(container.querySelector('.search-settings-switch-card')).toBeTruthy();
     expect((screen.getByLabelText('Global FAISS search gate') as HTMLInputElement).checked).toBe(
       false,
     );
   });
 
-  it('switches to global mode copy when the toggle is enabled', async () => {
+  it('switches to global mode when the toggle is enabled', async () => {
     const user = userEvent.setup();
     renderSection();
 
@@ -88,11 +78,6 @@ describe('SearchSettingsSection', () => {
     expect((screen.getByLabelText('Global FAISS search gate') as HTMLInputElement).checked).toBe(
       true,
     );
-    expect(
-      screen.getByText(
-        'Serialize all FAISS searches through one process-wide gate for maximum server isolation.',
-      ),
-    ).toBeTruthy();
   });
 
   it('calls save once and shows the saving state', async () => {

--- a/ragtime/frontend/src/components/shared/AgentAccessSection.test.tsx
+++ b/ragtime/frontend/src/components/shared/AgentAccessSection.test.tsx
@@ -71,7 +71,6 @@ describe('AgentAccessSection', () => {
     ).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy agent manifest URL' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy agent instructions' })).toBeTruthy();
-    expect(screen.getByText(/paste them into the trusted external agent chat/i)).toBeTruthy();
   });
 
   it('retries initial load failures and copies secret-safe instructions', async () => {

--- a/ragtime/frontend/src/components/shared/SearchFilterBar.test.tsx
+++ b/ragtime/frontend/src/components/shared/SearchFilterBar.test.tsx
@@ -119,7 +119,11 @@ describe('SearchFilterBar completion behavior', () => {
     const input = screen.getByRole('textbox', { name: 'Filter settings by keyword' });
     await user.type(input, 'server backup and');
 
-    expect(screen.getByText(/Tab to complete:/i).textContent).toContain('Server Backup & Restore');
+    const completionHintId = input.getAttribute('aria-describedby');
+    expect(completionHintId).toBeTruthy();
+    expect(document.getElementById(completionHintId!)?.textContent).toContain(
+      'Server Backup & Restore',
+    );
 
     await user.tab();
 
@@ -134,6 +138,9 @@ describe('SearchFilterBar completion behavior', () => {
 
     const input = screen.getByRole('textbox', { name: 'Filter settings by keyword' });
     await user.type(input, 'appearance');
+
+    expect(input.getAttribute('aria-describedby')).toBeNull();
+
     await user.tab();
 
     expect(document.activeElement).not.toBe(input);

--- a/ragtime/frontend/src/components/shared/ToolSelectorDropdown.test.tsx
+++ b/ragtime/frontend/src/components/shared/ToolSelectorDropdown.test.tsx
@@ -697,19 +697,19 @@ describe('ToolSelectorDropdown bulk selection', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(999);
     });
-    expect(screen.queryByText('Right-click a tool for more options')).toBeNull();
+    expect(document.body.querySelector('.popover')).toBeNull();
 
     fireEvent.mouseMove(dropdown, { clientX: 302, clientY: 252 });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(999);
     });
-    expect(screen.queryByText('Right-click a tool for more options')).toBeNull();
+    expect(document.body.querySelector('.popover')).toBeNull();
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1);
     });
 
-    const tooltip = screen.getByText('Right-click a tool for more options');
-    const popover = tooltip.closest('.popover') as HTMLElement;
+    const popover = document.body.querySelector('.popover') as HTMLElement;
+    expect(popover).not.toBeNull();
     expect(popover.style.left).toBe('302px');
     expect(popover.style.top).toBe('236px');
     expect(popover.style.zIndex).toBe('9001');
@@ -723,7 +723,7 @@ describe('ToolSelectorDropdown bulk selection', () => {
     await user.hover(document.querySelector('.userspace-tool-dropdown-surface') as HTMLElement);
 
     await new Promise((resolve) => setTimeout(resolve, 400));
-    expect(screen.queryByText('Right-click a tool for more options')).toBeNull();
+    expect(document.body.querySelector('.popover')).toBeNull();
   });
 
   it('does not hint at right-click when hovering the trigger while the menu is open', async () => {
@@ -743,8 +743,6 @@ describe('ToolSelectorDropdown bulk selection', () => {
     await user.click(screen.getByTitle('Conversation Tools (3/3 selected)'));
     await user.hover(screen.getByTitle('Conversation Tools (3/3 selected)'));
 
-    await waitFor(() =>
-      expect(screen.queryByText('Right-click a tool for more options')).toBeNull(),
-    );
+    await waitFor(() => expect(document.body.querySelector('.popover')).toBeNull());
   });
 });


### PR DESCRIPTION
## Summary
- remove assertions that lock incidental informational, hint, and toast wording
- retain business-state, interaction, accessibility, security, data, and error-propagation coverage
- replace wording selectors with existing structural or ARIA relationships where behavior still needs coverage

## Testing
- `npm test` (43 files, 447 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; 1 pre-existing warning in `SettingsPanel.test.tsx`)
- `npm run format:check`
- `git diff --check origin/beta...HEAD`

## Note
The reported `OdooStatusBanner.test.tsx` was not present in the checkout, fetched refs, git object history, or GitHub PR refs, so this audits all frontend tests currently available on `beta`.