### PR TITLE
fix: route runtime bridge over internal network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,10 @@ SESSION_COOKIE_SECURE=false
 # Set to blank/non-http to force local placeholder runtime mode.
 # RUNTIME_MANAGER_URL=http://runtime:8090
 
+# Internal Ragtime URL for User Space runtime workers.
+# Set only for remote/custom runtime networks where automatic discovery cannot reach Ragtime.
+# RUNTIME_BRIDGE_BASE_URL=http://ragtime:8000
+
 # Shared bearer token for Ragtime <-> runtime service calls. If unset, User
 # Space runtime features stay disabled and admins see a security warning in
 # the UI. Generate with: openssl rand -base64 32

--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ flowchart LR
    # Set to blank/non-http to force local placeholder runtime mode.
    # RUNTIME_MANAGER_URL=http://runtime:8090
 
+   # Internal Ragtime URL for User Space runtime workers.
+   # Set only for remote/custom runtime networks where automatic discovery cannot reach Ragtime.
+   # RUNTIME_BRIDGE_BASE_URL=http://ragtime:8000
+
    # Shared bearer token for Ragtime <-> runtime service calls. If unset, User
    # Space runtime features stay disabled and admins see a security warning in
    # the UI. Generate with: openssl rand -base64 32
@@ -324,6 +328,7 @@ flowchart LR
          # Recommended defaults
          DEBUG_MODE: "false"
          RUNTIME_MANAGER_URL: ${RUNTIME_MANAGER_URL:-http://runtime:8090}
+         RUNTIME_BRIDGE_BASE_URL: ${RUNTIME_BRIDGE_BASE_URL:-}
          # Shared Ragtime <-> runtime token. If unset, User Space runtime features
          # stay disabled and admins see a security warning in the UI.
          RUNTIME_AUTH_TOKEN: ${RUNTIME_AUTH_TOKEN:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       # Recommended defaults
       DEBUG_MODE: "false"
       RUNTIME_MANAGER_URL: ${RUNTIME_MANAGER_URL:-http://runtime:8090}
+      RUNTIME_BRIDGE_BASE_URL: ${RUNTIME_BRIDGE_BASE_URL:-}
       # Shared Ragtime <-> runtime token. If unset, User Space runtime features
       # stay disabled and admins see a security warning in the UI.
       RUNTIME_AUTH_TOKEN: ${RUNTIME_AUTH_TOKEN:-}

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -73,6 +73,7 @@ services:
       - INDEX_DATA_PATH=/data
       - API_PORT=${API_PORT:-8001}
       - RUNTIME_MANAGER_URL=${RUNTIME_MANAGER_URL:-http://runtime:8090}
+      - RUNTIME_BRIDGE_BASE_URL=${RUNTIME_BRIDGE_BASE_URL:-}
       # Development-only defaults. Override these when testing adversarial/networked deployments.
       - RUNTIME_AUTH_TOKEN=${RUNTIME_AUTH_TOKEN:-dev-runtime-auth-token}
       # Authentication settings (from .env file via env_file)

--- a/ragtime/config/settings.py
+++ b/ragtime/config/settings.py
@@ -139,6 +139,11 @@ class Settings(BaseSettings):
         alias="RUNTIME_AUTH_TOKEN",
         description="Bearer token shared by Ragtime and the runtime service",
     )
+    runtime_bridge_base_url: str = Field(
+        default="",
+        alias="RUNTIME_BRIDGE_BASE_URL",
+        description="Optional internal Ragtime origin reachable by User Space runtime workers",
+    )
     # DEPRECATED legacy bridge: older compose files set RUNTIME_MANAGER_AUTH_TOKEN /
     # RUNTIME_WORKER_AUTH_TOKEN instead of RUNTIME_AUTH_TOKEN. When the shared
     # token is unset we fall back to the legacy manager value so those

--- a/ragtime/frontend/src/App.test.tsx
+++ b/ragtime/frontend/src/App.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from './App';
 import { SERVER_BACKUP_RESTORE_HIGHLIGHT } from './components/shared/securityWarnings';
-import type { ServerBackupJob, ServerRestoreJob, User } from './types';
+import type { ConfigurationWarning, ServerBackupJob, ServerRestoreJob, User } from './types';
 
 const localStorageMock = vi.hoisted(() => ({
   getItem: vi.fn(() => null),
@@ -253,7 +253,7 @@ beforeEach(() => {
   apiMock.logout.mockResolvedValue(undefined);
 });
 
-function mockAuthenticatedAdmin(): void {
+function mockAuthenticatedAdmin(configurationWarnings: ConfigurationWarning[] = []): void {
   apiMock.getAuthStatus.mockResolvedValue({
     authenticated: true,
     ldap_configured: false,
@@ -276,7 +276,7 @@ function mockAuthenticatedAdmin(): void {
       server_name: 'Ragtime',
       authenticated_webgl_background_enabled: false,
     },
-    configuration_warnings: [],
+    configuration_warnings: configurationWarnings,
   });
 }
 
@@ -338,30 +338,7 @@ describe('App chat fullscreen layout', () => {
 
   it('applies fullscreen state to the outer chat page container', async () => {
     const user = userEvent.setup();
-    apiMock.getAuthStatus.mockResolvedValue({
-      authenticated: true,
-      ldap_configured: false,
-      local_admin_enabled: true,
-      debug_mode: false,
-      api_key_configured: true,
-      session_cookie_secure: false,
-      allowed_origins_open: false,
-      authenticated_webgl_background_enabled: false,
-      server_name: 'Ragtime',
-    });
-    apiMock.getCurrentUser.mockResolvedValue({
-      id: 'user-1',
-      username: 'local:admin',
-      display_name: 'Admin',
-      role: 'admin',
-    });
-    apiMock.getSettings.mockResolvedValue({
-      settings: {
-        server_name: 'Ragtime',
-        authenticated_webgl_background_enabled: false,
-      },
-      configuration_warnings: [],
-    });
+    mockAuthenticatedAdmin();
 
     const { container } = render(<App />);
 
@@ -378,36 +355,13 @@ describe('App chat fullscreen layout', () => {
 
   it('deep-links the encryption backup reminder into server backup settings and dismisses it only after delivery is reported', async () => {
     const user = userEvent.setup();
-    apiMock.getAuthStatus.mockResolvedValue({
-      authenticated: true,
-      ldap_configured: false,
-      local_admin_enabled: true,
-      debug_mode: false,
-      api_key_configured: true,
-      session_cookie_secure: false,
-      allowed_origins_open: false,
-      authenticated_webgl_background_enabled: false,
-      server_name: 'Ragtime',
-    });
-    apiMock.getCurrentUser.mockResolvedValue({
-      id: 'user-1',
-      username: 'local:admin',
-      display_name: 'Admin',
-      role: 'admin',
-    });
-    apiMock.getSettings.mockResolvedValue({
-      settings: {
-        server_name: 'Ragtime',
-        authenticated_webgl_background_enabled: false,
+    mockAuthenticatedAdmin([
+      {
+        level: 'warning',
+        category: 'encryption_backup',
+        message: 'Back up your managed encryption key in an encrypted server backup.',
       },
-      configuration_warnings: [
-        {
-          level: 'warning',
-          category: 'encryption_backup',
-          message: 'Back up your managed encryption key in an encrypted server backup.',
-        },
-      ],
-    });
+    ]);
 
     render(<App />);
 

--- a/ragtime/frontend/src/components/ChatPage.test.tsx
+++ b/ragtime/frontend/src/components/ChatPage.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useEffect } from 'react';
+import type { ConversationShareLinkStatus } from '@/types/api';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatPage } from './ChatPage';
@@ -74,73 +75,72 @@ afterEach(() => {
   sseMock.sources.length = 0;
 });
 
+const makeShareLinkStatus = (
+  overrides: Partial<ConversationShareLinkStatus> = {},
+): ConversationShareLinkStatus => ({
+  id: 'share-1',
+  conversation_id: 'conv-1',
+  has_share_link: true,
+  owner_username: 'owner',
+  label: 'Alpha link',
+  share_slug: 'alpha-link',
+  share_token: 'token-1',
+  share_url: 'https://example.com/owner/alpha-link',
+  anonymous_share_url: 'https://example.com/shared/token-1',
+  created_at: '2026-07-14T00:00:00Z',
+  share_access_mode: 'token',
+  selected_user_ids: [],
+  selected_ldap_groups: [],
+  has_password: false,
+  granted_role: 'viewer',
+  scope_anchor_message_idx: null,
+  scope_direction: null,
+  active_share_style: 'named',
+  public_hit_count: 0,
+  last_public_hit_at: null,
+  ...overrides,
+});
+
+const mockConversationShareLinks = (links: ConversationShareLinkStatus[]): void => {
+  apiMock.listConversationShareLinks.mockResolvedValue({
+    conversation_id: 'conv-1',
+    owner_username: 'owner',
+    links,
+  });
+};
+
+const renderAuthenticatedChatPage = () =>
+  render(
+    <ChatPage
+      currentUser={{
+        id: 'user-1',
+        username: 'local:admin',
+        display_name: 'Admin',
+        email: null,
+        role: 'admin',
+        auth_provider: 'local',
+      }}
+    />,
+  );
+
 describe('ChatPage share link analytics', () => {
   it('removes a deleted share link without reloading the list', async () => {
     const user = userEvent.setup();
-    apiMock.listConversationShareLinks.mockResolvedValue({
-      conversation_id: 'conv-1',
-      owner_username: 'owner',
-      links: [
-        {
-          id: 'share-1',
-          conversation_id: 'conv-1',
-          has_share_link: true,
-          owner_username: 'owner',
-          label: 'Alpha link',
-          share_slug: 'alpha-link',
-          share_token: 'token-1',
-          share_url: 'https://example.com/owner/alpha-link',
-          anonymous_share_url: 'https://example.com/shared/token-1',
-          created_at: '2026-07-14T00:00:00Z',
-          share_access_mode: 'token',
-          selected_user_ids: [],
-          selected_ldap_groups: [],
-          has_password: false,
-          granted_role: 'viewer',
-          scope_anchor_message_idx: null,
-          scope_direction: null,
-          active_share_style: 'named',
-          public_hit_count: 0,
-          last_public_hit_at: null,
-        },
-        {
-          id: 'share-2',
-          conversation_id: 'conv-1',
-          has_share_link: true,
-          owner_username: 'owner',
-          label: 'Beta link',
-          share_slug: 'beta-link',
-          share_token: 'token-2',
-          share_url: 'https://example.com/owner/beta-link',
-          anonymous_share_url: 'https://example.com/shared/token-2',
-          created_at: '2026-07-14T00:05:00Z',
-          share_access_mode: 'token',
-          selected_user_ids: [],
-          selected_ldap_groups: [],
-          has_password: false,
-          granted_role: 'viewer',
-          scope_anchor_message_idx: null,
-          scope_direction: null,
-          active_share_style: 'named',
-          public_hit_count: 0,
-          last_public_hit_at: null,
-        },
-      ],
-    });
+    mockConversationShareLinks([
+      makeShareLinkStatus(),
+      makeShareLinkStatus({
+        id: 'share-2',
+        label: 'Beta link',
+        share_slug: 'beta-link',
+        share_token: 'token-2',
+        share_url: 'https://example.com/owner/beta-link',
+        anonymous_share_url: 'https://example.com/shared/token-2',
+        created_at: '2026-07-14T00:05:00Z',
+      }),
+    ]);
     apiMock.deleteConversationShareLink.mockResolvedValue(undefined);
 
-    render(
-      <ChatPage
-        currentUser={{
-          id: 'user-1',
-          username: 'local:admin',
-          display_name: 'Admin',
-          email: null,
-          role: 'admin',
-          auth_provider: 'local',
-        }}
-      />,
-    );
+    renderAuthenticatedChatPage();
 
     await user.click(await screen.findByRole('button', { name: 'Open share modal' }));
 
@@ -168,70 +168,21 @@ describe('ChatPage share link analytics', () => {
       rejectDelete = reject;
     });
 
-    apiMock.listConversationShareLinks.mockResolvedValue({
-      conversation_id: 'conv-1',
-      owner_username: 'owner',
-      links: [
-        {
-          id: 'share-1',
-          conversation_id: 'conv-1',
-          has_share_link: true,
-          owner_username: 'owner',
-          label: 'Alpha link',
-          share_slug: 'alpha-link',
-          share_token: 'token-1',
-          share_url: 'https://example.com/owner/alpha-link',
-          anonymous_share_url: 'https://example.com/shared/token-1',
-          created_at: '2026-07-14T00:00:00Z',
-          share_access_mode: 'token',
-          selected_user_ids: [],
-          selected_ldap_groups: [],
-          has_password: false,
-          granted_role: 'viewer',
-          scope_anchor_message_idx: null,
-          scope_direction: null,
-          active_share_style: 'named',
-          public_hit_count: 0,
-          last_public_hit_at: null,
-        },
-        {
-          id: 'share-2',
-          conversation_id: 'conv-1',
-          has_share_link: true,
-          owner_username: 'owner',
-          label: 'Beta link',
-          share_slug: 'beta-link',
-          share_token: 'token-2',
-          share_url: 'https://example.com/owner/beta-link',
-          anonymous_share_url: 'https://example.com/shared/token-2',
-          created_at: '2026-07-14T00:05:00Z',
-          share_access_mode: 'token',
-          selected_user_ids: [],
-          selected_ldap_groups: [],
-          has_password: false,
-          granted_role: 'viewer',
-          scope_anchor_message_idx: null,
-          scope_direction: null,
-          active_share_style: 'named',
-          public_hit_count: 0,
-          last_public_hit_at: null,
-        },
-      ],
-    });
+    mockConversationShareLinks([
+      makeShareLinkStatus(),
+      makeShareLinkStatus({
+        id: 'share-2',
+        label: 'Beta link',
+        share_slug: 'beta-link',
+        share_token: 'token-2',
+        share_url: 'https://example.com/owner/beta-link',
+        anonymous_share_url: 'https://example.com/shared/token-2',
+        created_at: '2026-07-14T00:05:00Z',
+      }),
+    ]);
     apiMock.deleteConversationShareLink.mockReturnValue(deletePromise);
 
-    render(
-      <ChatPage
-        currentUser={{
-          id: 'user-1',
-          username: 'local:admin',
-          display_name: 'Admin',
-          email: null,
-          role: 'admin',
-          auth_provider: 'local',
-        }}
-      />,
-    );
+    renderAuthenticatedChatPage();
 
     await user.click(await screen.findByRole('button', { name: 'Open share modal' }));
 
@@ -262,34 +213,7 @@ describe('ChatPage share link analytics', () => {
 
   it('renders click counts and merges analytics updates without clobbering local drafts', async () => {
     const user = userEvent.setup();
-    apiMock.listConversationShareLinks.mockResolvedValue({
-      conversation_id: 'conv-1',
-      owner_username: 'owner',
-      links: [
-        {
-          id: 'share-1',
-          conversation_id: 'conv-1',
-          has_share_link: true,
-          owner_username: 'owner',
-          label: 'Alpha link',
-          share_slug: 'alpha-link',
-          share_token: 'token-1',
-          share_url: 'https://example.com/owner/alpha-link',
-          anonymous_share_url: 'https://example.com/shared/token-1',
-          created_at: '2026-07-14T00:00:00Z',
-          share_access_mode: 'token',
-          selected_user_ids: [],
-          selected_ldap_groups: [],
-          has_password: false,
-          granted_role: 'viewer',
-          scope_anchor_message_idx: null,
-          scope_direction: null,
-          active_share_style: 'named',
-          public_hit_count: 0,
-          last_public_hit_at: null,
-        },
-      ],
-    });
+    mockConversationShareLinks([makeShareLinkStatus()]);
     apiMock.createConversationShareLink.mockResolvedValue({
       id: 'share-1',
       conversation_id: 'conv-1',
@@ -303,18 +227,7 @@ describe('ChatPage share link analytics', () => {
       scope_direction: null,
     });
 
-    render(
-      <ChatPage
-        currentUser={{
-          id: 'user-1',
-          username: 'local:admin',
-          display_name: 'Admin',
-          email: null,
-          role: 'admin',
-          auth_provider: 'local',
-        }}
-      />,
-    );
+    renderAuthenticatedChatPage();
 
     await user.click(await screen.findByRole('button', { name: 'Open share modal' }));
 

--- a/ragtime/userspace/runtime_service.py
+++ b/ragtime/userspace/runtime_service.py
@@ -202,11 +202,15 @@ class UserSpaceRuntimeService:
 
     @staticmethod
     def _runtime_bridge_control_plane_origin() -> str:
+        configured_bridge_origin = str(getattr(settings, "runtime_bridge_base_url", "") or "").strip()
+        if configured_bridge_origin:
+            parsed = urlsplit(configured_bridge_origin)
+            if parsed.scheme in {"http", "https"} and parsed.netloc:
+                return urlunsplit((parsed.scheme, parsed.netloc, "", "", "")).rstrip("/")
+            logger.warning("Ignoring invalid RUNTIME_BRIDGE_BASE_URL for runtime bridge origin resolution")
+
         public_origin = UserSpaceRuntimeService._default_public_control_plane_origin()
-        public_parts = urlsplit(public_origin)
-        public_scheme = public_parts.scheme or "http"
-        public_port = public_parts.port or int(getattr(settings, "port", 8000) or 8000)
-        if not UserSpaceRuntimeService._is_loopback_host(public_parts.hostname):
+        if bool(getattr(settings, "enable_https", False)):
             return public_origin
 
         manager_base_url = str(getattr(get_runtime_manager_request_config(), "base_url", "") or "").strip()
@@ -215,11 +219,14 @@ class UserSpaceRuntimeService:
         if not manager_host or UserSpaceRuntimeService._is_loopback_host(manager_host):
             return public_origin
 
-        manager_port = manager_parts.port or 80
+        manager_port = manager_parts.port or (443 if manager_parts.scheme == "https" else 80)
         bridge_host = UserSpaceRuntimeService._discover_runtime_bridge_host(manager_host, manager_port)
         if not bridge_host:
-            bridge_host = "ragtime-dev"
-        return UserSpaceRuntimeService._build_origin_with_host(public_scheme, bridge_host, public_port)
+            return public_origin
+
+        internal_scheme = "https" if bool(getattr(settings, "enable_https", False)) else "http"
+        internal_port = int(getattr(settings, "port", 8000) or 8000)
+        return UserSpaceRuntimeService._build_origin_with_host(internal_scheme, bridge_host, internal_port)
 
     @staticmethod
     def _is_loopback_host(hostname: str | None) -> bool:
@@ -240,11 +247,25 @@ class UserSpaceRuntimeService:
             with socket.socket(socket_family, socket.SOCK_DGRAM) as probe_socket:
                 probe_socket.connect((manager_host, manager_port))
                 local_host = str(probe_socket.getsockname()[0] or "").strip()
+                peer_host = str(probe_socket.getpeername()[0] or "").strip()
         except OSError:
+            return None
+        if not UserSpaceRuntimeService._is_private_or_link_local_ip(peer_host):
             return None
         if not local_host or UserSpaceRuntimeService._is_loopback_host(local_host):
             return None
         return local_host
+
+    @staticmethod
+    def _is_private_or_link_local_ip(hostname: str | None) -> bool:
+        normalized = str(hostname or "").strip().strip("[]")
+        if not normalized:
+            return False
+        try:
+            address = ipaddress.ip_address(normalized)
+        except ValueError:
+            return False
+        return bool(address.is_private or address.is_link_local)
 
     @staticmethod
     def _build_origin_with_host(scheme: str, host: str, port: int) -> str:

--- a/tests/test_userspace_runtime_bridge_env.py
+++ b/tests/test_userspace_runtime_bridge_env.py
@@ -36,21 +36,135 @@ class RuntimeBridgeEnvTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("api_key", dumped)
         self.assertNotIn("basic_password", dumped)
 
-    def test_runtime_bridge_origin_keeps_non_local_public_origin(self) -> None:
+    def test_runtime_bridge_origin_prefers_explicit_override(self) -> None:
         with (
+            mock.patch.object(settings, "runtime_bridge_base_url", " https://bridge.internal:9443/runtime-bridge "),
             mock.patch.object(settings, "external_base_url", "https://public.example.com/app"),
             mock.patch(
                 "ragtime.userspace.runtime_service.get_runtime_manager_request_config",
                 return_value=SimpleNamespace(base_url="http://runtime:8090"),
+            ),
+            mock.patch.object(
+                UserSpaceRuntimeService,
+                "_discover_runtime_bridge_host",
+                return_value="172.18.0.3",
+            ),
+        ):
+            origin = self.service._runtime_bridge_control_plane_origin()
+
+        self.assertEqual(origin, "https://bridge.internal:9443")
+
+    def test_runtime_bridge_origin_ignores_invalid_explicit_override_and_logs_warning(self) -> None:
+        with (
+            mock.patch.object(settings, "runtime_bridge_base_url", "ragtime:8000"),
+            mock.patch.object(settings, "external_base_url", "https://public.example.com/app"),
+            mock.patch.object(settings, "enable_https", False),
+            mock.patch.object(settings, "port", 8000),
+            mock.patch(
+                "ragtime.userspace.runtime_service.get_runtime_manager_request_config",
+                return_value=SimpleNamespace(base_url="http://runtime:8090"),
+            ),
+            mock.patch.object(
+                UserSpaceRuntimeService,
+                "_discover_runtime_bridge_host",
+                return_value="172.18.0.3",
+            ),
+            mock.patch("ragtime.userspace.runtime_service.logger.warning") as warning,
+        ):
+            origin = self.service._runtime_bridge_control_plane_origin()
+
+        self.assertEqual(origin, "http://172.18.0.3:8000")
+        warning.assert_called_once()
+        warning_message = warning.call_args.args[0]
+        self.assertIn("Ignoring invalid RUNTIME_BRIDGE_BASE_URL", warning_message)
+        self.assertNotIn("ragtime:8000", warning_message)
+
+    def test_runtime_bridge_origin_discovers_internal_origin_for_private_manager_peer(self) -> None:
+        with (
+            mock.patch.object(settings, "runtime_bridge_base_url", ""),
+            mock.patch.object(settings, "external_base_url", "https://public.example.com/app"),
+            mock.patch.object(settings, "enable_https", False),
+            mock.patch.object(settings, "port", 8000),
+            mock.patch(
+                "ragtime.userspace.runtime_service.get_runtime_manager_request_config",
+                return_value=SimpleNamespace(base_url="http://runtime:8090"),
+            ),
+            mock.patch.object(
+                UserSpaceRuntimeService,
+                "_discover_runtime_bridge_host",
+                return_value="172.18.0.3",
+            ),
+        ):
+            origin = self.service._runtime_bridge_control_plane_origin()
+
+        self.assertEqual(origin, "http://172.18.0.3:8000")
+
+    def test_runtime_bridge_origin_falls_back_to_public_origin_for_public_manager_peer(self) -> None:
+        with (
+            mock.patch.object(settings, "runtime_bridge_base_url", ""),
+            mock.patch.object(settings, "external_base_url", "https://public.example.com/app"),
+            mock.patch.object(settings, "enable_https", False),
+            mock.patch.object(settings, "port", 8000),
+            mock.patch(
+                "ragtime.userspace.runtime_service.get_runtime_manager_request_config",
+                return_value=SimpleNamespace(base_url="http://203.0.113.10:8090"),
+            ),
+            mock.patch.object(
+                UserSpaceRuntimeService,
+                "_discover_runtime_bridge_host",
+                return_value=None,
             ),
         ):
             origin = self.service._runtime_bridge_control_plane_origin()
 
         self.assertEqual(origin, "https://public.example.com")
 
-    def test_runtime_bridge_origin_keeps_native_localhost_when_manager_is_loopback(self) -> None:
+    def test_runtime_bridge_origin_skips_discovery_when_https_enabled_without_override(self) -> None:
         with (
-            mock.patch.object(settings, "external_base_url", "http://localhost:8000/app"),
+            mock.patch.object(settings, "runtime_bridge_base_url", ""),
+            mock.patch.object(settings, "external_base_url", "https://public.example.com/app"),
+            mock.patch.object(settings, "enable_https", True),
+            mock.patch.object(settings, "port", 8443),
+            mock.patch(
+                "ragtime.userspace.runtime_service.get_runtime_manager_request_config",
+                return_value=SimpleNamespace(base_url="http://runtime:8090"),
+            ),
+            mock.patch.object(
+                UserSpaceRuntimeService,
+                "_discover_runtime_bridge_host",
+                return_value="fd00::1",
+            ) as discover,
+        ):
+            origin = self.service._runtime_bridge_control_plane_origin()
+
+        self.assertEqual(origin, "https://public.example.com")
+        discover.assert_not_called()
+
+    def test_runtime_bridge_origin_uses_https_default_manager_port_for_probe(self) -> None:
+        with (
+            mock.patch.object(settings, "runtime_bridge_base_url", ""),
+            mock.patch.object(settings, "external_base_url", "https://public.example.com/app"),
+            mock.patch.object(settings, "enable_https", False),
+            mock.patch.object(settings, "port", 8000),
+            mock.patch(
+                "ragtime.userspace.runtime_service.get_runtime_manager_request_config",
+                return_value=SimpleNamespace(base_url="https://runtime"),
+            ),
+            mock.patch.object(
+                UserSpaceRuntimeService,
+                "_discover_runtime_bridge_host",
+                return_value="172.18.0.3",
+            ) as discover,
+        ):
+            origin = self.service._runtime_bridge_control_plane_origin()
+
+        self.assertEqual(origin, "http://172.18.0.3:8000")
+        discover.assert_called_once_with("runtime", 443)
+
+    def test_runtime_bridge_origin_falls_back_to_public_origin_when_manager_is_loopback(self) -> None:
+        with (
+            mock.patch.object(settings, "runtime_bridge_base_url", ""),
+            mock.patch.object(settings, "external_base_url", "https://public.example.com/app"),
             mock.patch(
                 "ragtime.userspace.runtime_service.get_runtime_manager_request_config",
                 return_value=SimpleNamespace(base_url="http://127.0.0.1:8090"),
@@ -58,7 +172,25 @@ class RuntimeBridgeEnvTests(unittest.IsolatedAsyncioTestCase):
         ):
             origin = self.service._runtime_bridge_control_plane_origin()
 
-        self.assertEqual(origin, "http://localhost:8000")
+        self.assertEqual(origin, "https://public.example.com")
+
+    def test_runtime_bridge_origin_falls_back_to_public_origin_when_discovery_fails(self) -> None:
+        with (
+            mock.patch.object(settings, "runtime_bridge_base_url", ""),
+            mock.patch.object(settings, "external_base_url", "https://public.example.com/app"),
+            mock.patch(
+                "ragtime.userspace.runtime_service.get_runtime_manager_request_config",
+                return_value=SimpleNamespace(base_url="http://runtime:8090"),
+            ),
+            mock.patch.object(
+                UserSpaceRuntimeService,
+                "_discover_runtime_bridge_host",
+                return_value=None,
+            ),
+        ):
+            origin = self.service._runtime_bridge_control_plane_origin()
+
+        self.assertEqual(origin, "https://public.example.com")
 
     def test_bridge_env_uses_discovered_container_reachable_origin_for_local_public_url(self) -> None:
         socket_instance = mock.Mock()
@@ -66,6 +198,7 @@ class RuntimeBridgeEnvTests(unittest.IsolatedAsyncioTestCase):
         socket_context.__enter__ = mock.Mock(return_value=socket_instance)
         socket_context.__exit__ = mock.Mock(return_value=False)
         socket_instance.getsockname.return_value = ("172.18.0.3", 54321)
+        socket_instance.getpeername.return_value = ("172.18.0.2", 8090)
 
         with (
             mock.patch.object(settings, "external_base_url", "http://localhost:8000"),
@@ -84,7 +217,7 @@ class RuntimeBridgeEnvTests(unittest.IsolatedAsyncioTestCase):
             "http://172.18.0.3:8000/indexes/userspace/runtime-bridge",
         )
 
-    def test_bridge_env_falls_back_to_ragtime_dev_when_socket_discovery_fails(self) -> None:
+    def test_bridge_env_falls_back_to_public_origin_when_socket_discovery_fails(self) -> None:
         socket_instance = mock.Mock()
         socket_context = mock.Mock()
         socket_context.__enter__ = mock.Mock(return_value=socket_instance)
@@ -103,11 +236,50 @@ class RuntimeBridgeEnvTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             env["RAGTIME_BRIDGE_URL"],
-            "http://ragtime-dev:8000/indexes/userspace/runtime-bridge",
+            "http://localhost:8000/indexes/userspace/runtime-bridge",
         )
 
-    def test_settings_no_longer_exposes_runtime_bridge_base_url(self) -> None:
-        self.assertFalse(hasattr(settings, "runtime_bridge_base_url"))
+    def test_discover_runtime_bridge_host_accepts_private_ipv4_peer(self) -> None:
+        socket_instance = mock.Mock()
+        socket_context = mock.Mock()
+        socket_context.__enter__ = mock.Mock(return_value=socket_instance)
+        socket_context.__exit__ = mock.Mock(return_value=False)
+        socket_instance.getsockname.return_value = ("172.18.0.3", 54321)
+        socket_instance.getpeername.return_value = ("172.18.0.2", 8090)
+
+        with mock.patch("ragtime.userspace.runtime_service.socket.socket", return_value=socket_context):
+            host = self.service._discover_runtime_bridge_host("runtime", 8090)
+
+        self.assertEqual(host, "172.18.0.3")
+
+    def test_discover_runtime_bridge_host_rejects_public_ipv4_peer(self) -> None:
+        socket_instance = mock.Mock()
+        socket_context = mock.Mock()
+        socket_context.__enter__ = mock.Mock(return_value=socket_instance)
+        socket_context.__exit__ = mock.Mock(return_value=False)
+        socket_instance.getsockname.return_value = ("10.0.0.5", 54321)
+        socket_instance.getpeername.return_value = ("8.8.8.8", 8090)
+
+        with mock.patch("ragtime.userspace.runtime_service.socket.socket", return_value=socket_context):
+            host = self.service._discover_runtime_bridge_host("8.8.8.8", 8090)
+
+        self.assertIsNone(host)
+
+    def test_discover_runtime_bridge_host_accepts_private_ipv6_peer(self) -> None:
+        socket_instance = mock.Mock()
+        socket_context = mock.Mock()
+        socket_context.__enter__ = mock.Mock(return_value=socket_instance)
+        socket_context.__exit__ = mock.Mock(return_value=False)
+        socket_instance.getsockname.return_value = ("fd00::10", 54321, 0, 0)
+        socket_instance.getpeername.return_value = ("fe80::1", 8090, 0, 0)
+
+        with mock.patch("ragtime.userspace.runtime_service.socket.socket", return_value=socket_context):
+            host = self.service._discover_runtime_bridge_host("fd00::1", 8090)
+
+        self.assertEqual(host, "fd00::10")
+
+    def test_settings_runtime_bridge_base_url_defaults_blank(self) -> None:
+        self.assertEqual(settings.runtime_bridge_base_url, "")
 
     async def test_provider_start_merges_bridge_env_without_clobbering_user_env(self) -> None:
         with (


### PR DESCRIPTION
## Summary
- prefer an explicit `RUNTIME_BRIDGE_BASE_URL` when configured
- otherwise derive a reachable internal Ragtime origin for private/link-local runtime-manager peers
- preserve the public origin for public managers, discovery failures, and built-in HTTPS
- document the optional override and pass it through production/development Compose with an empty default

## Production incident
The `Exit Interview Tracking` Flask runtime received Cloudflare HTTP 403 responses because its bridge URL used `EXTERNAL_BASE_URL`. Production evidence showed token refresh was healthy, no bridge request reached FastAPI, the public route returned `Server: cloudflare`, and the internal Docker route returned Uvicorn HTTP 200.

## Verification
- focused bridge environment tests: `19 passed`
- full Python/frontend lint gate: Ruff, mypy (`363 source files`), pyright (`0 errors, 0 warnings`), Prettier, ESLint `--max-warnings 0`
- full test gate: `2131 passed, 7 skipped`
- frontend production build passed
- README synchronization passed
- production and development Compose rendering verified with the override unset and explicitly set
- final `reviewer-alt` review approved with no Critical or Important findings

## Deployment note
Standard Docker deployments require no new setting. Set `RUNTIME_BRIDGE_BASE_URL` only for remote/custom networks where automatic discovery cannot reach Ragtime. Existing active runtimes must refresh or restart their environment before they receive a changed bridge URL.